### PR TITLE
feat(workflows): add canonical data pull pipeline

### DIFF
--- a/app/db/index.ts
+++ b/app/db/index.ts
@@ -3,5 +3,9 @@ import { drizzle } from 'drizzle-orm/node-postgres';
 import * as schema from './schema';
 
 export function getDb() {
-  return drizzle(env.HYPERDRIVE.connectionString, { schema });
+  const connectionString = env.HYPERDRIVE?.connectionString;
+  if (!connectionString) {
+    throw new Error('Missing HYPERDRIVE binding/connectionString');
+  }
+  return drizzle(connectionString, { schema });
 }

--- a/app/db/index.ts
+++ b/app/db/index.ts
@@ -1,0 +1,7 @@
+import { env } from 'cloudflare:workers';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import * as schema from './schema';
+
+export function getDb() {
+  return drizzle(env.HYPERDRIVE.connectionString, { schema });
+}

--- a/app/helpers/ZipStore.ts
+++ b/app/helpers/ZipStore.ts
@@ -20,6 +20,16 @@ const textDecoder = new TextDecoder();
 const MAX_INFLATED_CACHE_BYTES = 8 * 1024 * 1024;
 
 function toArchivePath(path: string): string {
+  const normalizedInput = normalizeZipPath(path);
+  if (
+    normalizedInput.startsWith('/') ||
+    normalizedInput === '..' ||
+    normalizedInput.startsWith('../') ||
+    normalizedInput.includes('/../')
+  ) {
+    throw new Error(`Invalid archive path outside '${ZIP_DATA_ROOT}': ${path}`);
+  }
+
   const normalized = normalizeArchivePath(path);
   if (normalized === '') {
     return ZIP_DATA_ROOT;

--- a/app/helpers/ZipStore.ts
+++ b/app/helpers/ZipStore.ts
@@ -1,0 +1,255 @@
+import { posix } from 'node:path';
+import type { IStore } from '@mrtdown/fs';
+import * as fflate from 'fflate';
+
+function normalizeZipPath(path: string): string {
+  return posix.normalize(path.replaceAll('\\', '/'));
+}
+
+function normalizeArchivePath(path: string): string {
+  const normalized = normalizeZipPath(path).replace(/^\/+/, '');
+  if (normalized === '.') {
+    return '';
+  }
+  return normalized.replace(/\/+$/, '');
+}
+
+const ZIP_DATA_ROOT = 'data';
+const textDecoder = new TextDecoder();
+// Workers are memory-constrained, so keep only a small window of inflated files.
+const MAX_INFLATED_CACHE_BYTES = 8 * 1024 * 1024;
+
+function toArchivePath(path: string): string {
+  const normalized = normalizeArchivePath(path);
+  if (normalized === '') {
+    return ZIP_DATA_ROOT;
+  }
+  return `${ZIP_DATA_ROOT}/${normalized}`;
+}
+
+type ZipEntry = {
+  name: string;
+  isDirectory: boolean;
+  size?: number;
+  originalSize?: number;
+  compression: number;
+};
+
+/**
+ * Manages a zip archive using {@link https://github.com/101arrowz/fflate fflate}.
+ */
+class ZipManager {
+  private readonly zipData: Buffer<ArrayBufferLike>;
+  private entryIndex: Map<string, ZipEntry> | null = null;
+  private readonly directoryIndex = new Map<string, Set<string>>();
+  private readonly fileDataCache = new Map<string, Uint8Array>();
+  private cachedInflatedBytes = 0;
+
+  constructor(zipData: Buffer<ArrayBufferLike>) {
+    this.zipData = zipData;
+  }
+
+  private ensureIndexed(): Map<string, ZipEntry> {
+    if (this.entryIndex != null) {
+      return this.entryIndex;
+    }
+
+    const entries = new Map<string, ZipEntry>();
+    this.entryIndex = entries;
+    fflate.unzipSync(this.zipData, {
+      filter: (file) => {
+        const name = normalizeArchivePath(file.name);
+        if (name === '') {
+          return false;
+        }
+
+        const isDirectory = file.name.endsWith('/');
+
+        entries.set(name, {
+          name,
+          isDirectory,
+          size: file.size,
+          originalSize: file.originalSize,
+          compression: file.compression,
+        });
+        this.indexAncestors(entries, name, isDirectory);
+        return false;
+      },
+    });
+
+    return entries;
+  }
+
+  private indexAncestors(
+    entries: Map<string, ZipEntry>,
+    path: string,
+    isDirectory: boolean,
+  ): void {
+    const segments = path.split('/');
+    let current = '';
+
+    for (let i = 0; i < segments.length; i++) {
+      const segment = segments[i];
+      const parent = current;
+
+      let children = this.directoryIndex.get(parent);
+      if (children == null) {
+        children = new Set<string>();
+        this.directoryIndex.set(parent, children);
+      }
+      children.add(segment);
+
+      current = current === '' ? segment : `${current}/${segment}`;
+
+      if (i < segments.length - 1) {
+        const existing = entries.get(current);
+        if (existing == null) {
+          entries.set(current, {
+            name: current,
+            isDirectory: true,
+            compression: 0,
+          });
+        } else if (!existing.isDirectory) {
+          existing.isDirectory = true;
+        }
+      }
+    }
+
+    const entry = entries.get(path);
+    if ((isDirectory || entry?.isDirectory) && !this.directoryIndex.has(path)) {
+      this.directoryIndex.set(path, new Set<string>());
+    }
+  }
+
+  /**
+   * Gets the data for an entry in the zip archive.
+   * @param path - The path to the entry.
+   * @returns The data for the entry, or null if the entry does not exist.
+   */
+  readEntry(path: string): Uint8Array | null {
+    const normalizedPath = normalizeArchivePath(path);
+    const cached = this.fileDataCache.get(normalizedPath);
+    if (cached != null) {
+      // Refresh insertion order so eviction behaves like a simple LRU.
+      this.fileDataCache.delete(normalizedPath);
+      this.fileDataCache.set(normalizedPath, cached);
+      return cached;
+    }
+
+    const entry = this.getEntry(normalizedPath);
+    if (entry == null || entry.isDirectory) {
+      return null;
+    }
+
+    const result = fflate.unzipSync(this.zipData, {
+      filter: (file) => normalizeArchivePath(file.name) === normalizedPath,
+    });
+    const data = result[normalizedPath] ?? null;
+
+    if (data == null) {
+      return null;
+    }
+    this.addToCache(normalizedPath, data);
+    return data;
+  }
+
+  clearCache(): void {
+    this.fileDataCache.clear();
+    this.cachedInflatedBytes = 0;
+  }
+
+  private addToCache(path: string, data: Uint8Array): void {
+    if (data.byteLength > MAX_INFLATED_CACHE_BYTES) {
+      // Oversized entries are returned to the caller but never retained.
+      this.clearCache();
+      return;
+    }
+
+    const existing = this.fileDataCache.get(path);
+    if (existing != null) {
+      this.cachedInflatedBytes -= existing.byteLength;
+      this.fileDataCache.delete(path);
+    }
+
+    this.fileDataCache.set(path, data);
+    this.cachedInflatedBytes += data.byteLength;
+
+    while (this.cachedInflatedBytes > MAX_INFLATED_CACHE_BYTES) {
+      // Drop the oldest inflated entries first to cap peak memory.
+      const oldest = this.fileDataCache.entries().next().value;
+      if (oldest == null) {
+        break;
+      }
+
+      const [oldestPath, oldestData] = oldest;
+      this.fileDataCache.delete(oldestPath);
+      this.cachedInflatedBytes -= oldestData.byteLength;
+    }
+  }
+
+  getEntry(path: string): ZipEntry | null {
+    return this.ensureIndexed().get(normalizeArchivePath(path)) ?? null;
+  }
+
+  hasPath(path: string): boolean {
+    return this.getEntry(path) != null;
+  }
+
+  /**
+   * Lists all entries in the zip archive.
+   * @returns A list of entries.
+   */
+  listEntries(path = ''): ZipEntry[] {
+    const normalizedPath = normalizeArchivePath(path);
+    const prefix = normalizedPath === '' ? '' : `${normalizedPath}/`;
+
+    return [...this.ensureIndexed().values()].filter((entry) => {
+      if (normalizedPath === '') {
+        return true;
+      }
+      return entry.name === normalizedPath || entry.name.startsWith(prefix);
+    });
+  }
+
+  listDirectory(path: string): string[] {
+    this.ensureIndexed();
+    return Array.from(
+      this.directoryIndex.get(normalizeArchivePath(path)) ?? [],
+    ).sort();
+  }
+}
+
+/**
+ * Reads repository data directly from a ZIP archive.
+ */
+export class ZipStore implements IStore {
+  private readonly zipManager: ZipManager;
+
+  constructor(zipData: Buffer<ArrayBufferLike>) {
+    this.zipManager = new ZipManager(zipData);
+  }
+
+  readText(path: string): string {
+    const entry = this.zipManager.readEntry(toArchivePath(path));
+    if (entry == null) {
+      throw new Error(`ENOENT: no such file or directory, open '${path}'`);
+    }
+    return entry.length > 0 ? textDecoder.decode(entry) : '';
+  }
+
+  readJson<T>(path: string): T {
+    return JSON.parse(this.readText(path)) as T;
+  }
+
+  listDir(path: string): string[] {
+    return this.zipManager.listDirectory(toArchivePath(path));
+  }
+
+  exists(path: string): boolean {
+    return this.zipManager.hasPath(toArchivePath(path));
+  }
+
+  clearCache(): void {
+    this.zipManager.clearCache();
+  }
+}

--- a/app/routeTree.gen.ts
+++ b/app/routeTree.gen.ts
@@ -26,6 +26,7 @@ import { Route as Char123LangChar125IssuesIssueIdIndexRouteImport } from './rout
 import { Route as Char123LangChar125HistoryYearIndexRouteImport } from './routes/{-$lang}/history/$year/index'
 import { Route as Char123LangChar125HistoryPagePageNumRouteImport } from './routes/{-$lang}/history/page.$pageNum'
 import { Route as Char123LangChar125HistoryYearMonthRouteImport } from './routes/{-$lang}/history/$year/$month'
+import { Route as InternalApiTasksPullRouteImport } from './routes/internal.api.tasks.pull'
 
 const Char123LangChar125Route = Char123LangChar125RouteImport.update({
   id: '/{-$lang}',
@@ -124,6 +125,11 @@ const Char123LangChar125HistoryYearMonthRoute =
     path: '/history/$year/$month',
     getParentRoute: () => Char123LangChar125Route,
   } as any)
+const InternalApiTasksPullRoute = InternalApiTasksPullRouteImport.update({
+  id: '/internal/api/tasks/pull',
+  path: '/internal/api/tasks/pull',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/{-$lang}': typeof Char123LangChar125RouteWithChildren
@@ -137,6 +143,7 @@ export interface FileRoutesByFullPath {
   '/{-$lang}/status/$lineId': typeof Char123LangChar125StatusLineIdRoute
   '/{-$lang}/history/': typeof Char123LangChar125HistoryIndexRoute
   '/{-$lang}/statistics/': typeof Char123LangChar125StatisticsIndexRoute
+  '/internal/api/tasks/pull': typeof InternalApiTasksPullRoute
   '/{-$lang}/history/$year/$month': typeof Char123LangChar125HistoryYearMonthRoute
   '/{-$lang}/history/page/$pageNum': typeof Char123LangChar125HistoryPagePageNumRoute
   '/{-$lang}/history/$year/': typeof Char123LangChar125HistoryYearIndexRoute
@@ -155,6 +162,7 @@ export interface FileRoutesByTo {
   '/{-$lang}/status/$lineId': typeof Char123LangChar125StatusLineIdRoute
   '/{-$lang}/history': typeof Char123LangChar125HistoryIndexRoute
   '/{-$lang}/statistics': typeof Char123LangChar125StatisticsIndexRoute
+  '/internal/api/tasks/pull': typeof InternalApiTasksPullRoute
   '/{-$lang}/history/$year/$month': typeof Char123LangChar125HistoryYearMonthRoute
   '/{-$lang}/history/page/$pageNum': typeof Char123LangChar125HistoryPagePageNumRoute
   '/{-$lang}/history/$year': typeof Char123LangChar125HistoryYearIndexRoute
@@ -175,6 +183,7 @@ export interface FileRoutesById {
   '/{-$lang}/status/$lineId': typeof Char123LangChar125StatusLineIdRoute
   '/{-$lang}/history/': typeof Char123LangChar125HistoryIndexRoute
   '/{-$lang}/statistics/': typeof Char123LangChar125StatisticsIndexRoute
+  '/internal/api/tasks/pull': typeof InternalApiTasksPullRoute
   '/{-$lang}/history/$year/$month': typeof Char123LangChar125HistoryYearMonthRoute
   '/{-$lang}/history/page/$pageNum': typeof Char123LangChar125HistoryPagePageNumRoute
   '/{-$lang}/history/$year/': typeof Char123LangChar125HistoryYearIndexRoute
@@ -196,6 +205,7 @@ export interface FileRouteTypes {
     | '/{-$lang}/status/$lineId'
     | '/{-$lang}/history/'
     | '/{-$lang}/statistics/'
+    | '/internal/api/tasks/pull'
     | '/{-$lang}/history/$year/$month'
     | '/{-$lang}/history/page/$pageNum'
     | '/{-$lang}/history/$year/'
@@ -214,6 +224,7 @@ export interface FileRouteTypes {
     | '/{-$lang}/status/$lineId'
     | '/{-$lang}/history'
     | '/{-$lang}/statistics'
+    | '/internal/api/tasks/pull'
     | '/{-$lang}/history/$year/$month'
     | '/{-$lang}/history/page/$pageNum'
     | '/{-$lang}/history/$year'
@@ -233,6 +244,7 @@ export interface FileRouteTypes {
     | '/{-$lang}/status/$lineId'
     | '/{-$lang}/history/'
     | '/{-$lang}/statistics/'
+    | '/internal/api/tasks/pull'
     | '/{-$lang}/history/$year/$month'
     | '/{-$lang}/history/page/$pageNum'
     | '/{-$lang}/history/$year/'
@@ -245,6 +257,7 @@ export interface RootRouteChildren {
   Char123LangChar125Route: typeof Char123LangChar125RouteWithChildren
   ApiIssuesDayRoute: typeof ApiIssuesDayRoute
   ApiPhSplatRoute: typeof ApiPhSplatRoute
+  InternalApiTasksPullRoute: typeof InternalApiTasksPullRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -368,6 +381,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof Char123LangChar125HistoryYearMonthRouteImport
       parentRoute: typeof Char123LangChar125Route
     }
+    '/internal/api/tasks/pull': {
+      id: '/internal/api/tasks/pull'
+      path: '/internal/api/tasks/pull'
+      fullPath: '/internal/api/tasks/pull'
+      preLoaderRoute: typeof InternalApiTasksPullRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -420,6 +440,7 @@ const rootRouteChildren: RootRouteChildren = {
   Char123LangChar125Route: Char123LangChar125RouteWithChildren,
   ApiIssuesDayRoute: ApiIssuesDayRoute,
   ApiPhSplatRoute: ApiPhSplatRoute,
+  InternalApiTasksPullRoute: InternalApiTasksPullRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/app/routes/internal.api.tasks.pull.ts
+++ b/app/routes/internal.api.tasks.pull.ts
@@ -14,20 +14,31 @@ export const Route = createFileRoute('/internal/api/tasks/pull')({
           );
         }
 
-        const workflow = await env.PULL_WORKFLOW.create();
-        if (!workflow?.id) {
+        try {
+          const workflow = await env.PULL_WORKFLOW.create();
+          if (!workflow?.id) {
+            return Response.json(
+              { success: false, error: 'PULL_WORKFLOW creation failed' },
+              { status: 500 },
+            );
+          }
+
           return Response.json(
-            { success: false, error: 'PULL_WORKFLOW creation failed' },
+            { success: true, workflowId: workflow.id },
+            {
+              status: 202,
+            },
+          );
+        } catch (error) {
+          return Response.json(
+            {
+              success: false,
+              error: 'PULL_WORKFLOW creation failed',
+              details: error instanceof Error ? error.message : String(error),
+            },
             { status: 500 },
           );
         }
-
-        return Response.json(
-          { success: true, workflowId: workflow.id },
-          {
-            status: 202,
-          },
-        );
       },
     },
   },

--- a/app/routes/internal.api.tasks.pull.ts
+++ b/app/routes/internal.api.tasks.pull.ts
@@ -1,0 +1,20 @@
+import { env } from 'cloudflare:workers';
+import { createFileRoute } from '@tanstack/react-router';
+import { internalMiddleware } from '~/util/internal.middleware';
+
+export const Route = createFileRoute('/internal/api/tasks/pull')({
+  server: {
+    middleware: [internalMiddleware],
+    handlers: {
+      async POST() {
+        const workflow = await env.PULL_WORKFLOW?.create();
+        return Response.json(
+          { success: true, workflowId: workflow?.id },
+          {
+            status: 200,
+          },
+        );
+      },
+    },
+  },
+});

--- a/app/routes/internal.api.tasks.pull.ts
+++ b/app/routes/internal.api.tasks.pull.ts
@@ -30,11 +30,11 @@ export const Route = createFileRoute('/internal/api/tasks/pull')({
             },
           );
         } catch (error) {
+          console.error('PULL_WORKFLOW creation failed', { error });
           return Response.json(
             {
               success: false,
               error: 'PULL_WORKFLOW creation failed',
-              details: error instanceof Error ? error.message : String(error),
             },
             { status: 500 },
           );

--- a/app/routes/internal.api.tasks.pull.ts
+++ b/app/routes/internal.api.tasks.pull.ts
@@ -7,11 +7,25 @@ export const Route = createFileRoute('/internal/api/tasks/pull')({
     middleware: [internalMiddleware],
     handlers: {
       async POST() {
-        const workflow = await env.PULL_WORKFLOW?.create();
+        if (!env.PULL_WORKFLOW) {
+          return Response.json(
+            { success: false, error: 'PULL_WORKFLOW binding is missing' },
+            { status: 503 },
+          );
+        }
+
+        const workflow = await env.PULL_WORKFLOW.create();
+        if (!workflow?.id) {
+          return Response.json(
+            { success: false, error: 'PULL_WORKFLOW creation failed' },
+            { status: 500 },
+          );
+        }
+
         return Response.json(
-          { success: true, workflowId: workflow?.id },
+          { success: true, workflowId: workflow.id },
           {
-            status: 200,
+            status: 202,
           },
         );
       },

--- a/app/server.ts
+++ b/app/server.ts
@@ -8,6 +8,8 @@ const wrappedFetch = wrapFetchWithSentry({
   },
 });
 
+export { PullWorkflow } from './workflows/pull';
+
 export default Sentry.withSentry(
   (env) => {
     return {

--- a/app/util/internal.middleware.ts
+++ b/app/util/internal.middleware.ts
@@ -7,11 +7,15 @@ export const internalMiddleware = createMiddleware().server(
       // In development, we allow all requests
       return next();
     }
-    const token = request.headers.get('Authorization')?.split(' ')[1];
+    const auth = request.headers.get('Authorization');
+    const token = auth?.match(/^Bearer\s+(.+)$/i)?.[1]?.trim();
     if (!token) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }
-    const permittedTokens = env.INTERNAL_API_TOKENS?.split(',') ?? [];
+    const permittedTokens =
+      env.INTERNAL_API_TOKENS?.split(',')
+        .map((t) => t.trim())
+        .filter(Boolean) ?? [];
     if (!permittedTokens.includes(token)) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/app/util/internal.middleware.ts
+++ b/app/util/internal.middleware.ts
@@ -1,0 +1,20 @@
+import { env } from 'cloudflare:workers';
+import { createMiddleware } from '@tanstack/react-start';
+
+export const internalMiddleware = createMiddleware().server(
+  async ({ next, request }) => {
+    if (import.meta.env.DEV) {
+      // In development, we allow all requests
+      return next();
+    }
+    const token = request.headers.get('Authorization')?.split(' ')[1];
+    if (!token) {
+      return Response.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const permittedTokens = env.INTERNAL_API_TOKENS?.split(',') ?? [];
+    if (!permittedTokens.includes(token)) {
+      return Response.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return next();
+  },
+);

--- a/app/workflows/pull/helpers/fetchArchive.ts
+++ b/app/workflows/pull/helpers/fetchArchive.ts
@@ -1,0 +1,17 @@
+/**
+ * Fetches the zip archive from mrtdown-data as a single buffer for AdmZip.
+ */
+export async function fetchArchive(mrtdownDataUrl: string): Promise<Buffer> {
+  const response = await fetch(`${mrtdownDataUrl}/archive.zip`, {
+    headers: {
+      Accept: 'application/zip',
+    },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `archive.zip returned ${response.status}: ${await response.text()}`,
+    );
+  }
+  const ab = await response.arrayBuffer();
+  return Buffer.from(ab);
+}

--- a/app/workflows/pull/helpers/fetchArchive.ts
+++ b/app/workflows/pull/helpers/fetchArchive.ts
@@ -1,17 +1,87 @@
 /**
  * Fetches the zip archive from mrtdown-data as a single buffer for AdmZip.
  */
-export async function fetchArchive(mrtdownDataUrl: string): Promise<Buffer> {
-  const response = await fetch(`${mrtdownDataUrl}/archive.zip`, {
-    headers: {
-      Accept: 'application/zip',
-    },
-  });
-  if (!response.ok) {
-    throw new Error(
-      `archive.zip returned ${response.status}: ${await response.text()}`,
-    );
+const ARCHIVE_FETCH_TIMEOUT_MS = 30_000;
+const MAX_ARCHIVE_BYTES = 50 * 1024 * 1024;
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
+async function readBoundedBody(
+  response: Response,
+  controller: AbortController,
+): Promise<Buffer> {
+  const contentLength = Number.parseInt(
+    response.headers.get('content-length') ?? '',
+    10,
+  );
+  if (Number.isFinite(contentLength) && contentLength > MAX_ARCHIVE_BYTES) {
+    throw new Error(`archive.zip too large: ${contentLength} bytes`);
   }
-  const ab = await response.arrayBuffer();
-  return Buffer.from(ab);
+
+  if (response.body == null) {
+    const ab = await response.arrayBuffer();
+    if (ab.byteLength > MAX_ARCHIVE_BYTES) {
+      throw new Error(`archive.zip too large: ${ab.byteLength} bytes`);
+    }
+    return Buffer.from(ab);
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value == null) continue;
+
+    total += value.byteLength;
+    if (total > MAX_ARCHIVE_BYTES) {
+      controller.abort();
+      throw new Error(`archive.zip too large: ${total} bytes`);
+    }
+    chunks.push(value);
+  }
+
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return Buffer.from(out);
+}
+
+export async function fetchArchive(mrtdownDataUrl: string): Promise<Buffer> {
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    ARCHIVE_FETCH_TIMEOUT_MS,
+  );
+
+  try {
+    const response = await fetch(`${mrtdownDataUrl}/archive.zip`, {
+      headers: {
+        Accept: 'application/zip',
+      },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(
+        `archive.zip returned ${response.status}: ${await response.text()}`,
+      );
+    }
+    return await readBoundedBody(response, controller);
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw new Error(
+        `archive.zip fetch timed out after ${ARCHIVE_FETCH_TIMEOUT_MS}ms`,
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
 }

--- a/app/workflows/pull/helpers/fetchArchive.ts
+++ b/app/workflows/pull/helpers/fetchArchive.ts
@@ -1,5 +1,6 @@
 /**
- * Fetches the zip archive from mrtdown-data as a single buffer for AdmZip.
+ * Fetches the zip archive from mrtdown-data as a single buffer for ZipStore's
+ * fflate-based archive reader.
  */
 const ARCHIVE_FETCH_TIMEOUT_MS = 30_000;
 const MAX_ARCHIVE_BYTES = 50 * 1024 * 1024;

--- a/app/workflows/pull/helpers/fetchManifest.ts
+++ b/app/workflows/pull/helpers/fetchManifest.ts
@@ -1,0 +1,19 @@
+import type { Manifest } from '@mrtdown/core';
+
+/**
+ * Fetches the manifest from mrtdown-data
+ */
+export async function fetchManifest(mrtdownDataUrl: string): Promise<Manifest> {
+  const response = await fetch(`${mrtdownDataUrl}/manifest.json`, {
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `manifest.json returned ${response.status}: ${await response.text()}`,
+    );
+  }
+  const manifest: Manifest = await response.json();
+  return manifest;
+}

--- a/app/workflows/pull/helpers/fetchManifest.ts
+++ b/app/workflows/pull/helpers/fetchManifest.ts
@@ -1,19 +1,43 @@
 import type { Manifest } from '@mrtdown/core';
 
+const MANIFEST_FETCH_TIMEOUT_MS = 15_000;
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
 /**
  * Fetches the manifest from mrtdown-data
  */
 export async function fetchManifest(mrtdownDataUrl: string): Promise<Manifest> {
-  const response = await fetch(`${mrtdownDataUrl}/manifest.json`, {
-    headers: {
-      Accept: 'application/json',
-    },
-  });
-  if (!response.ok) {
-    throw new Error(
-      `manifest.json returned ${response.status}: ${await response.text()}`,
-    );
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    MANIFEST_FETCH_TIMEOUT_MS,
+  );
+
+  try {
+    const response = await fetch(`${mrtdownDataUrl}/manifest.json`, {
+      headers: {
+        Accept: 'application/json',
+      },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(
+        `manifest.json returned ${response.status}: ${await response.text()}`,
+      );
+    }
+    const manifest: Manifest = await response.json();
+    return manifest;
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw new Error(
+        `manifest.json fetch timed out after ${MANIFEST_FETCH_TIMEOUT_MS}ms`,
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
   }
-  const manifest: Manifest = await response.json();
-  return manifest;
 }

--- a/app/workflows/pull/helpers/getEntityTypeFromArchivePath.ts
+++ b/app/workflows/pull/helpers/getEntityTypeFromArchivePath.ts
@@ -1,0 +1,29 @@
+export function getEntityTypeFromArchivePath(path: string) {
+  if (path.startsWith('data/landmark/')) {
+    return 'landmark';
+  }
+  if (path.startsWith('data/line/')) {
+    return 'line';
+  }
+  if (path.startsWith('data/operator/')) {
+    return 'operator';
+  }
+  if (path.startsWith('data/town/')) {
+    return 'town';
+  }
+  if (path.startsWith('data/station/')) {
+    return 'station';
+  }
+  if (path.startsWith('data/service/')) {
+    return 'service';
+  }
+  if (path.startsWith('data/issue/')) {
+    if (path.endsWith('/evidence.ndjson')) {
+      return 'issue.evidence';
+    } else if (path.endsWith('/impact.ndjson')) {
+      return 'issue.impact';
+    }
+    return 'issue';
+  }
+  throw new Error(`Unknown entity type for path: ${path}`);
+}

--- a/app/workflows/pull/helpers/stagingSync.ts
+++ b/app/workflows/pull/helpers/stagingSync.ts
@@ -1,0 +1,1101 @@
+/**
+ * Promotes data from `*_next` staging tables (filled during the workflow `parse` step)
+ * into live Drizzle tables. Each sync runs in its own transaction and uses
+ * manifest hashes to skip unchanged rows; orphan deletes use `NOT EXISTS` anti-joins
+ * against `*_next` so we avoid huge `IN (...)` parameter lists.
+ */
+import {
+  type Evidence,
+  type ImpactEvent,
+  type Issue,
+  type Landmark,
+  type Line,
+  type Operator,
+  resolvePeriods,
+  type Service,
+  type Station,
+  type Town,
+} from '@mrtdown/core';
+import {
+  eq,
+  type InferInsertModel,
+  inArray,
+  notExists,
+  sql,
+} from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import type { getDb } from '../../../db/index.js';
+import {
+  evidencesTable,
+  impactEventBasisEvidencesTable,
+  impactEventCausesTable,
+  impactEventEntityFacilitiesTable,
+  impactEventEntityServicesTable,
+  impactEventFacilityEffectsTable,
+  impactEventPeriodsTable,
+  impactEventServiceEffectsTable,
+  impactEventServiceScopesTable,
+  impactEventsTable,
+  issuesNextTable,
+  issuesTable,
+  landmarksNextTable,
+  landmarksTable,
+  lineOperatorsTable,
+  lineServicesTable,
+  linesNextTable,
+  linesTable,
+  metadataTable,
+  operatorsNextTable,
+  operatorsTable,
+  serviceRevisionPathStationEntriesTable,
+  serviceRevisionsTable,
+  servicesNextTable,
+  servicesTable,
+  stationCodesTable,
+  stationLandmarksTable,
+  stationsNextTable,
+  stationsTable,
+  townsNextTable,
+  townsTable,
+} from '../../../db/schema.js';
+
+/** Max rows per `insert().values()` batch to stay within driver/param limits. */
+const BATCH = 500;
+
+type Db = ReturnType<typeof getDb>;
+
+/** Splits an array into fixed-size chunks for batched inserts. */
+function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    out.push(arr.slice(i, i + size));
+  }
+  return out;
+}
+
+/** Clears all pull staging tables before a new parse run. */
+export async function truncateStagingTables(db: Db): Promise<void> {
+  // Multi-table TRUNCATE is DDL; Drizzle has no builder — use `sql` with table refs.
+  await db.execute(
+    sql`TRUNCATE ${operatorsNextTable}, ${townsNextTable}, ${landmarksNextTable}, ${linesNextTable}, ${stationsNextTable}, ${servicesNextTable}, ${issuesNextTable} RESTART IDENTITY`,
+  );
+}
+
+export async function insertOperatorsStaging(
+  db: Db,
+  operators: readonly (Operator & { hash: string })[],
+): Promise<void> {
+  const opRows = operators.map((o) => ({
+    id: o.id,
+    hash: o.hash,
+    name: o.name,
+    founded_at: o.foundedAt,
+    url: o.url,
+  }));
+  for (const c of chunk(opRows, BATCH)) {
+    if (c.length === 0) continue;
+    await db.insert(operatorsNextTable).values(c);
+  }
+}
+
+export async function insertTownsStaging(
+  db: Db,
+  towns: readonly (Town & { hash: string })[],
+): Promise<void> {
+  const townRows = towns.map((t) => ({
+    id: t.id,
+    hash: t.hash,
+    name: t.name,
+  }));
+  for (const c of chunk(townRows, BATCH)) {
+    if (c.length === 0) continue;
+    await db.insert(townsNextTable).values(c);
+  }
+}
+
+export async function insertLandmarksStaging(
+  db: Db,
+  landmarks: readonly (Landmark & { hash: string })[],
+): Promise<void> {
+  const lmRows = landmarks.map((l) => ({
+    id: l.id,
+    hash: l.hash,
+    name: l.name,
+  }));
+  for (const c of chunk(lmRows, BATCH)) {
+    if (c.length === 0) continue;
+    await db.insert(landmarksNextTable).values(c);
+  }
+}
+
+export async function insertLinesStaging(
+  db: Db,
+  lines: readonly (Line & { hash: string })[],
+): Promise<void> {
+  const lineRows = lines.flatMap((l) => {
+    if (l.startedAt == null || l.operatingHours == null) {
+      return [];
+    }
+    return [
+      {
+        id: l.id,
+        hash: l.hash,
+        name: l.name,
+        type: l.type,
+        color: l.color,
+        started_at: l.startedAt,
+        ended_at: null,
+        operating_hours: l.operatingHours,
+        operators: l.operators,
+      },
+    ];
+  });
+  for (const c of chunk(lineRows, BATCH)) {
+    if (c.length === 0) continue;
+    await db.insert(linesNextTable).values(c);
+  }
+}
+
+export async function insertStationsStaging(
+  db: Db,
+  stations: readonly (Station & { hash: string })[],
+): Promise<void> {
+  const stationRows = stations.map((s) => ({
+    id: s.id,
+    hash: s.hash,
+    name: s.name,
+    // Drizzle/PostGIS: [longitude, latitude] tuple for SRID 4326 point
+    geo: [s.geo.longitude, s.geo.latitude] as [number, number],
+    town_id: s.townId,
+    station_codes: s.stationCodes,
+    landmark_ids: s.landmarkIds,
+  }));
+  for (const c of chunk(stationRows, BATCH)) {
+    if (c.length === 0) continue;
+    await db.insert(stationsNextTable).values(c);
+  }
+}
+
+export async function insertServicesStaging(
+  db: Db,
+  services: readonly (Service & { hash: string })[],
+): Promise<void> {
+  const serviceRows = services.map((s) => ({
+    id: s.id,
+    hash: s.hash,
+    name: s.name,
+    line_id: s.lineId,
+    revisions: s.revisions,
+  }));
+  for (const c of chunk(serviceRows, BATCH)) {
+    if (c.length === 0) continue;
+    await db.insert(servicesNextTable).values(c);
+  }
+}
+
+type IssueBundle = {
+  issue: Issue & { hash: string };
+  evidence: Evidence[];
+  impactEvents: ImpactEvent[];
+};
+
+export async function insertIssuesStaging(
+  db: Db,
+  issues: readonly IssueBundle[],
+): Promise<void> {
+  const issueRows = issues.map(({ issue, evidence, impactEvents }) => ({
+    id: issue.id,
+    hash: issue.hash,
+    type: issue.type,
+    title: issue.title,
+    title_meta: issue.titleMeta,
+    evidences: evidence,
+    impact_events: impactEvents,
+  }));
+  for (const c of chunk(issueRows, BATCH)) {
+    if (c.length === 0) continue;
+    await db.insert(issuesNextTable).values(c);
+  }
+}
+
+/**
+ * Deletes all rows in impact-event child tables for the given impact event ids.
+ * Order matches FK dependencies (children before `impact_events` is deleted elsewhere).
+ */
+async function deleteImpactEventChildren(
+  tx: Parameters<Parameters<Db['transaction']>[0]>[0],
+  impactEventIds: string[],
+): Promise<void> {
+  if (impactEventIds.length === 0) return;
+  await tx
+    .delete(impactEventPeriodsTable)
+    .where(inArray(impactEventPeriodsTable.impact_event_id, impactEventIds));
+  await tx
+    .delete(impactEventBasisEvidencesTable)
+    .where(
+      inArray(impactEventBasisEvidencesTable.impact_event_id, impactEventIds),
+    );
+  await tx
+    .delete(impactEventServiceScopesTable)
+    .where(
+      inArray(impactEventServiceScopesTable.impact_event_id, impactEventIds),
+    );
+  await tx
+    .delete(impactEventServiceEffectsTable)
+    .where(
+      inArray(impactEventServiceEffectsTable.impact_event_id, impactEventIds),
+    );
+  await tx
+    .delete(impactEventFacilityEffectsTable)
+    .where(
+      inArray(impactEventFacilityEffectsTable.impact_event_id, impactEventIds),
+    );
+  await tx
+    .delete(impactEventCausesTable)
+    .where(inArray(impactEventCausesTable.impact_event_id, impactEventIds));
+  await tx
+    .delete(impactEventEntityServicesTable)
+    .where(
+      inArray(impactEventEntityServicesTable.impact_event_id, impactEventIds),
+    );
+  await tx
+    .delete(impactEventEntityFacilitiesTable)
+    .where(
+      inArray(impactEventEntityFacilitiesTable.impact_event_id, impactEventIds),
+    );
+}
+
+/** Hash diff staging vs live; upsert changed rows; delete live rows absent from staging. */
+async function upsertChangedOperators(
+  tx: Parameters<Parameters<Db['transaction']>[0]>[0],
+): Promise<void> {
+  const rows = await tx
+    .select({
+      id: operatorsNextTable.id,
+      nextHash: operatorsNextTable.hash,
+      liveHash: operatorsTable.hash,
+    })
+    .from(operatorsNextTable)
+    .leftJoin(operatorsTable, eq(operatorsNextTable.id, operatorsTable.id));
+
+  const toUpsert = rows.filter(
+    (r) => r.liveHash == null || r.liveHash !== r.nextHash,
+  );
+
+  for (const ch of chunk(toUpsert, BATCH)) {
+    const ids = ch.map((r) => r.id);
+    if (ids.length === 0) continue;
+    const full = await tx
+      .select()
+      .from(operatorsNextTable)
+      .where(inArray(operatorsNextTable.id, ids));
+    for (const row of full) {
+      await tx
+        .insert(operatorsTable)
+        .values({
+          id: row.id,
+          hash: row.hash,
+          name: row.name,
+          founded_at: row.founded_at,
+          url: row.url,
+        })
+        .onConflictDoUpdate({
+          target: [operatorsTable.id],
+          set: {
+            hash: row.hash,
+            name: row.name,
+            founded_at: row.founded_at,
+            url: row.url,
+            updated_at: new Date(),
+          },
+        });
+    }
+  }
+  await tx
+    .delete(operatorsTable)
+    .where(
+      notExists(
+        tx
+          .select()
+          .from(operatorsNextTable)
+          .where(eq(operatorsNextTable.id, operatorsTable.id)),
+      ),
+    );
+}
+
+/** @see upsertChangedOperators */
+async function upsertChangedTowns(
+  tx: Parameters<Parameters<Db['transaction']>[0]>[0],
+): Promise<void> {
+  const rows = await tx
+    .select({
+      id: townsNextTable.id,
+      nextHash: townsNextTable.hash,
+      liveHash: townsTable.hash,
+    })
+    .from(townsNextTable)
+    .leftJoin(townsTable, eq(townsNextTable.id, townsTable.id));
+
+  const toUpsert = rows.filter(
+    (r) => r.liveHash == null || r.liveHash !== r.nextHash,
+  );
+
+  for (const ch of chunk(toUpsert, BATCH)) {
+    const ids = ch.map((r) => r.id);
+    if (ids.length === 0) continue;
+    const full = await tx
+      .select()
+      .from(townsNextTable)
+      .where(inArray(townsNextTable.id, ids));
+    for (const row of full) {
+      await tx
+        .insert(townsTable)
+        .values({ id: row.id, hash: row.hash, name: row.name })
+        .onConflictDoUpdate({
+          target: [townsTable.id],
+          set: {
+            hash: row.hash,
+            name: row.name,
+            updated_at: new Date(),
+          },
+        });
+    }
+  }
+  await tx
+    .delete(townsTable)
+    .where(
+      notExists(
+        tx
+          .select()
+          .from(townsNextTable)
+          .where(eq(townsNextTable.id, townsTable.id)),
+      ),
+    );
+}
+
+/** @see upsertChangedOperators */
+async function upsertChangedLandmarks(
+  tx: Parameters<Parameters<Db['transaction']>[0]>[0],
+): Promise<void> {
+  const rows = await tx
+    .select({
+      id: landmarksNextTable.id,
+      nextHash: landmarksNextTable.hash,
+      liveHash: landmarksTable.hash,
+    })
+    .from(landmarksNextTable)
+    .leftJoin(landmarksTable, eq(landmarksNextTable.id, landmarksTable.id));
+
+  const toUpsert = rows.filter(
+    (r) => r.liveHash == null || r.liveHash !== r.nextHash,
+  );
+
+  for (const ch of chunk(toUpsert, BATCH)) {
+    const ids = ch.map((r) => r.id);
+    if (ids.length === 0) continue;
+    const full = await tx
+      .select()
+      .from(landmarksNextTable)
+      .where(inArray(landmarksNextTable.id, ids));
+    for (const row of full) {
+      await tx
+        .insert(landmarksTable)
+        .values({ id: row.id, hash: row.hash, name: row.name })
+        .onConflictDoUpdate({
+          target: [landmarksTable.id],
+          set: {
+            hash: row.hash,
+            name: row.name,
+            updated_at: new Date(),
+          },
+        });
+    }
+  }
+  await tx
+    .delete(landmarksTable)
+    .where(
+      notExists(
+        tx
+          .select()
+          .from(landmarksNextTable)
+          .where(eq(landmarksNextTable.id, landmarksTable.id)),
+      ),
+    );
+}
+
+/** Operators, towns, landmarks — independent order; single transaction. */
+export async function syncOperatorsTownsLandmarks(db: Db): Promise<void> {
+  await db.transaction(async (tx) => {
+    await upsertChangedOperators(tx);
+    await upsertChangedTowns(tx);
+    await upsertChangedLandmarks(tx);
+  });
+}
+
+/**
+ * Lines plus `line_operators`. For changed lines: replace operator rows for those
+ * line ids, then orphan-delete lines (and operators) not in `lines_next`.
+ */
+export async function syncLines(db: Db): Promise<void> {
+  await db.transaction(async (tx) => {
+    const rows = await tx
+      .select({
+        id: linesNextTable.id,
+        nextHash: linesNextTable.hash,
+        liveHash: linesTable.hash,
+      })
+      .from(linesNextTable)
+      .leftJoin(linesTable, eq(linesNextTable.id, linesTable.id));
+
+    const changedIds = rows
+      .filter((r) => r.liveHash == null || r.liveHash !== r.nextHash)
+      .map((r) => r.id);
+
+    for (const ch of chunk(changedIds, BATCH)) {
+      if (ch.length === 0) continue;
+      const full = await tx
+        .select()
+        .from(linesNextTable)
+        .where(inArray(linesNextTable.id, ch));
+      for (const row of full) {
+        await tx
+          .insert(linesTable)
+          .values({
+            id: row.id,
+            hash: row.hash,
+            name: row.name,
+            type: row.type,
+            color: row.color,
+            started_at: row.started_at,
+            operating_hours: row.operating_hours,
+          })
+          .onConflictDoUpdate({
+            target: [linesTable.id],
+            set: {
+              hash: row.hash,
+              name: row.name,
+              updated_at: new Date(),
+            },
+          });
+      }
+      await tx
+        .delete(lineOperatorsTable)
+        .where(inArray(lineOperatorsTable.line_id, ch));
+      for (const row of full) {
+        if (row.operators.length > 0) {
+          await tx.insert(lineOperatorsTable).values(
+            row.operators.map((operator) => {
+              return {
+                line_id: row.id,
+                operator_id: operator.operatorId,
+                started_at: operator.startedAt,
+                ended_at: operator.endedAt,
+                hash: row.hash,
+              } satisfies InferInsertModel<typeof lineOperatorsTable>;
+            }),
+          );
+        }
+      }
+    }
+
+    await tx
+      .delete(lineOperatorsTable)
+      .where(
+        notExists(
+          tx
+            .select()
+            .from(linesNextTable)
+            .where(eq(linesNextTable.id, lineOperatorsTable.line_id)),
+        ),
+      );
+    await tx
+      .delete(linesTable)
+      .where(
+        notExists(
+          tx
+            .select()
+            .from(linesNextTable)
+            .where(eq(linesNextTable.id, linesTable.id)),
+        ),
+      );
+  });
+}
+
+/**
+ * Stations plus `station_codes` / `station_landmarks`. For changed stations:
+ * child rows are removed and reinserted from staging JSON.
+ */
+export async function syncStations(db: Db): Promise<void> {
+  await db.transaction(async (tx) => {
+    const rows = await tx
+      .select({
+        id: stationsNextTable.id,
+        nextHash: stationsNextTable.hash,
+        liveHash: stationsTable.hash,
+      })
+      .from(stationsNextTable)
+      .leftJoin(stationsTable, eq(stationsNextTable.id, stationsTable.id));
+
+    const changedIds = rows
+      .filter((r) => r.liveHash == null || r.liveHash !== r.nextHash)
+      .map((r) => r.id);
+
+    for (const ch of chunk(changedIds, BATCH)) {
+      if (ch.length === 0) continue;
+      const full = await tx
+        .select()
+        .from(stationsNextTable)
+        .where(inArray(stationsNextTable.id, ch));
+      for (const row of full) {
+        await tx
+          .insert(stationsTable)
+          .values({
+            id: row.id,
+            hash: row.hash,
+            name: row.name,
+            geo: row.geo,
+            townId: row.town_id,
+          })
+          .onConflictDoUpdate({
+            target: [stationsTable.id],
+            set: {
+              hash: row.hash,
+              name: row.name,
+              geo: row.geo,
+              townId: row.town_id,
+            },
+          });
+      }
+      await tx
+        .delete(stationCodesTable)
+        .where(inArray(stationCodesTable.station_id, ch));
+      await tx
+        .delete(stationLandmarksTable)
+        .where(inArray(stationLandmarksTable.station_id, ch));
+      for (const row of full) {
+        await tx.insert(stationCodesTable).values(
+          row.station_codes.map((stationCode) => {
+            return {
+              station_id: row.id,
+              line_id: stationCode.lineId,
+              code: stationCode.code,
+              structure_type: stationCode.structureType,
+              started_at: stationCode.startedAt,
+              ended_at: stationCode.endedAt,
+            } satisfies InferInsertModel<typeof stationCodesTable>;
+          }),
+        );
+        await tx.insert(stationLandmarksTable).values(
+          row.landmark_ids.map((landmarkId) => {
+            return {
+              station_id: row.id,
+              landmark_id: landmarkId,
+            } satisfies InferInsertModel<typeof stationLandmarksTable>;
+          }),
+        );
+      }
+    }
+
+    await tx
+      .delete(stationCodesTable)
+      .where(
+        notExists(
+          tx
+            .select()
+            .from(stationsNextTable)
+            .where(eq(stationsNextTable.id, stationCodesTable.station_id)),
+        ),
+      );
+    await tx
+      .delete(stationLandmarksTable)
+      .where(
+        notExists(
+          tx
+            .select()
+            .from(stationsNextTable)
+            .where(eq(stationsNextTable.id, stationLandmarksTable.station_id)),
+        ),
+      );
+    await tx
+      .delete(stationsTable)
+      .where(
+        notExists(
+          tx
+            .select()
+            .from(stationsNextTable)
+            .where(eq(stationsNextTable.id, stationsTable.id)),
+        ),
+      );
+  });
+}
+
+/**
+ * Services, `line_services`, revisions, and path station entries. Changed services
+ * get revisions/path wiped before reinsert (FK order: path entries → revisions → line_services).
+ */
+export async function syncServices(db: Db): Promise<void> {
+  await db.transaction(async (tx) => {
+    const rows = await tx
+      .select({
+        id: servicesNextTable.id,
+        nextHash: servicesNextTable.hash,
+        liveHash: servicesTable.hash,
+      })
+      .from(servicesNextTable)
+      .leftJoin(servicesTable, eq(servicesNextTable.id, servicesTable.id));
+
+    const changedIds = rows
+      .filter((r) => r.liveHash == null || r.liveHash !== r.nextHash)
+      .map((r) => r.id);
+
+    for (const ch of chunk(changedIds, BATCH)) {
+      if (ch.length === 0) continue;
+      await tx
+        .delete(serviceRevisionPathStationEntriesTable)
+        .where(inArray(serviceRevisionPathStationEntriesTable.service_id, ch));
+      await tx
+        .delete(serviceRevisionsTable)
+        .where(inArray(serviceRevisionsTable.service_id, ch));
+      await tx
+        .delete(lineServicesTable)
+        .where(inArray(lineServicesTable.service_id, ch));
+
+      const full = await tx
+        .select()
+        .from(servicesNextTable)
+        .where(inArray(servicesNextTable.id, ch));
+      for (const row of full) {
+        await tx
+          .insert(servicesTable)
+          .values({
+            id: row.id,
+            hash: row.hash,
+            name: row.name,
+            line_id: row.line_id,
+          })
+          .onConflictDoUpdate({
+            target: [servicesTable.id],
+            set: {
+              hash: row.hash,
+              name: row.name,
+              line_id: row.line_id,
+            },
+          });
+        await tx
+          .insert(lineServicesTable)
+          .values({
+            service_id: row.id,
+            line_id: row.line_id,
+          } satisfies InferInsertModel<typeof lineServicesTable>)
+          .onConflictDoNothing();
+
+        for (const revisionData of row.revisions) {
+          await tx
+            .insert(serviceRevisionsTable)
+            .values({
+              id: revisionData.id,
+              service_id: row.id,
+              operating_hours: revisionData.operatingHours,
+            } satisfies InferInsertModel<typeof serviceRevisionsTable>)
+            .onConflictDoUpdate({
+              target: [
+                serviceRevisionsTable.id,
+                serviceRevisionsTable.service_id,
+              ],
+              set: {
+                operating_hours: revisionData.operatingHours,
+                updated_at: new Date(),
+              },
+            });
+
+          await tx
+            .insert(serviceRevisionPathStationEntriesTable)
+            .values(
+              revisionData.path.stations.map((station, index) => {
+                return {
+                  service_revision_id: revisionData.id,
+                  service_id: row.id,
+                  station_id: station.stationId,
+                  display_code: station.displayCode,
+                  path_index: index,
+                } satisfies InferInsertModel<
+                  typeof serviceRevisionPathStationEntriesTable
+                >;
+              }),
+            )
+            // Postgres `excluded.*` — update display_code/path_index on conflict
+            .onConflictDoUpdate({
+              target: [
+                serviceRevisionPathStationEntriesTable.service_revision_id,
+                serviceRevisionPathStationEntriesTable.station_id,
+                serviceRevisionPathStationEntriesTable.path_index,
+              ],
+              set: {
+                display_code: sql.raw(
+                  `excluded.${serviceRevisionPathStationEntriesTable.display_code.name}`,
+                ),
+                path_index: sql.raw(
+                  `excluded.${serviceRevisionPathStationEntriesTable.path_index.name}`,
+                ),
+              },
+            });
+        }
+      }
+    }
+
+    await tx
+      .delete(serviceRevisionPathStationEntriesTable)
+      .where(
+        notExists(
+          tx
+            .select()
+            .from(servicesNextTable)
+            .where(
+              eq(
+                servicesNextTable.id,
+                serviceRevisionPathStationEntriesTable.service_id,
+              ),
+            ),
+        ),
+      );
+    await tx
+      .delete(serviceRevisionsTable)
+      .where(
+        notExists(
+          tx
+            .select()
+            .from(servicesNextTable)
+            .where(eq(servicesNextTable.id, serviceRevisionsTable.service_id)),
+        ),
+      );
+    await tx
+      .delete(lineServicesTable)
+      .where(
+        notExists(
+          tx
+            .select()
+            .from(servicesNextTable)
+            .where(eq(servicesNextTable.id, lineServicesTable.service_id)),
+        ),
+      );
+    await tx
+      .delete(servicesTable)
+      .where(
+        notExists(
+          tx
+            .select()
+            .from(servicesNextTable)
+            .where(eq(servicesNextTable.id, servicesTable.id)),
+        ),
+      );
+  });
+}
+
+/** Latest evidence timestamp; used for operational period resolution (`resolvePeriods`). */
+function lastEvidenceAtFromList(evidences: Evidence[]): DateTime | null {
+  return evidences.reduce(
+    (max, evidence) => {
+      const evidenceAt = DateTime.fromISO(evidence.ts);
+      if (max == null || evidenceAt > max) {
+        return evidenceAt;
+      }
+      return max;
+    },
+    null as DateTime | null,
+  );
+}
+
+/**
+ * Issues, evidences, impact events and all impact child tables. For changed issues:
+ * remove impact subtree + evidences, reinsert from staging. Then remove issues
+ * missing from `issues_next` (with full subtree cleanup).
+ */
+export async function syncIssues(db: Db): Promise<void> {
+  await db.transaction(async (tx) => {
+    const rows = await tx
+      .select({
+        id: issuesNextTable.id,
+        nextHash: issuesNextTable.hash,
+        liveHash: issuesTable.hash,
+      })
+      .from(issuesNextTable)
+      .leftJoin(issuesTable, eq(issuesNextTable.id, issuesTable.id));
+
+    const changedIds = rows
+      .filter((r) => r.liveHash == null || r.liveHash !== r.nextHash)
+      .map((r) => r.id);
+
+    for (const ch of chunk(changedIds, BATCH)) {
+      if (ch.length === 0) continue;
+      const impactRows = await tx
+        .select({ id: impactEventsTable.id })
+        .from(impactEventsTable)
+        .where(inArray(impactEventsTable.issue_id, ch));
+      const impactEventIds = impactRows.map((r) => r.id);
+      await deleteImpactEventChildren(tx, impactEventIds);
+      await tx
+        .delete(impactEventsTable)
+        .where(inArray(impactEventsTable.issue_id, ch));
+      await tx
+        .delete(evidencesTable)
+        .where(inArray(evidencesTable.issue_id, ch));
+
+      const full = await tx
+        .select()
+        .from(issuesNextTable)
+        .where(inArray(issuesNextTable.id, ch));
+      for (const row of full) {
+        await tx
+          .insert(issuesTable)
+          .values({
+            id: row.id,
+            hash: row.hash,
+            type: row.type,
+            title: row.title,
+            title_meta: row.title_meta,
+          })
+          .onConflictDoUpdate({
+            target: [issuesTable.id],
+            set: {
+              hash: row.hash,
+              type: row.type,
+              title: row.title,
+              title_meta: row.title_meta,
+            },
+          });
+
+        if (row.evidences.length > 0) {
+          await tx.insert(evidencesTable).values(
+            row.evidences.map((evidence) => {
+              return {
+                id: evidence.id,
+                ts: evidence.ts,
+                text: evidence.text,
+                type: evidence.type,
+                render: evidence.render,
+                source_url: evidence.sourceUrl,
+                issue_id: row.id,
+              } satisfies InferInsertModel<typeof evidencesTable>;
+            }),
+          );
+        }
+
+        const impactEvents = row.impact_events;
+        if (impactEvents.length > 0) {
+          const lastEvidenceAt = lastEvidenceAtFromList(row.evidences);
+
+          await tx
+            .insert(impactEventsTable)
+            .values(
+              impactEvents.map((impactEvent) => {
+                return {
+                  id: impactEvent.id,
+                  ts: impactEvent.ts,
+                  type: impactEvent.type,
+                  issue_id: row.id,
+                } satisfies InferInsertModel<typeof impactEventsTable>;
+              }),
+            )
+            .onConflictDoUpdate({
+              target: [impactEventsTable.id],
+              set: {
+                ts: sql.raw(`excluded.${impactEventsTable.ts.name}`),
+                type: sql.raw(`excluded.${impactEventsTable.type.name}`),
+                issue_id: sql.raw(`excluded.${issuesTable.id.name}`),
+              },
+            });
+
+          // One row per impact event — `basis.evidenceId` is a single id in core schema
+          const basisEvidence = impactEvents.map((impactEvent) => ({
+            impact_event_id: impactEvent.id,
+            evidence_id: impactEvent.basis.evidenceId,
+          }));
+
+          if (basisEvidence.length > 0) {
+            await tx
+              .insert(impactEventBasisEvidencesTable)
+              .values(basisEvidence);
+          }
+
+          for (const impactEvent of impactEvents) {
+            switch (impactEvent.entity.type) {
+              case 'service': {
+                await tx.insert(impactEventEntityServicesTable).values({
+                  impact_event_id: impactEvent.id,
+                  service_id: impactEvent.entity.serviceId,
+                } satisfies InferInsertModel<
+                  typeof impactEventEntityServicesTable
+                >);
+                break;
+              }
+              case 'facility': {
+                await tx.insert(impactEventEntityFacilitiesTable).values({
+                  impact_event_id: impactEvent.id,
+                  station_id: impactEvent.entity.stationId,
+                  kind: impactEvent.entity.kind,
+                } satisfies InferInsertModel<
+                  typeof impactEventEntityFacilitiesTable
+                >);
+                break;
+              }
+            }
+
+            switch (impactEvent.type) {
+              case 'periods.set': {
+                const resolvedPeriodsOperational = resolvePeriods({
+                  mode: {
+                    kind: 'operational',
+                    lastEvidenceAt: lastEvidenceAt?.toISO() ?? null,
+                  },
+                  periods: impactEvent.periods,
+                  asOf: impactEvent.ts,
+                });
+                if (resolvedPeriodsOperational.length > 0) {
+                  await tx.insert(impactEventPeriodsTable).values(
+                    resolvedPeriodsOperational.map((period, index) => {
+                      return {
+                        impact_event_id: impactEvent.id,
+                        mode: 'operational',
+                        index,
+                        start_at: period.startAt,
+                        end_at: period.endAt,
+                        end_at_resolved: period.endAtResolved,
+                        end_at_source: period.endAtSource,
+                        end_at_reason: period.endAtReason,
+                      } satisfies InferInsertModel<
+                        typeof impactEventPeriodsTable
+                      >;
+                    }),
+                  );
+                }
+
+                const resolvedPeriodsCanonical = resolvePeriods({
+                  mode: {
+                    kind: 'canonical',
+                  },
+                  periods: impactEvent.periods,
+                  asOf: impactEvent.ts,
+                });
+                if (resolvedPeriodsCanonical.length > 0) {
+                  await tx.insert(impactEventPeriodsTable).values(
+                    resolvedPeriodsCanonical.map((period, index) => {
+                      return {
+                        impact_event_id: impactEvent.id,
+                        mode: 'canonical',
+                        index,
+                        start_at: period.startAt,
+                        end_at: period.endAt,
+                        end_at_resolved: period.endAtResolved,
+                        end_at_source: period.endAtSource,
+                        end_at_reason: period.endAtReason,
+                      } satisfies InferInsertModel<
+                        typeof impactEventPeriodsTable
+                      >;
+                    }),
+                  );
+                }
+                break;
+              }
+              case 'causes.set': {
+                await tx.insert(impactEventCausesTable).values(
+                  impactEvent.causes.map((cause) => {
+                    return {
+                      impact_event_id: impactEvent.id,
+                      type: cause,
+                    } satisfies InferInsertModel<typeof impactEventCausesTable>;
+                  }),
+                );
+                break;
+              }
+              case 'service_scopes.set': {
+                if (impactEvent.serviceScopes.length > 0) {
+                  await tx.insert(impactEventServiceScopesTable).values(
+                    impactEvent.serviceScopes.map((serviceScope, index) => {
+                      return {
+                        impact_event_id: impactEvent.id,
+                        type: serviceScope.type,
+                        index,
+                      } satisfies InferInsertModel<
+                        typeof impactEventServiceScopesTable
+                      >;
+                    }),
+                  );
+                }
+                break;
+              }
+              case 'service_effects.set': {
+                await tx.insert(impactEventServiceEffectsTable).values({
+                  impact_event_id: impactEvent.id,
+                  kind: impactEvent.effect.kind,
+                  duration:
+                    impactEvent.effect.kind === 'delay'
+                      ? impactEvent.effect.duration
+                      : null,
+                } satisfies InferInsertModel<
+                  typeof impactEventServiceEffectsTable
+                >);
+                break;
+              }
+              case 'facility_effects.set': {
+                await tx.insert(impactEventFacilityEffectsTable).values({
+                  impact_event_id: impactEvent.id,
+                  kind: impactEvent.effect.kind,
+                } satisfies InferInsertModel<
+                  typeof impactEventFacilityEffectsTable
+                >);
+                break;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    const orphanIssueRows = await tx
+      .select({ id: issuesTable.id })
+      .from(issuesTable)
+      .where(
+        notExists(
+          tx
+            .select()
+            .from(issuesNextTable)
+            .where(eq(issuesNextTable.id, issuesTable.id)),
+        ),
+      );
+    const orphanIds = orphanIssueRows.map((r) => r.id);
+    if (orphanIds.length > 0) {
+      const impRows = await tx
+        .select({ id: impactEventsTable.id })
+        .from(impactEventsTable)
+        .where(inArray(impactEventsTable.issue_id, orphanIds));
+      const orphanImpactIds = impRows.map((r) => r.id);
+      await deleteImpactEventChildren(tx, orphanImpactIds);
+      await tx
+        .delete(impactEventsTable)
+        .where(inArray(impactEventsTable.issue_id, orphanIds));
+      await tx
+        .delete(evidencesTable)
+        .where(inArray(evidencesTable.issue_id, orphanIds));
+      await tx.delete(issuesTable).where(inArray(issuesTable.id, orphanIds));
+    }
+  });
+}
+
+/** Truncates staging tables and records `manifest_last_pulled_at` in one transaction. */
+export async function finalizePull(db: Db): Promise<void> {
+  await db.transaction(async (tx) => {
+    await tx.execute(
+      sql`TRUNCATE ${operatorsNextTable}, ${townsNextTable}, ${landmarksNextTable}, ${linesNextTable}, ${stationsNextTable}, ${servicesNextTable}, ${issuesNextTable} RESTART IDENTITY`,
+    );
+    await tx
+      .insert(metadataTable)
+      .values({
+        key: 'manifest_last_pulled_at',
+        value: new Date().toISOString(),
+      })
+      .onConflictDoUpdate({
+        target: [metadataTable.key],
+        set: { value: new Date().toISOString() },
+      });
+  });
+}

--- a/app/workflows/pull/helpers/stagingSync.ts
+++ b/app/workflows/pull/helpers/stagingSync.ts
@@ -64,6 +64,10 @@ const BATCH = 500;
 
 type Db = ReturnType<typeof getDb>;
 
+function assertUnreachable(value: never, message: string): never {
+  throw new Error(`${message}: ${String(value)}`);
+}
+
 /** Splits an array into fixed-size chunks for batched inserts. */
 function chunk<T>(arr: T[], size: number): T[][] {
   const out: T[][] = [];
@@ -132,6 +136,22 @@ export async function insertLinesStaging(
   db: Db,
   lines: readonly (Line & { hash: string })[],
 ): Promise<void> {
+  const skippedLines = lines.flatMap((l) => {
+    const missing = [
+      l.startedAt == null ? 'startedAt' : null,
+      l.operatingHours == null ? 'operatingHours' : null,
+    ].filter(Boolean);
+    return missing.length > 0 ? [`${l.id} (${missing.join(', ')})`] : [];
+  });
+  if (skippedLines.length > 0) {
+    const sample = skippedLines.slice(0, 10).join('; ');
+    const suffix =
+      skippedLines.length > 10 ? `; +${skippedLines.length - 10} more` : '';
+    console.warn(
+      `[PULL] Skipping ${skippedLines.length} line(s) missing required fields: ${sample}${suffix}`,
+    );
+  }
+
   const lineRows = lines.flatMap((l) => {
     if (l.startedAt == null || l.operatingHours == null) {
       return [];
@@ -289,27 +309,28 @@ async function upsertChangedOperators(
       .select()
       .from(operatorsNextTable)
       .where(inArray(operatorsNextTable.id, ids));
-    for (const row of full) {
-      await tx
-        .insert(operatorsTable)
-        .values({
+    if (full.length === 0) continue;
+    await tx
+      .insert(operatorsTable)
+      .values(
+        full.map((row) => ({
           id: row.id,
           hash: row.hash,
           name: row.name,
           founded_at: row.founded_at,
           url: row.url,
-        })
-        .onConflictDoUpdate({
-          target: [operatorsTable.id],
-          set: {
-            hash: row.hash,
-            name: row.name,
-            founded_at: row.founded_at,
-            url: row.url,
-            updated_at: new Date(),
-          },
-        });
-    }
+        })),
+      )
+      .onConflictDoUpdate({
+        target: [operatorsTable.id],
+        set: {
+          hash: sql.raw(`excluded.${operatorsTable.hash.name}`),
+          name: sql.raw(`excluded.${operatorsTable.name.name}`),
+          founded_at: sql.raw(`excluded.${operatorsTable.founded_at.name}`),
+          url: sql.raw(`excluded.${operatorsTable.url.name}`),
+          updated_at: new Date(),
+        },
+      });
   }
   await tx
     .delete(operatorsTable)
@@ -573,26 +594,30 @@ export async function syncStations(db: Db): Promise<void> {
         .delete(stationLandmarksTable)
         .where(inArray(stationLandmarksTable.station_id, ch));
       for (const row of full) {
-        await tx.insert(stationCodesTable).values(
-          row.station_codes.map((stationCode) => {
-            return {
-              station_id: row.id,
-              line_id: stationCode.lineId,
-              code: stationCode.code,
-              structure_type: stationCode.structureType,
-              started_at: stationCode.startedAt,
-              ended_at: stationCode.endedAt,
-            } satisfies InferInsertModel<typeof stationCodesTable>;
-          }),
-        );
-        await tx.insert(stationLandmarksTable).values(
-          row.landmark_ids.map((landmarkId) => {
-            return {
-              station_id: row.id,
-              landmark_id: landmarkId,
-            } satisfies InferInsertModel<typeof stationLandmarksTable>;
-          }),
-        );
+        if (row.station_codes.length > 0) {
+          await tx.insert(stationCodesTable).values(
+            row.station_codes.map((stationCode) => {
+              return {
+                station_id: row.id,
+                line_id: stationCode.lineId,
+                code: stationCode.code,
+                structure_type: stationCode.structureType,
+                started_at: stationCode.startedAt,
+                ended_at: stationCode.endedAt,
+              } satisfies InferInsertModel<typeof stationCodesTable>;
+            }),
+          );
+        }
+        if (row.landmark_ids.length > 0) {
+          await tx.insert(stationLandmarksTable).values(
+            row.landmark_ids.map((landmarkId) => {
+              return {
+                station_id: row.id,
+                landmark_id: landmarkId,
+              } satisfies InferInsertModel<typeof stationLandmarksTable>;
+            }),
+          );
+        }
       }
     }
 
@@ -901,7 +926,9 @@ export async function syncIssues(db: Db): Promise<void> {
               set: {
                 ts: sql.raw(`excluded.${impactEventsTable.ts.name}`),
                 type: sql.raw(`excluded.${impactEventsTable.type.name}`),
-                issue_id: sql.raw(`excluded.${issuesTable.id.name}`),
+                issue_id: sql.raw(
+                  `excluded.${impactEventsTable.issue_id.name}`,
+                ),
               },
             });
 
@@ -937,6 +964,12 @@ export async function syncIssues(db: Db): Promise<void> {
                   typeof impactEventEntityFacilitiesTable
                 >);
                 break;
+              }
+              default: {
+                assertUnreachable(
+                  impactEvent.entity,
+                  'Unexpected impact event entity',
+                );
               }
             }
 
@@ -1044,6 +1077,9 @@ export async function syncIssues(db: Db): Promise<void> {
                   typeof impactEventFacilityEffectsTable
                 >);
                 break;
+              }
+              default: {
+                assertUnreachable(impactEvent, 'Unexpected impact event type');
               }
             }
           }

--- a/app/workflows/pull/index.ts
+++ b/app/workflows/pull/index.ts
@@ -1,0 +1,188 @@
+import {
+  WorkflowEntrypoint,
+  type WorkflowEvent,
+  type WorkflowStep,
+} from 'cloudflare:workers';
+import { MRTDownRepository } from '@mrtdown/fs';
+import { ZipStore } from '~/helpers/ZipStore.js';
+import { getDb } from '../../db/index.js';
+import { fetchArchive } from './helpers/fetchArchive.js';
+import { fetchManifest } from './helpers/fetchManifest.js';
+import {
+  finalizePull,
+  insertIssuesStaging,
+  insertLandmarksStaging,
+  insertLinesStaging,
+  insertOperatorsStaging,
+  insertServicesStaging,
+  insertStationsStaging,
+  insertTownsStaging,
+  syncIssues,
+  syncLines,
+  syncOperatorsTownsLandmarks,
+  syncServices,
+  syncStations,
+  truncateStagingTables,
+} from './helpers/stagingSync.js';
+
+type Params = Record<string, never>;
+
+/** CPU-heavy gzip/tar parse + batched writes to `*_next`; larger timeout for big archives. */
+const parseStepConfig = {
+  retries: {
+    limit: 2,
+    delay: '10 seconds' as const,
+    backoff: 'linear' as const,
+  },
+  timeout: '5 minutes' as const,
+};
+
+/** DB promotion steps: retries for transient Hyperdrive / Postgres errors. */
+const syncStepConfig = {
+  retries: {
+    limit: 3,
+    delay: '5 seconds' as const,
+    backoff: 'exponential' as const,
+  },
+};
+
+/**
+ * Durable pull pipeline: manifest → parse into staging → promote by domain →
+ * truncate staging + metadata. Staging is the handoff between steps (no large step returns).
+ */
+export class PullWorkflow extends WorkflowEntrypoint<Env, Params> {
+  async run(_event: WorkflowEvent<Params>, step: WorkflowStep) {
+    const dataUrl = this.env.MRTDOWN_DATA_URL;
+
+    const manifest = await step.do('manifest', async () =>
+      fetchManifest(dataUrl),
+    );
+
+    const counts = await step.do('parse', parseStepConfig, async () => {
+      const archiveBuffer = await fetchArchive(dataUrl);
+      console.log('[PULL] Fetched archive', archiveBuffer.length);
+      const store = new ZipStore(archiveBuffer);
+      console.log('[PULL] Created zip store');
+
+      const repo = new MRTDownRepository({ store });
+      const db = getDb();
+      await truncateStagingTables(db);
+
+      // Stage one repository domain at a time so the workflow does not retain
+      // the full parsed dataset in memory between inserts.
+      const operators = repo.operators.list().map((operator) => ({
+        ...operator,
+        hash: manifest.operators[operator.id] ?? '',
+      }));
+      await insertOperatorsStaging(db, operators);
+      // The repository caches parsed entities; this drops only inflated ZIP bytes.
+      store.clearCache();
+
+      const towns = repo.towns.list().map((town) => ({
+        ...town,
+        hash: manifest.towns[town.id] ?? '',
+      }));
+      await insertTownsStaging(db, towns);
+      store.clearCache();
+
+      const landmarks = repo.landmarks.list().map((landmark) => ({
+        ...landmark,
+        hash: manifest.landmarks[landmark.id] ?? '',
+      }));
+      await insertLandmarksStaging(db, landmarks);
+      store.clearCache();
+
+      const lines = repo.lines.list().map((line) => ({
+        ...line,
+        hash: manifest.lines[line.id] ?? '',
+      }));
+      await insertLinesStaging(db, lines);
+      store.clearCache();
+
+      const issues = repo.issues.list().map((issue) => ({
+        issue: {
+          ...issue.issue,
+          hash: manifest.issues[issue.issue.id] ?? '',
+        },
+        evidence: issue.evidence,
+        impactEvents: issue.impactEvents,
+      }));
+      await insertIssuesStaging(db, issues);
+      store.clearCache();
+
+      const stations = repo.stations.list().map((station) => ({
+        ...station,
+        hash: manifest.stations[station.id] ?? '',
+      }));
+      await insertStationsStaging(db, stations);
+      store.clearCache();
+
+      const services = repo.services.list().map((service) => ({
+        ...service,
+        hash: manifest.services[service.id] ?? '',
+      }));
+      await insertServicesStaging(db, services);
+      store.clearCache();
+
+      console.log(
+        `[PULL] Parsed ${operators.length} operators, ${towns.length} towns, ${landmarks.length} landmarks, ${lines.length} lines, ${stations.length} stations, ${services.length} services, ${issues.length} issues`,
+      );
+
+      return {
+        operators: operators.length,
+        towns: towns.length,
+        landmarks: landmarks.length,
+        lines: lines.length,
+        stations: stations.length,
+        services: services.length,
+        issues: issues.length,
+      };
+    });
+
+    await step.do(
+      'sync-operators-towns-landmarks',
+      syncStepConfig,
+      async () => {
+        const db = getDb();
+        await syncOperatorsTownsLandmarks(db);
+      },
+    );
+
+    await step.do('sync-lines', syncStepConfig, async () => {
+      const db = getDb();
+      console.log('Syncing lines...');
+      await syncLines(db);
+    });
+
+    await step.do('sync-stations', syncStepConfig, async () => {
+      const db = getDb();
+      console.log('Syncing stations...');
+      await syncStations(db);
+    });
+
+    await step.do('sync-services', syncStepConfig, async () => {
+      const db = getDb();
+      console.log('Syncing services...');
+      await syncServices(db);
+    });
+
+    await step.do('sync-issues', syncStepConfig, async () => {
+      const db = getDb();
+      console.log('Syncing issues...');
+      try {
+        await syncIssues(db);
+      } catch (error) {
+        console.error('Error syncing issues', error);
+        throw error;
+      }
+    });
+
+    await step.do('finalize', syncStepConfig, async () => {
+      const db = getDb();
+      console.log('Finalizing pull...');
+      await finalizePull(db);
+    });
+
+    console.log('[PULL] Pull complete', counts);
+  }
+}

--- a/app/workflows/pull/index.ts
+++ b/app/workflows/pull/index.ts
@@ -70,72 +70,100 @@ export class PullWorkflow extends WorkflowEntrypoint<Env, Params> {
 
       // Stage one repository domain at a time so the workflow does not retain
       // the full parsed dataset in memory between inserts.
-      const operators = repo.operators.list().map((operator) => ({
-        ...operator,
-        hash: manifest.operators[operator.id] ?? '',
-      }));
-      await insertOperatorsStaging(db, operators);
+      let operatorsCount = 0;
+      {
+        const operators = repo.operators.list().map((operator) => ({
+          ...operator,
+          hash: manifest.operators[operator.id] ?? '',
+        }));
+        await insertOperatorsStaging(db, operators);
+        operatorsCount = operators.length;
+      }
       // The repository caches parsed entities; this drops only inflated ZIP bytes.
       store.clearCache();
 
-      const towns = repo.towns.list().map((town) => ({
-        ...town,
-        hash: manifest.towns[town.id] ?? '',
-      }));
-      await insertTownsStaging(db, towns);
+      let townsCount = 0;
+      {
+        const towns = repo.towns.list().map((town) => ({
+          ...town,
+          hash: manifest.towns[town.id] ?? '',
+        }));
+        await insertTownsStaging(db, towns);
+        townsCount = towns.length;
+      }
       store.clearCache();
 
-      const landmarks = repo.landmarks.list().map((landmark) => ({
-        ...landmark,
-        hash: manifest.landmarks[landmark.id] ?? '',
-      }));
-      await insertLandmarksStaging(db, landmarks);
+      let landmarksCount = 0;
+      {
+        const landmarks = repo.landmarks.list().map((landmark) => ({
+          ...landmark,
+          hash: manifest.landmarks[landmark.id] ?? '',
+        }));
+        await insertLandmarksStaging(db, landmarks);
+        landmarksCount = landmarks.length;
+      }
       store.clearCache();
 
-      const lines = repo.lines.list().map((line) => ({
-        ...line,
-        hash: manifest.lines[line.id] ?? '',
-      }));
-      await insertLinesStaging(db, lines);
+      let linesCount = 0;
+      {
+        const lines = repo.lines.list().map((line) => ({
+          ...line,
+          hash: manifest.lines[line.id] ?? '',
+        }));
+        await insertLinesStaging(db, lines);
+        linesCount = lines.length;
+      }
       store.clearCache();
 
-      const issues = repo.issues.list().map((issue) => ({
-        issue: {
-          ...issue.issue,
-          hash: manifest.issues[issue.issue.id] ?? '',
-        },
-        evidence: issue.evidence,
-        impactEvents: issue.impactEvents,
-      }));
-      await insertIssuesStaging(db, issues);
+      let issuesCount = 0;
+      {
+        const issues = repo.issues.list().map((issue) => ({
+          issue: {
+            ...issue.issue,
+            hash: manifest.issues[issue.issue.id] ?? '',
+          },
+          evidence: issue.evidence,
+          impactEvents: issue.impactEvents,
+        }));
+        await insertIssuesStaging(db, issues);
+        issuesCount = issues.length;
+      }
       store.clearCache();
 
-      const stations = repo.stations.list().map((station) => ({
-        ...station,
-        hash: manifest.stations[station.id] ?? '',
-      }));
-      await insertStationsStaging(db, stations);
+      let stationsCount = 0;
+      {
+        const stations = repo.stations.list().map((station) => ({
+          ...station,
+          hash: manifest.stations[station.id] ?? '',
+        }));
+        await insertStationsStaging(db, stations);
+        stationsCount = stations.length;
+      }
       store.clearCache();
 
-      const services = repo.services.list().map((service) => ({
-        ...service,
-        hash: manifest.services[service.id] ?? '',
-      }));
-      await insertServicesStaging(db, services);
+      let servicesCount = 0;
+      {
+        const services = repo.services.list().map((service) => ({
+          ...service,
+          hash: manifest.services[service.id] ?? '',
+        }));
+        await insertServicesStaging(db, services);
+        servicesCount = services.length;
+      }
       store.clearCache();
 
       console.log(
-        `[PULL] Parsed ${operators.length} operators, ${towns.length} towns, ${landmarks.length} landmarks, ${lines.length} lines, ${stations.length} stations, ${services.length} services, ${issues.length} issues`,
+        `[PULL] Parsed ${operatorsCount} operators, ${townsCount} towns, ${landmarksCount} landmarks, ${linesCount} lines, ${stationsCount} stations, ${servicesCount} services, ${issuesCount} issues`,
       );
 
       return {
-        operators: operators.length,
-        towns: towns.length,
-        landmarks: landmarks.length,
-        lines: lines.length,
-        stations: stations.length,
-        services: services.length,
-        issues: issues.length,
+        operators: operatorsCount,
+        towns: townsCount,
+        landmarks: landmarksCount,
+        lines: linesCount,
+        stations: stationsCount,
+        services: servicesCount,
+        issues: issuesCount,
       };
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,10 @@
         "tailwindcss": "^4.0.9",
         "use-debounce": "^10.0.4",
         "xast-util-to-xml": "^4.0.0",
-        "zod": "^4.1.12"
+        "zod": "^4.1.12",
+        "@mrtdown/fs": "^2.0.0-alpha.22",
+        "fflate": "^0.8.2",
+        "json-nd": "^1.0.0"
       },
       "devDependencies": {
         "@biomejs/biome": "2.0.0",
@@ -13279,6 +13282,54 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@mrtdown/fs": {
+      "version": "2.0.0-alpha.22",
+      "resolved": "https://registry.npmjs.org/@mrtdown/fs/-/fs-2.0.0-alpha.22.tgz",
+      "integrity": "sha512-70FnOPCegYMjk4uvbmurMBWz+etPhxDe4QzC1ELggw3BKVjd9S7OEpVsZgePWdkN4X7fhthAJOrnlPZm22WUpQ==",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@mrtdown/core": "^2.0.0-alpha.22",
+        "fuse.js": "^7.1.0",
+        "json-nd": "^1.0.0",
+        "luxon": "^3.5.0",
+        "ulid": "^3.0.2",
+        "zod": "^4.0.14"
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
+    "node_modules/fuse.js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
+      }
+    },
+    "node_modules/json-nd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-nd/-/json-nd-1.0.0.tgz",
+      "integrity": "sha512-8TIp0HZAY0VVrwRQJJPb4+nOTSPoOWZeEKBTLizUfQO4oym5Fc/MKqN8vEbLCxcyxDf2vwNxOQ1q84O49GWPyQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ulid": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/ulid/-/ulid-3.0.2.tgz",
+      "integrity": "sha512-yu26mwteFYzBAot7KVMqFGCVpsF6g8wXfJzQUHvu1no3+rRRSFcSV2nKeYvNPLD2J4b08jYBDhHUjeH0ygIl9w==",
+      "license": "MIT",
+      "bin": {
+        "ulid": "dist/cli.js"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "i18n:extract": "formatjs extract 'app/**/*.{ts,tsx}' --ignore '**/*.d.ts' --out-file lang/en-SG.json --format simple",
     "build": "vite build",
     "test": "vitest",
+    "dev:pull": "curl -i -X POST http://localhost:3000/internal/api/tasks/pull",
     "api:client:generate": "tsx app/scripts/generateApiClient.ts",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@heroicons/react": "^2.2.0",
     "@mrtdown/core": "^2.0.0-alpha.22",
+    "@mrtdown/fs": "^2.0.0-alpha.22",
     "@posthog/react": "^1.8.3",
     "@sentry/cloudflare": "^10.47.0",
     "@sentry/tanstackstart-react": "^10.47.0",
@@ -29,8 +30,10 @@
     "@tanstack/react-start": "^1.167.16",
     "classnames": "^2.5.1",
     "drizzle-orm": "^0.45.2",
+    "fflate": "^0.8.2",
     "html-entities": "^2.6.0",
     "isbot": "^5",
+    "json-nd": "^1.0.0",
     "luxon": "^3.5.0",
     "pg": "^8.20.0",
     "posthog-js": "^1.335.0",

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -5,6 +5,28 @@ declare namespace Cloudflare {
 	interface GlobalProps {
 		mainModule: typeof import("./app/server");
 	}
+	interface StagingEnv {
+		API_ENDPOINT: string;
+		API_TOKEN: string;
+		SENTRY_DSN: string;
+		TIER: string;
+		GIT_SHA: string;
+		VITE_ROOT_URL: string;
+		MRTDOWN_DATA_URL: string;
+		INTERNAL_API_TOKENS: string;
+	}
+	interface ProductionEnv {
+		HYPERDRIVE: Hyperdrive;
+		API_ENDPOINT: string;
+		API_TOKEN: string;
+		SENTRY_DSN: string;
+		TIER: string;
+		GIT_SHA: string;
+		VITE_ROOT_URL: string;
+		MRTDOWN_DATA_URL: string;
+		INTERNAL_API_TOKENS: string;
+		PULL_WORKFLOW: Workflow<Parameters<import("./app/server").PullWorkflow['run']>[0]['payload']>;
+	}
 	interface Env {
 		API_ENDPOINT: string;
 		API_TOKEN: string;
@@ -12,6 +34,10 @@ declare namespace Cloudflare {
 		TIER: string;
 		GIT_SHA: string;
 		VITE_ROOT_URL: string;
+		MRTDOWN_DATA_URL: string;
+		INTERNAL_API_TOKENS: string;
+		HYPERDRIVE?: Hyperdrive;
+		PULL_WORKFLOW?: Workflow<Parameters<import("./app/server").PullWorkflow['run']>[0]['payload']>;
 	}
 }
 interface Env extends Cloudflare.Env {}
@@ -19,7 +45,7 @@ type StringifyValues<EnvType extends Record<string, unknown>> = {
 	[Binding in keyof EnvType]: EnvType[Binding] extends string ? EnvType[Binding] : string;
 };
 declare namespace NodeJS {
-	interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, "API_ENDPOINT" | "API_TOKEN" | "SENTRY_DSN" | "TIER" | "GIT_SHA" | "VITE_ROOT_URL">> {}
+	interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, "API_ENDPOINT" | "API_TOKEN" | "SENTRY_DSN" | "TIER" | "GIT_SHA" | "VITE_ROOT_URL" | "MRTDOWN_DATA_URL" | "INTERNAL_API_TOKENS">> {}
 }
 
 // Begin runtime types

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -14,6 +14,23 @@
             "head_sampling_rate": 1
         }
     },
+    "limits": {
+        "cpu_ms": 300000
+    },
+    "hyperdrive": [
+        {
+            "binding": "HYPERDRIVE",
+            "id": "1413ff84b6ef40a19973b1bc8a662736",
+            "localConnectionString": "postgresql://postgres:postgres@localhost:5432/mrtdown-db"
+        }
+    ],
+    "workflows": [
+        {
+            "binding": "PULL_WORKFLOW",
+            "name": "mrtdown-pull",
+            "class_name": "PullWorkflow"
+        }
+    ],
     "env": {
         "staging": {
             "observability": {
@@ -33,7 +50,23 @@
                     "enabled": true,
                     "head_sampling_rate": 0.1
                 }
-            }
+            },
+            "limits": {
+                "cpu_ms": 300000
+            },
+            "hyperdrive": [
+                {
+                    "binding": "HYPERDRIVE",
+                    "id": "1d9561e9411649a6afe8612881ff926d"
+                }
+            ],
+            "workflows": [
+                {
+                    "binding": "PULL_WORKFLOW",
+                    "name": "mrtdown-pull",
+                    "class_name": "PullWorkflow"
+                }
+            ]
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds the canonical data pull workflow layer on top of the DB foundation.

- Adds archive/manifest fetch helpers and `ZipStore`.
- Adds staging sync helpers and the Cloudflare `PullWorkflow` entrypoint.
- Adds the internal pull task route and workflow bindings.

Related: https://github.com/foldaway/mrtdown-data/issues/156

## Validation

Not run as a standalone strict gate. This PR is part of the stacked overhaul; baseline validation is introduced in the harness PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Triggerable durable "pull" workflow to import and promote external dataset.
  * ZIP-backed archive reader for bulk data ingestion and a DB connection helper.
  * Protected internal API endpoint with token-based middleware.

* **Bug Fixes / Reliability**
  * Enforced fetch timeouts and size limits; safer streaming and clearer error/status responses.
  * Improved caching behavior and robust staged-to-live synchronization with orphan cleanup.

* **Chores**
  * Runtime config, workflow binding, dev script and dependency updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-site/pull/67)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->