### PR TITLE
feat(db): replace API reads with DB queries

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -41,7 +41,7 @@ jobs:
         run: npm run db:preview:prepare
         env:
           ALLOW_DATABASE_RESET: "true"
-          DATABASE_URL: ${{ secrets.PREVIEW_DATABASE_URL }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
           FIXTURES_BASE_URL: https://foldaway.github.io/mrtdown-data/fixtures
 
       - name: Build

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -57,6 +57,7 @@ jobs:
           fi
 
           echo "current_branch=$sanitized_branch" >> "$GITHUB_OUTPUT"
+          echo "neon_branch=preview/pr-$PR_NUMBER-$sanitized_branch" >> "$GITHUB_OUTPUT"
 
       - name: Build
         run: npm run build
@@ -68,9 +69,20 @@ jobs:
           VITE_PUBLIC_POSTHOG_HOST: ${{ secrets.VITE_PUBLIC_POSTHOG_HOST }}
           VITE_ROOT_URL: "https://www.mrtdown.org"
 
+      - name: Create Neon Branch
+        id: create_neon_branch
+        uses: neondatabase/create-branch-action@v6
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          branch_name: ${{ steps.branch_name.outputs.neon_branch }}
+          role: hyperdrive-user
+          database: mrtdown-db
+          api_key: ${{ secrets.NEON_API_KEY }}
+
       - name: Create preview.env
         run: |-
           echo "VITE_ROOT_URL=https://www.mrtdown.org" >> preview.env
+          echo "DATABASE_URL=${{ steps.create_neon_branch.outputs.db_url }}" >> preview.env
 
       - name: Deploy to Cloudflare Workers
         id: deploy
@@ -82,3 +94,39 @@ jobs:
 
       - name: Remove preview.env
         run: rm preview.env
+
+  teardown:
+    name: Teardown
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate preview alias
+        id: branch_name
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          sanitized_branch=$(
+            printf '%s' "$BRANCH_NAME" \
+              | tr '[:upper:]' '[:lower:]' \
+              | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g'
+          )
+
+          if [ -z "$sanitized_branch" ]; then
+            sanitized_branch="pr-$PR_NUMBER"
+          elif ! printf '%s' "$sanitized_branch" | grep -Eq '^[a-z]'; then
+            sanitized_branch="pr-$sanitized_branch"
+          fi
+
+          echo "current_branch=$sanitized_branch" >> "$GITHUB_OUTPUT"
+          echo "neon_branch=preview/pr-$PR_NUMBER-$sanitized_branch" >> "$GITHUB_OUTPUT"
+
+      - name: Delete Neon Branch
+        uses: neondatabase/delete-branch-action@v3
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          branch: ${{ steps.branch_name.outputs.neon_branch }}
+          api_key: ${{ secrets.NEON_API_KEY }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -6,7 +6,6 @@ on:
       - opened
       - reopened
       - synchronize
-      - closed
 
 jobs:
   deploy:
@@ -57,7 +56,6 @@ jobs:
           fi
 
           echo "current_branch=$sanitized_branch" >> "$GITHUB_OUTPUT"
-          echo "neon_branch=preview/pr-$PR_NUMBER-$sanitized_branch" >> "$GITHUB_OUTPUT"
 
       - name: Build
         run: npm run build
@@ -69,67 +67,20 @@ jobs:
           VITE_PUBLIC_POSTHOG_HOST: ${{ secrets.VITE_PUBLIC_POSTHOG_HOST }}
           VITE_ROOT_URL: "https://www.mrtdown.org"
 
-      - name: Create Neon Branch
-        id: create_neon_branch
-        uses: neondatabase/create-branch-action@v6
-        with:
-          project_id: ${{ vars.NEON_PROJECT_ID }}
-          branch_name: ${{ steps.branch_name.outputs.neon_branch }}
-          role: hyperdrive-user
-          database: mrtdown_db
-          api_key: ${{ secrets.NEON_API_KEY }}
-
       - name: Create preview.env
         run: |-
           echo "VITE_ROOT_URL=https://www.mrtdown.org" >> preview.env
-          echo "DATABASE_URL=${{ steps.create_neon_branch.outputs.db_url }}" >> preview.env
 
       - name: Deploy to Cloudflare Workers
         id: deploy
         uses: cloudflare/wrangler-action@v3
         with:
-          # Preview deployments intentionally share the top-level PULL_WORKFLOW
-          # binding. If PR-level workflow isolation becomes necessary, generate
-          # a temporary Wrangler config for this upload.
+          # Preview deployments intentionally share the top-level HYPERDRIVE
+          # and PULL_WORKFLOW bindings. If PR-level isolation becomes necessary,
+          # generate a temporary Wrangler config for this upload.
           command: versions upload --env preview --preview-alias "${{ steps.branch_name.outputs.current_branch }}" --secrets-file preview.env
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Remove preview.env
         run: rm preview.env
-
-  teardown:
-    name: Teardown
-    if: |
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Generate preview alias
-        id: branch_name
-        env:
-          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          sanitized_branch=$(
-            printf '%s' "$BRANCH_NAME" \
-              | tr '[:upper:]' '[:lower:]' \
-              | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g'
-          )
-
-          if [ -z "$sanitized_branch" ]; then
-            sanitized_branch="pr-$PR_NUMBER"
-          elif ! printf '%s' "$sanitized_branch" | grep -Eq '^[a-z]'; then
-            sanitized_branch="pr-$sanitized_branch"
-          fi
-
-          echo "current_branch=$sanitized_branch" >> "$GITHUB_OUTPUT"
-          echo "neon_branch=preview/pr-$PR_NUMBER-$sanitized_branch" >> "$GITHUB_OUTPUT"
-
-      - name: Delete Neon Branch
-        uses: neondatabase/delete-branch-action@v3
-        with:
-          project_id: ${{ vars.NEON_PROJECT_ID }}
-          branch: ${{ steps.branch_name.outputs.neon_branch }}
-          api_key: ${{ secrets.NEON_API_KEY }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -22,8 +22,8 @@ jobs:
       name: preview
       url: ${{ steps.deploy.outputs.deployment-url }}
     concurrency:
-      group: deploy-preview-${{ github.ref }}
-      cancel-in-progress: true
+      group: deploy-preview-shared-database
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -37,26 +37,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Generate preview alias
-        id: branch_name
-        env:
-          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          sanitized_branch=$(
-            printf '%s' "$BRANCH_NAME" \
-              | tr '[:upper:]' '[:lower:]' \
-              | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g'
-          )
-
-          if [ -z "$sanitized_branch" ]; then
-            sanitized_branch="pr-$PR_NUMBER"
-          elif ! printf '%s' "$sanitized_branch" | grep -Eq '^[a-z]'; then
-            sanitized_branch="pr-$sanitized_branch"
-          fi
-
-          echo "current_branch=$sanitized_branch" >> "$GITHUB_OUTPUT"
-
       - name: Build
         run: npm run build
         env:
@@ -75,10 +55,17 @@ jobs:
         id: deploy
         uses: cloudflare/wrangler-action@v3
         with:
-          # Preview deployments intentionally share the top-level HYPERDRIVE
-          # and PULL_WORKFLOW bindings. If PR-level isolation becomes necessary,
-          # generate a temporary Wrangler config for this upload.
-          command: versions upload --env preview --preview-alias "${{ steps.branch_name.outputs.current_branch }}" --secrets-file preview.env
+          # Preview deployments intentionally use the top-level Wrangler config,
+          # not per-PR preview aliases. All open PRs deploy over the same preview
+          # Worker/Workflow resources, so newer preview deploys override older
+          # ones and share the same HYPERDRIVE and PULL_WORKFLOW config.
+          # `versions upload --preview-alias` does not deploy/update Workflows,
+          # so use `deploy` here to keep the Worker and Workflow in sync.
+          # Fully isolated previews would need per-PR Worker, Workflow,
+          # Hyperdrive, and Neon resources plus reliable teardown. That
+          # operational cost is not worth it while preview deploys are mostly
+          # for one active contributor.
+          command: deploy --secrets-file preview.env
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -37,6 +37,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Reset, migrate, and seed preview database
+        run: npm run db:preview:prepare
+        env:
+          ALLOW_DATABASE_RESET: "true"
+          DATABASE_URL: ${{ secrets.PREVIEW_DATABASE_URL }}
+          FIXTURES_BASE_URL: https://foldaway.github.io/mrtdown-data/fixtures
+
       - name: Build
         run: npm run build
         env:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -76,7 +76,7 @@ jobs:
           project_id: ${{ vars.NEON_PROJECT_ID }}
           branch_name: ${{ steps.branch_name.outputs.neon_branch }}
           role: hyperdrive-user
-          database: mrtdown-db
+          database: mrtdown_db
           api_key: ${{ secrets.NEON_API_KEY }}
 
       - name: Create preview.env

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -88,6 +88,9 @@ jobs:
         id: deploy
         uses: cloudflare/wrangler-action@v3
         with:
+          # Preview deployments intentionally share the top-level PULL_WORKFLOW
+          # binding. If PR-level workflow isolation becomes necessary, generate
+          # a temporary Wrangler config for this upload.
           command: versions upload --env preview --preview-alias "${{ steps.branch_name.outputs.current_branch }}" --secrets-file preview.env
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -14,7 +14,6 @@ import {
   type OperatingHours,
   ResolvePeriodsEndAtReasonSchema,
   ResolvePeriodsEndAtSourceSchema,
-  ResolvePeriodsModeKindSchema,
   type Service,
   ServiceEffectKindSchema,
   ServiceScopeTypeSchema,
@@ -25,6 +24,7 @@ import {
 } from '@mrtdown/core';
 import { sql } from 'drizzle-orm';
 import {
+  boolean,
   check,
   date,
   foreignKey,
@@ -504,11 +504,6 @@ export const impactEventBasisEvidencesTable = pgTable(
   },
 );
 
-export const resolvePeriodsModeKindEnum = pgEnum(
-  'resolve_periods_mode_kind',
-  enumToPgEnum(ResolvePeriodsModeKindSchema.enum),
-);
-
 export const resolvePeriodsEndAtSourceEnum = pgEnum(
   'resolve_periods_end_at_source',
   enumToPgEnum(ResolvePeriodsEndAtSourceSchema.enum),
@@ -519,7 +514,8 @@ export const resolvePeriodsEndAtReasonEnum = pgEnum(
   enumToPgEnum(ResolvePeriodsEndAtReasonSchema.enum),
 );
 
-// Normalized Entity Field: ImpactEventPeriodsSet.periods
+// Canonical periods as emitted by `periods.set` events. Operational resolution is
+// derived at read time or during analytics fact generation.
 export const impactEventPeriodsTable = pgTable(
   'impact_event_periods',
   {
@@ -527,28 +523,20 @@ export const impactEventPeriodsTable = pgTable(
       .references(() => impactEventsTable.id)
       .notNull(),
     index: integer('index').notNull(),
-    mode: resolvePeriodsModeKindEnum().notNull(),
     start_at: timestamp('start_ts', {
       withTimezone: true,
       mode: 'string',
     }).notNull(),
     end_at: timestamp('end_ts', { withTimezone: true, mode: 'string' }),
-    end_at_resolved: timestamp('end_ts_resolved', {
-      withTimezone: true,
-      mode: 'string',
-    }),
-    end_at_source: resolvePeriodsEndAtSourceEnum().notNull(),
-    end_at_reason: resolvePeriodsEndAtReasonEnum(),
     ...timestampColumns,
   },
   (table) => {
     return [
-      primaryKey({ columns: [table.impact_event_id, table.index, table.mode] }),
+      primaryKey({ columns: [table.impact_event_id, table.index] }),
       index('impact_event_periods_set_periods_impact_event_id_idx').on(
         table.impact_event_id,
         table.index,
       ),
-      index('impact_event_periods_mode_idx').on(table.mode),
       index('impact_event_periods_start_at_idx').using(
         'btree',
         table.start_at.asc(),
@@ -557,12 +545,72 @@ export const impactEventPeriodsTable = pgTable(
         'btree',
         table.end_at.asc(),
       ),
-      index('impact_event_periods_end_at_resolved_idx').using(
-        'btree',
-        table.end_at_resolved.asc(),
+    ];
+  },
+);
+
+// Derived daily issue facts. These are rebuildable analytics outputs rather than
+// canonical source data, and may depend on `resolvePeriods(... kind: operational)`.
+export const issueDayFactsTable = pgTable(
+  'issue_day_facts',
+  {
+    date: date('date', { mode: 'string' }).notNull(),
+    issue_id: text('issue_id')
+      .references(() => issuesTable.id)
+      .notNull(),
+    issue_type: issueTypeEnum().notNull(),
+    as_of: timestamp('as_of', {
+      withTimezone: true,
+      mode: 'string',
+    }).notNull(),
+    active_anytime: boolean('active_anytime').notNull(),
+    active_end_of_day: boolean('active_end_of_day').notNull(),
+    duration_seconds: integer('duration_seconds').notNull(),
+    inferred_interval_count: integer('inferred_interval_count').notNull(),
+    ...timestampColumns,
+  },
+  (table) => {
+    return [
+      primaryKey({ columns: [table.date, table.issue_id] }),
+      index('issue_day_facts_issue_id_idx').on(table.issue_id),
+      index('issue_day_facts_date_issue_type_idx').on(
+        table.date,
+        table.issue_type,
       ),
-      index('impact_event_periods_end_at_source_idx').on(table.end_at_source),
-      index('impact_event_periods_end_at_reason_idx').on(table.end_at_reason),
+      index('issue_day_facts_as_of_idx').using('btree', table.as_of.asc()),
+    ];
+  },
+);
+
+// Derived daily uptime and incident facts per line. This is the intended landing
+// zone for analytical queries that would otherwise need to recompute operational
+// periods across the full issue history on every request.
+export const lineDayFactsTable = pgTable(
+  'line_day_facts',
+  {
+    date: date('date', { mode: 'string' }).notNull(),
+    line_id: text('line_id')
+      .references(() => linesTable.id)
+      .notNull(),
+    as_of: timestamp('as_of', {
+      withTimezone: true,
+      mode: 'string',
+    }).notNull(),
+    service_seconds: integer('service_seconds').notNull(),
+    downtime_disruption_seconds: integer('downtime_disruption_seconds').notNull(),
+    downtime_maintenance_seconds: integer('downtime_maintenance_seconds').notNull(),
+    downtime_infra_seconds: integer('downtime_infra_seconds').notNull(),
+    issue_count_disruption: integer('issue_count_disruption').notNull(),
+    issue_count_maintenance: integer('issue_count_maintenance').notNull(),
+    issue_count_infra: integer('issue_count_infra').notNull(),
+    ...timestampColumns,
+  },
+  (table) => {
+    return [
+      primaryKey({ columns: [table.date, table.line_id] }),
+      index('line_day_facts_line_id_idx').on(table.line_id),
+      index('line_day_facts_date_idx').on(table.date),
+      index('line_day_facts_as_of_idx').using('btree', table.as_of.asc()),
     ];
   },
 );

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -14,6 +14,7 @@ import {
   type OperatingHours,
   ResolvePeriodsEndAtReasonSchema,
   ResolvePeriodsEndAtSourceSchema,
+  ResolvePeriodsModeKindSchema,
   type Service,
   ServiceEffectKindSchema,
   ServiceScopeTypeSchema,
@@ -514,8 +515,12 @@ export const resolvePeriodsEndAtReasonEnum = pgEnum(
   enumToPgEnum(ResolvePeriodsEndAtReasonSchema.enum),
 );
 
-// Canonical periods as emitted by `periods.set` events. Operational resolution is
-// derived at read time or during analytics fact generation.
+export const resolvePeriodsModeKindEnum = pgEnum(
+  'resolve_periods_mode_kind',
+  enumToPgEnum(ResolvePeriodsModeKindSchema.enum),
+);
+
+// Normalized Entity Field: ImpactEventPeriodsSet.periods
 export const impactEventPeriodsTable = pgTable(
   'impact_event_periods',
   {
@@ -523,20 +528,28 @@ export const impactEventPeriodsTable = pgTable(
       .references(() => impactEventsTable.id)
       .notNull(),
     index: integer('index').notNull(),
+    mode: resolvePeriodsModeKindEnum().notNull(),
     start_at: timestamp('start_ts', {
       withTimezone: true,
       mode: 'string',
     }).notNull(),
     end_at: timestamp('end_ts', { withTimezone: true, mode: 'string' }),
+    end_at_resolved: timestamp('end_ts_resolved', {
+      withTimezone: true,
+      mode: 'string',
+    }),
+    end_at_source: resolvePeriodsEndAtSourceEnum().notNull(),
+    end_at_reason: resolvePeriodsEndAtReasonEnum(),
     ...timestampColumns,
   },
   (table) => {
     return [
-      primaryKey({ columns: [table.impact_event_id, table.index] }),
+      primaryKey({ columns: [table.impact_event_id, table.index, table.mode] }),
       index('impact_event_periods_set_periods_impact_event_id_idx').on(
         table.impact_event_id,
         table.index,
       ),
+      index('impact_event_periods_mode_idx').on(table.mode),
       index('impact_event_periods_start_at_idx').using(
         'btree',
         table.start_at.asc(),
@@ -545,6 +558,12 @@ export const impactEventPeriodsTable = pgTable(
         'btree',
         table.end_at.asc(),
       ),
+      index('impact_event_periods_end_at_resolved_idx').using(
+        'btree',
+        table.end_at_resolved.asc(),
+      ),
+      index('impact_event_periods_end_at_source_idx').on(table.end_at_source),
+      index('impact_event_periods_end_at_reason_idx').on(table.end_at_reason),
     ];
   },
 );
@@ -597,8 +616,12 @@ export const lineDayFactsTable = pgTable(
       mode: 'string',
     }).notNull(),
     service_seconds: integer('service_seconds').notNull(),
-    downtime_disruption_seconds: integer('downtime_disruption_seconds').notNull(),
-    downtime_maintenance_seconds: integer('downtime_maintenance_seconds').notNull(),
+    downtime_disruption_seconds: integer(
+      'downtime_disruption_seconds',
+    ).notNull(),
+    downtime_maintenance_seconds: integer(
+      'downtime_maintenance_seconds',
+    ).notNull(),
     downtime_infra_seconds: integer('downtime_infra_seconds').notNull(),
     issue_count_disruption: integer('issue_count_disruption').notNull(),
     issue_count_maintenance: integer('issue_count_maintenance').notNull(),

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -575,7 +575,10 @@ export const issueDayFactsTable = pgTable(
   {
     date: date('date', { mode: 'string' }).notNull(),
     issue_id: text('issue_id')
-      .references(() => issuesTable.id)
+      .references(() => issuesTable.id, {
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      })
       .notNull(),
     issue_type: issueTypeEnum().notNull(),
     as_of: timestamp('as_of', {
@@ -609,7 +612,10 @@ export const lineDayFactsTable = pgTable(
   {
     date: date('date', { mode: 'string' }).notNull(),
     line_id: text('line_id')
-      .references(() => linesTable.id)
+      .references(() => linesTable.id, {
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      })
       .notNull(),
     as_of: timestamp('as_of', {
       withTimezone: true,

--- a/app/routes/api.issues-day.tsx
+++ b/app/routes/api.issues-day.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { getIssuesHistoryYearMonthDay } from '~/client';
-import { assert } from '../util/assert';
+import { getHistoryDayData } from '../util/db.queries';
 
 export const Route = createFileRoute('/api/issues-day')({
   server: {
@@ -18,25 +17,11 @@ export const Route = createFileRoute('/api/issues-day')({
           });
         }
 
-        const { data, error, response } = await getIssuesHistoryYearMonthDay({
-          auth: () => process.env.API_TOKEN,
-          baseUrl: process.env.API_ENDPOINT,
-          path: {
-            year,
-            month,
-            day,
-          },
-        });
-
-        if (error != null) {
-          console.error('Error fetching issues for day:', error);
-          return new Response('Failed to fetch issues for day', {
-            status: response?.status ?? 500,
-            statusText: response?.statusText ?? 'Internal Server Error',
-          });
-        }
-
-        assert(data != null);
+        const data = await getHistoryDayData(
+          Number(year),
+          Number(month),
+          Number(day),
+        );
 
         return Response.json({
           success: true,

--- a/app/routes/api.issues-day.tsx
+++ b/app/routes/api.issues-day.tsx
@@ -1,5 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { DateTime } from 'luxon';
 import { getHistoryDayData } from '../util/db.queries';
+
+function parseDatePart(value: string) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) ? parsed : null;
+}
 
 export const Route = createFileRoute('/api/issues-day')({
   server: {
@@ -17,10 +23,32 @@ export const Route = createFileRoute('/api/issues-day')({
           });
         }
 
+        const yearNumber = parseDatePart(year);
+        const monthNumber = parseDatePart(month);
+        const dayNumber = parseDatePart(day);
+        if (yearNumber == null || monthNumber == null || dayNumber == null) {
+          return new Response('Invalid parameters: year, month, day', {
+            status: 400,
+            statusText: 'Bad Request',
+          });
+        }
+
+        const date = DateTime.fromObject({
+          year: yearNumber,
+          month: monthNumber,
+          day: dayNumber,
+        });
+        if (!date.isValid) {
+          return new Response('Invalid date parameters: year, month, day', {
+            status: 400,
+            statusText: 'Bad Request',
+          });
+        }
+
         const data = await getHistoryDayData(
-          Number(year),
-          Number(month),
-          Number(day),
+          yearNumber,
+          monthNumber,
+          dayNumber,
         );
 
         return Response.json({

--- a/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/StationsIssueCountCard/components/Tick.tsx
+++ b/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/StationsIssueCountCard/components/Tick.tsx
@@ -19,6 +19,8 @@ export const Tick: React.FC<TickProps> = (props) => {
   const station = useMemo(() => {
     return stations[stationId];
   }, [stations, stationId]);
+  const stationName =
+    station?.nameTranslations[intl.locale] ?? station?.name ?? stationId;
 
   return (
     <g transform={`translate(${x},${y})`}>
@@ -35,7 +37,7 @@ export const Tick: React.FC<TickProps> = (props) => {
           letterSpacing: '0.025em',
         }}
       >
-        {station.nameTranslations[intl.locale] ?? station.name}
+        {stationName}
       </text>
     </g>
   );

--- a/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/StationsIssueCountCard/components/Tick.tsx
+++ b/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/StationsIssueCountCard/components/Tick.tsx
@@ -20,7 +20,7 @@ export const Tick: React.FC<TickProps> = (props) => {
     return stations[stationId];
   }, [stations, stationId]);
   const stationName =
-    station?.nameTranslations[intl.locale] ?? station?.name ?? stationId;
+    station?.nameTranslations?.[intl.locale] ?? station?.name ?? stationId;
 
   return (
     <g transform={`translate(${x},${y})`}>

--- a/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/StationsIssueCountCard/components/TooltipContent.tsx
+++ b/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/StationsIssueCountCard/components/TooltipContent.tsx
@@ -22,6 +22,8 @@ export const TooltipContent: React.FC<Props> = ({ active, payload, label }) => {
   }
 
   const station = stations[label];
+  const stationName =
+    station?.nameTranslations[intl.locale] ?? station?.name ?? label;
 
   return (
     <div
@@ -31,7 +33,7 @@ export const TooltipContent: React.FC<Props> = ({ active, payload, label }) => {
       {isVisible && (
         <div className="z-50 flex w-52 flex-col rounded-lg border border-gray-200 bg-white px-4 py-3 shadow-lg outline-none ring-1 ring-black/5 backdrop-blur-sm dark:border-gray-700 dark:bg-gray-800 dark:ring-white/10">
           <span className="mb-2 font-semibold text-gray-900 text-sm dark:text-gray-100">
-            {station.nameTranslations[intl.locale] ?? station.name}
+            {stationName}
           </span>
           {payload.map((item) => (
             <div key={item.dataKey} className="flex items-center py-0.5">

--- a/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/StationsIssueCountCard/components/TooltipContent.tsx
+++ b/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/StationsIssueCountCard/components/TooltipContent.tsx
@@ -23,7 +23,7 @@ export const TooltipContent: React.FC<Props> = ({ active, payload, label }) => {
 
   const station = stations[label];
   const stationName =
-    station?.nameTranslations[intl.locale] ?? station?.name ?? label;
+    station?.nameTranslations?.[intl.locale] ?? station?.name ?? label;
 
   return (
     <div

--- a/app/scripts/migrateDatabase.ts
+++ b/app/scripts/migrateDatabase.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert';
+import { readMigrationFiles } from 'drizzle-orm/migrator';
+import pg from 'pg';
+
+const { Client } = pg;
+
+const { DATABASE_URL } = process.env;
+
+assert(
+  DATABASE_URL != null && DATABASE_URL.length > 0,
+  'DATABASE_URL must be set',
+);
+
+const migrations = readMigrationFiles({ migrationsFolder: 'drizzle' });
+const client = new Client({ connectionString: DATABASE_URL });
+
+try {
+  await client.connect();
+  await client.query('CREATE SCHEMA IF NOT EXISTS drizzle');
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS drizzle.__drizzle_migrations (
+      id SERIAL PRIMARY KEY,
+      hash text NOT NULL,
+      created_at bigint
+    )
+  `);
+
+  const lastMigrationResult = await client.query<{
+    created_at: string | number;
+  }>(
+    'SELECT created_at FROM drizzle.__drizzle_migrations ORDER BY created_at DESC LIMIT 1',
+  );
+  const lastMigration = lastMigrationResult.rows[0];
+  const lastMigrationCreatedAt =
+    lastMigration == null ? null : Number(lastMigration.created_at);
+  const pendingMigrations = migrations.filter(
+    (migration) =>
+      lastMigrationCreatedAt == null ||
+      lastMigrationCreatedAt < migration.folderMillis,
+  );
+
+  console.log(
+    `Applying ${pendingMigrations.length} pending database migration(s)`,
+  );
+
+  await client.query('BEGIN');
+  for (const migration of pendingMigrations) {
+    console.log(`Applying migration ${migration.folderMillis}`);
+    for (const [index, statement] of migration.sql.entries()) {
+      try {
+        await client.query(statement);
+      } catch (error) {
+        console.error(
+          `Migration ${migration.folderMillis} statement ${index + 1} failed`,
+        );
+        console.error(statement);
+        throw error;
+      }
+    }
+    await client.query(
+      'INSERT INTO drizzle.__drizzle_migrations (hash, created_at) VALUES ($1, $2)',
+      [migration.hash, migration.folderMillis],
+    );
+  }
+  await client.query('COMMIT');
+
+  console.log('Database migrations complete');
+} catch (error) {
+  try {
+    await client.query('ROLLBACK');
+  } catch {
+    // Ignore rollback errors so the original migration error remains visible.
+  }
+  console.error(error);
+  process.exitCode = 1;
+} finally {
+  await client.end();
+}

--- a/app/scripts/migrateDatabase.ts
+++ b/app/scripts/migrateDatabase.ts
@@ -13,6 +13,7 @@ assert(
 
 const migrations = readMigrationFiles({ migrationsFolder: 'drizzle' });
 const client = new Client({ connectionString: DATABASE_URL });
+const MIGRATION_LOCK_ID = 612348731;
 
 try {
   await client.connect();
@@ -24,6 +25,9 @@ try {
       created_at bigint
     )
   `);
+
+  await client.query('BEGIN');
+  await client.query('SELECT pg_advisory_xact_lock($1)', [MIGRATION_LOCK_ID]);
 
   const lastMigrationResult = await client.query<{
     created_at: string | number;
@@ -43,7 +47,6 @@ try {
     `Applying ${pendingMigrations.length} pending database migration(s)`,
   );
 
-  await client.query('BEGIN');
   for (const migration of pendingMigrations) {
     console.log(`Applying migration ${migration.folderMillis}`);
     for (const [index, statement] of migration.sql.entries()) {

--- a/app/scripts/resetDatabase.ts
+++ b/app/scripts/resetDatabase.ts
@@ -18,12 +18,70 @@ const client = new Client({ connectionString: DATABASE_URL });
 
 try {
   await client.connect();
-  await client.query('DROP EXTENSION IF EXISTS postgis CASCADE');
-  await client.query('DROP SCHEMA IF EXISTS drizzle CASCADE');
-  await client.query('DROP SCHEMA IF EXISTS public CASCADE');
-  await client.query('CREATE SCHEMA public');
-  await client.query('GRANT ALL ON SCHEMA public TO public');
-  await client.query('GRANT ALL ON SCHEMA public TO CURRENT_USER');
+  await client.query(`
+    DO $$
+    DECLARE
+      item record;
+    BEGIN
+      FOR item IN
+        SELECT schemaname, tablename
+        FROM pg_tables
+        WHERE schemaname IN ('public', 'drizzle')
+          AND tableowner = CURRENT_USER
+      LOOP
+        EXECUTE format('DROP TABLE IF EXISTS %I.%I CASCADE', item.schemaname, item.tablename);
+      END LOOP;
+
+      FOR item IN
+        SELECT schemaname, viewname
+        FROM pg_views
+        WHERE schemaname IN ('public', 'drizzle')
+          AND viewowner = CURRENT_USER
+      LOOP
+        EXECUTE format('DROP VIEW IF EXISTS %I.%I CASCADE', item.schemaname, item.viewname);
+      END LOOP;
+
+      FOR item IN
+        SELECT schemaname, matviewname
+        FROM pg_matviews
+        WHERE schemaname IN ('public', 'drizzle')
+          AND matviewowner = CURRENT_USER
+      LOOP
+        EXECUTE format('DROP MATERIALIZED VIEW IF EXISTS %I.%I CASCADE', item.schemaname, item.matviewname);
+      END LOOP;
+
+      FOR item IN
+        SELECT n.nspname AS schema_name, c.relname AS sequence_name
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname IN ('public', 'drizzle')
+          AND c.relkind = 'S'
+          AND pg_get_userbyid(c.relowner) = CURRENT_USER
+      LOOP
+        EXECUTE format('DROP SEQUENCE IF EXISTS %I.%I CASCADE', item.schema_name, item.sequence_name);
+      END LOOP;
+
+      FOR item IN
+        SELECT n.nspname AS schema_name, t.typname AS type_name
+        FROM pg_type t
+        JOIN pg_namespace n ON n.oid = t.typnamespace
+        WHERE n.nspname = 'public'
+          AND t.typtype = 'e'
+          AND pg_get_userbyid(t.typowner) = CURRENT_USER
+      LOOP
+        EXECUTE format('DROP TYPE IF EXISTS %I.%I CASCADE', item.schema_name, item.type_name);
+      END LOOP;
+
+      IF EXISTS (
+        SELECT 1
+        FROM pg_namespace
+        WHERE nspname = 'drizzle'
+          AND pg_get_userbyid(nspowner) = CURRENT_USER
+      ) THEN
+        DROP SCHEMA drizzle CASCADE;
+      END IF;
+    END $$;
+  `);
   console.log('Database schema reset');
 } finally {
   await client.end();

--- a/app/scripts/resetDatabase.ts
+++ b/app/scripts/resetDatabase.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert';
+import pg from 'pg';
+
+const { Client } = pg;
+
+const { ALLOW_DATABASE_RESET, DATABASE_URL } = process.env;
+
+assert(
+  DATABASE_URL != null && DATABASE_URL.length > 0,
+  'DATABASE_URL must be set',
+);
+assert(
+  ALLOW_DATABASE_RESET === 'true',
+  'Refusing to reset database without ALLOW_DATABASE_RESET=true',
+);
+
+const client = new Client({ connectionString: DATABASE_URL });
+
+try {
+  await client.connect();
+  await client.query('DROP EXTENSION IF EXISTS postgis CASCADE');
+  await client.query('DROP SCHEMA IF EXISTS drizzle CASCADE');
+  await client.query('DROP SCHEMA IF EXISTS public CASCADE');
+  await client.query('CREATE SCHEMA public');
+  await client.query('GRANT ALL ON SCHEMA public TO public');
+  await client.query('GRANT ALL ON SCHEMA public TO CURRENT_USER');
+  console.log('Database schema reset');
+} finally {
+  await client.end();
+}

--- a/app/scripts/seedFixtures.ts
+++ b/app/scripts/seedFixtures.ts
@@ -28,84 +28,6 @@ const DEFAULT_FIXTURES_BASE_URL =
   'https://foldaway.github.io/mrtdown-data/fixtures';
 
 type Db = Parameters<typeof truncateStagingTables>[0];
-type IssueFixture = Parameters<typeof insertIssuesStaging>[1][number];
-
-function placeholderHash(entityName: string, id: string): string {
-  return `preview-fixture-placeholder:${entityName}:${id}`;
-}
-
-function placeholderName(id: string) {
-  return {
-    'en-SG': id,
-    'zh-Hans': null,
-    ms: null,
-    ta: null,
-  };
-}
-
-const placeholderOperatingHours = {
-  weekdays: { start: '05:30', end: '00:30' },
-  weekends: { start: '05:30', end: '00:30' },
-};
-
-function makeIssueEntityIdsUnique(issues: IssueFixture[]): IssueFixture[] {
-  const seenEvidenceIds = new Set<string>();
-  const seenImpactEventIds = new Set<string>();
-
-  return issues.map((issueBundle) => {
-    const evidenceIdMap = new Map<string, string>();
-    const evidence = issueBundle.evidence.map((evidenceEntry) => {
-      let id = evidenceEntry.id;
-      if (seenEvidenceIds.has(id)) {
-        const prefix = `${issueBundle.issue.id}:${evidenceEntry.id}`;
-        id = prefix;
-        for (let suffix = 2; seenEvidenceIds.has(id); suffix += 1) {
-          id = `${prefix}:${suffix}`;
-        }
-      }
-
-      seenEvidenceIds.add(id);
-      evidenceIdMap.set(evidenceEntry.id, id);
-      return id === evidenceEntry.id ? evidenceEntry : { ...evidenceEntry, id };
-    });
-
-    const impactEvents = issueBundle.impactEvents.map((impactEvent) => {
-      let id = impactEvent.id;
-      if (seenImpactEventIds.has(id)) {
-        const prefix = `${issueBundle.issue.id}:${impactEvent.id}`;
-        id = prefix;
-        for (let suffix = 2; seenImpactEventIds.has(id); suffix += 1) {
-          id = `${prefix}:${suffix}`;
-        }
-      }
-
-      seenImpactEventIds.add(id);
-      const evidenceId =
-        evidenceIdMap.get(impactEvent.basis.evidenceId) ??
-        impactEvent.basis.evidenceId;
-      if (
-        id === impactEvent.id &&
-        evidenceId === impactEvent.basis.evidenceId
-      ) {
-        return impactEvent;
-      }
-      return {
-        ...impactEvent,
-        id,
-        basis: {
-          ...impactEvent.basis,
-          evidenceId,
-        },
-      };
-    });
-
-    return {
-      ...issueBundle,
-      evidence,
-      impactEvents,
-    };
-  });
-}
 
 async function stageFixtures(db: Db, baseUrl: string): Promise<void> {
   const manifest = await fetchManifest(baseUrl);
@@ -123,126 +45,43 @@ async function stageFixtures(db: Db, baseUrl: string): Promise<void> {
     ...service,
     hash: manifest.services[service.id] ?? '',
   }));
-  const lineRows = new Map(
-    repo.lines.list().map((line) => [
-      line.id,
-      {
-        ...line,
-        startedAt: line.startedAt ?? '1900-01-01',
-        operatingHours: line.operatingHours ?? placeholderOperatingHours,
-        hash: manifest.lines[line.id] ?? '',
-      },
-    ]),
-  );
-  for (const lineId of new Set([
-    ...stations.flatMap((station) =>
-      station.stationCodes.map((stationCode) => stationCode.lineId),
-    ),
-    ...services.map((service) => service.lineId),
-  ])) {
-    if (!lineRows.has(lineId)) {
-      lineRows.set(lineId, {
-        id: lineId,
-        hash: placeholderHash('line', lineId),
-        name: placeholderName(lineId),
-        type: 'mrt.high',
-        color: '#000000',
-        startedAt: '1900-01-01',
-        serviceIds: services
-          .filter((service) => service.lineId === lineId)
-          .map((service) => service.id),
-        operators: [],
-        operatingHours: placeholderOperatingHours,
-      });
-    }
-  }
-  const lines = Array.from(lineRows.values());
+  const lines = repo.lines.list().map((line) => ({
+    ...line,
+    hash: manifest.lines[line.id] ?? '',
+  }));
 
-  const operatorRows = new Map(
-    repo.operators.list().map((operator) => [
-      operator.id,
-      {
-        ...operator,
-        hash: manifest.operators[operator.id] ?? '',
-      },
-    ]),
-  );
-  for (const line of lines) {
-    for (const operator of line.operators) {
-      if (!operatorRows.has(operator.operatorId)) {
-        operatorRows.set(operator.operatorId, {
-          id: operator.operatorId,
-          hash: placeholderHash('operator', operator.operatorId),
-          name: placeholderName(operator.operatorId),
-          foundedAt: '1900-01-01',
-          url: null,
-        });
-      }
-    }
-  }
-  const operators = Array.from(operatorRows.values());
+  const operators = repo.operators.list().map((operator) => ({
+    ...operator,
+    hash: manifest.operators[operator.id] ?? '',
+  }));
   await insertOperatorsStaging(db, operators);
   store.clearCache();
 
-  const townRows = new Map(
-    repo.towns.list().map((town) => [
-      town.id,
-      {
-        ...town,
-        hash: manifest.towns[town.id] ?? '',
-      },
-    ]),
-  );
-  for (const station of stations) {
-    if (!townRows.has(station.townId)) {
-      townRows.set(station.townId, {
-        id: station.townId,
-        hash: placeholderHash('town', station.townId),
-        name: placeholderName(station.townId),
-      });
-    }
-  }
-  const towns = Array.from(townRows.values());
+  const towns = repo.towns.list().map((town) => ({
+    ...town,
+    hash: manifest.towns[town.id] ?? '',
+  }));
   await insertTownsStaging(db, towns);
   store.clearCache();
 
-  const landmarkRows = new Map(
-    repo.landmarks.list().map((landmark) => [
-      landmark.id,
-      {
-        ...landmark,
-        hash: manifest.landmarks[landmark.id] ?? '',
-      },
-    ]),
-  );
-  for (const station of stations) {
-    for (const landmarkId of station.landmarkIds) {
-      if (!landmarkRows.has(landmarkId)) {
-        landmarkRows.set(landmarkId, {
-          id: landmarkId,
-          hash: placeholderHash('landmark', landmarkId),
-          name: placeholderName(landmarkId),
-        });
-      }
-    }
-  }
-  const landmarks = Array.from(landmarkRows.values());
+  const landmarks = repo.landmarks.list().map((landmark) => ({
+    ...landmark,
+    hash: manifest.landmarks[landmark.id] ?? '',
+  }));
   await insertLandmarksStaging(db, landmarks);
   store.clearCache();
 
   await insertLinesStaging(db, lines);
   store.clearCache();
 
-  const issues = makeIssueEntityIdsUnique(
-    repo.issues.list().map((issue) => ({
-      issue: {
-        ...issue.issue,
-        hash: manifest.issues[issue.issue.id] ?? '',
-      },
-      evidence: issue.evidence,
-      impactEvents: issue.impactEvents,
-    })),
-  );
+  const issues = repo.issues.list().map((issue) => ({
+    issue: {
+      ...issue.issue,
+      hash: manifest.issues[issue.issue.id] ?? '',
+    },
+    evidence: issue.evidence,
+    impactEvents: issue.impactEvents,
+  }));
   await insertIssuesStaging(db, issues);
   store.clearCache();
 

--- a/app/scripts/seedFixtures.ts
+++ b/app/scripts/seedFixtures.ts
@@ -48,8 +48,9 @@ const placeholderOperatingHours = {
   weekends: { start: '05:30', end: '00:30' },
 };
 
-function makeEvidenceIdsUnique(issues: IssueFixture[]): IssueFixture[] {
+function makeIssueEntityIdsUnique(issues: IssueFixture[]): IssueFixture[] {
   const seenEvidenceIds = new Set<string>();
+  const seenImpactEventIds = new Set<string>();
 
   return issues.map((issueBundle) => {
     const evidenceIdMap = new Map<string, string>();
@@ -69,14 +70,28 @@ function makeEvidenceIdsUnique(issues: IssueFixture[]): IssueFixture[] {
     });
 
     const impactEvents = issueBundle.impactEvents.map((impactEvent) => {
+      let id = impactEvent.id;
+      if (seenImpactEventIds.has(id)) {
+        const prefix = `${issueBundle.issue.id}:${impactEvent.id}`;
+        id = prefix;
+        for (let suffix = 2; seenImpactEventIds.has(id); suffix += 1) {
+          id = `${prefix}:${suffix}`;
+        }
+      }
+
+      seenImpactEventIds.add(id);
       const evidenceId =
         evidenceIdMap.get(impactEvent.basis.evidenceId) ??
         impactEvent.basis.evidenceId;
-      if (evidenceId === impactEvent.basis.evidenceId) {
+      if (
+        id === impactEvent.id &&
+        evidenceId === impactEvent.basis.evidenceId
+      ) {
         return impactEvent;
       }
       return {
         ...impactEvent,
+        id,
         basis: {
           ...impactEvent.basis,
           evidenceId,
@@ -218,7 +233,7 @@ async function stageFixtures(db: Db, baseUrl: string): Promise<void> {
   await insertLinesStaging(db, lines);
   store.clearCache();
 
-  const issues = makeEvidenceIdsUnique(
+  const issues = makeIssueEntityIdsUnique(
     repo.issues.list().map((issue) => ({
       issue: {
         ...issue.issue,

--- a/app/scripts/seedFixtures.ts
+++ b/app/scripts/seedFixtures.ts
@@ -29,6 +29,19 @@ const DEFAULT_FIXTURES_BASE_URL =
 
 type Db = Parameters<typeof truncateStagingTables>[0];
 
+function placeholderHash(entityName: string, id: string): string {
+  return `preview-fixture-placeholder:${entityName}:${id}`;
+}
+
+function placeholderName(id: string) {
+  return {
+    'en-SG': id,
+    'zh-Hans': null,
+    ms: null,
+    ta: null,
+  };
+}
+
 async function stageFixtures(db: Db, baseUrl: string): Promise<void> {
   const manifest = await fetchManifest(baseUrl);
   const archiveBuffer = await fetchArchive(baseUrl);
@@ -37,31 +50,87 @@ async function stageFixtures(db: Db, baseUrl: string): Promise<void> {
 
   await truncateStagingTables(db);
 
-  const operators = repo.operators.list().map((operator) => ({
-    ...operator,
-    hash: manifest.operators[operator.id] ?? '',
-  }));
-  await insertOperatorsStaging(db, operators);
-  store.clearCache();
-
-  const towns = repo.towns.list().map((town) => ({
-    ...town,
-    hash: manifest.towns[town.id] ?? '',
-  }));
-  await insertTownsStaging(db, towns);
-  store.clearCache();
-
-  const landmarks = repo.landmarks.list().map((landmark) => ({
-    ...landmark,
-    hash: manifest.landmarks[landmark.id] ?? '',
-  }));
-  await insertLandmarksStaging(db, landmarks);
-  store.clearCache();
-
   const lines = repo.lines.list().map((line) => ({
     ...line,
     hash: manifest.lines[line.id] ?? '',
   }));
+  const stations = repo.stations.list().map((station) => ({
+    ...station,
+    hash: manifest.stations[station.id] ?? '',
+  }));
+
+  const operatorRows = new Map(
+    repo.operators.list().map((operator) => [
+      operator.id,
+      {
+        ...operator,
+        hash: manifest.operators[operator.id] ?? '',
+      },
+    ]),
+  );
+  for (const line of lines) {
+    for (const operator of line.operators) {
+      if (!operatorRows.has(operator.operatorId)) {
+        operatorRows.set(operator.operatorId, {
+          id: operator.operatorId,
+          hash: placeholderHash('operator', operator.operatorId),
+          name: placeholderName(operator.operatorId),
+          foundedAt: '1900-01-01',
+          url: null,
+        });
+      }
+    }
+  }
+  const operators = Array.from(operatorRows.values());
+  await insertOperatorsStaging(db, operators);
+  store.clearCache();
+
+  const townRows = new Map(
+    repo.towns.list().map((town) => [
+      town.id,
+      {
+        ...town,
+        hash: manifest.towns[town.id] ?? '',
+      },
+    ]),
+  );
+  for (const station of stations) {
+    if (!townRows.has(station.townId)) {
+      townRows.set(station.townId, {
+        id: station.townId,
+        hash: placeholderHash('town', station.townId),
+        name: placeholderName(station.townId),
+      });
+    }
+  }
+  const towns = Array.from(townRows.values());
+  await insertTownsStaging(db, towns);
+  store.clearCache();
+
+  const landmarkRows = new Map(
+    repo.landmarks.list().map((landmark) => [
+      landmark.id,
+      {
+        ...landmark,
+        hash: manifest.landmarks[landmark.id] ?? '',
+      },
+    ]),
+  );
+  for (const station of stations) {
+    for (const landmarkId of station.landmarkIds) {
+      if (!landmarkRows.has(landmarkId)) {
+        landmarkRows.set(landmarkId, {
+          id: landmarkId,
+          hash: placeholderHash('landmark', landmarkId),
+          name: placeholderName(landmarkId),
+        });
+      }
+    }
+  }
+  const landmarks = Array.from(landmarkRows.values());
+  await insertLandmarksStaging(db, landmarks);
+  store.clearCache();
+
   await insertLinesStaging(db, lines);
   store.clearCache();
 
@@ -76,10 +145,6 @@ async function stageFixtures(db: Db, baseUrl: string): Promise<void> {
   await insertIssuesStaging(db, issues);
   store.clearCache();
 
-  const stations = repo.stations.list().map((station) => ({
-    ...station,
-    hash: manifest.stations[station.id] ?? '',
-  }));
   await insertStationsStaging(db, stations);
   store.clearCache();
 

--- a/app/scripts/seedFixtures.ts
+++ b/app/scripts/seedFixtures.ts
@@ -42,6 +42,11 @@ function placeholderName(id: string) {
   };
 }
 
+const placeholderOperatingHours = {
+  weekdays: { start: '05:30', end: '00:30' },
+  weekends: { start: '05:30', end: '00:30' },
+};
+
 async function stageFixtures(db: Db, baseUrl: string): Promise<void> {
   const manifest = await fetchManifest(baseUrl);
   const archiveBuffer = await fetchArchive(baseUrl);
@@ -50,14 +55,48 @@ async function stageFixtures(db: Db, baseUrl: string): Promise<void> {
 
   await truncateStagingTables(db);
 
-  const lines = repo.lines.list().map((line) => ({
-    ...line,
-    hash: manifest.lines[line.id] ?? '',
-  }));
   const stations = repo.stations.list().map((station) => ({
     ...station,
     hash: manifest.stations[station.id] ?? '',
   }));
+  const services = repo.services.list().map((service) => ({
+    ...service,
+    hash: manifest.services[service.id] ?? '',
+  }));
+  const lineRows = new Map(
+    repo.lines.list().map((line) => [
+      line.id,
+      {
+        ...line,
+        startedAt: line.startedAt ?? '1900-01-01',
+        operatingHours: line.operatingHours ?? placeholderOperatingHours,
+        hash: manifest.lines[line.id] ?? '',
+      },
+    ]),
+  );
+  for (const lineId of new Set([
+    ...stations.flatMap((station) =>
+      station.stationCodes.map((stationCode) => stationCode.lineId),
+    ),
+    ...services.map((service) => service.lineId),
+  ])) {
+    if (!lineRows.has(lineId)) {
+      lineRows.set(lineId, {
+        id: lineId,
+        hash: placeholderHash('line', lineId),
+        name: placeholderName(lineId),
+        type: 'mrt.high',
+        color: '#000000',
+        startedAt: '1900-01-01',
+        serviceIds: services
+          .filter((service) => service.lineId === lineId)
+          .map((service) => service.id),
+        operators: [],
+        operatingHours: placeholderOperatingHours,
+      });
+    }
+  }
+  const lines = Array.from(lineRows.values());
 
   const operatorRows = new Map(
     repo.operators.list().map((operator) => [
@@ -148,10 +187,6 @@ async function stageFixtures(db: Db, baseUrl: string): Promise<void> {
   await insertStationsStaging(db, stations);
   store.clearCache();
 
-  const services = repo.services.list().map((service) => ({
-    ...service,
-    hash: manifest.services[service.id] ?? '',
-  }));
   await insertServicesStaging(db, services);
   store.clearCache();
 

--- a/app/scripts/seedFixtures.ts
+++ b/app/scripts/seedFixtures.ts
@@ -1,0 +1,128 @@
+import { MRTDownRepository } from '@mrtdown/fs';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import pg from 'pg';
+import * as schema from '../db/schema.js';
+import { ZipStore } from '../helpers/ZipStore.js';
+import { fetchArchive } from '../workflows/pull/helpers/fetchArchive.js';
+import { fetchManifest } from '../workflows/pull/helpers/fetchManifest.js';
+import {
+  finalizePull,
+  insertIssuesStaging,
+  insertLandmarksStaging,
+  insertLinesStaging,
+  insertOperatorsStaging,
+  insertServicesStaging,
+  insertStationsStaging,
+  insertTownsStaging,
+  syncIssues,
+  syncLines,
+  syncOperatorsTownsLandmarks,
+  syncServices,
+  syncStations,
+  truncateStagingTables,
+} from '../workflows/pull/helpers/stagingSync.js';
+
+const { Pool } = pg;
+
+const DEFAULT_FIXTURES_BASE_URL =
+  'https://foldaway.github.io/mrtdown-data/fixtures';
+
+type Db = Parameters<typeof truncateStagingTables>[0];
+
+async function stageFixtures(db: Db, baseUrl: string): Promise<void> {
+  const manifest = await fetchManifest(baseUrl);
+  const archiveBuffer = await fetchArchive(baseUrl);
+  const store = new ZipStore(archiveBuffer);
+  const repo = new MRTDownRepository({ store });
+
+  await truncateStagingTables(db);
+
+  const operators = repo.operators.list().map((operator) => ({
+    ...operator,
+    hash: manifest.operators[operator.id] ?? '',
+  }));
+  await insertOperatorsStaging(db, operators);
+  store.clearCache();
+
+  const towns = repo.towns.list().map((town) => ({
+    ...town,
+    hash: manifest.towns[town.id] ?? '',
+  }));
+  await insertTownsStaging(db, towns);
+  store.clearCache();
+
+  const landmarks = repo.landmarks.list().map((landmark) => ({
+    ...landmark,
+    hash: manifest.landmarks[landmark.id] ?? '',
+  }));
+  await insertLandmarksStaging(db, landmarks);
+  store.clearCache();
+
+  const lines = repo.lines.list().map((line) => ({
+    ...line,
+    hash: manifest.lines[line.id] ?? '',
+  }));
+  await insertLinesStaging(db, lines);
+  store.clearCache();
+
+  const issues = repo.issues.list().map((issue) => ({
+    issue: {
+      ...issue.issue,
+      hash: manifest.issues[issue.issue.id] ?? '',
+    },
+    evidence: issue.evidence,
+    impactEvents: issue.impactEvents,
+  }));
+  await insertIssuesStaging(db, issues);
+  store.clearCache();
+
+  const stations = repo.stations.list().map((station) => ({
+    ...station,
+    hash: manifest.stations[station.id] ?? '',
+  }));
+  await insertStationsStaging(db, stations);
+  store.clearCache();
+
+  const services = repo.services.list().map((service) => ({
+    ...service,
+    hash: manifest.services[service.id] ?? '',
+  }));
+  await insertServicesStaging(db, services);
+  store.clearCache();
+
+  console.log(
+    `Staged ${operators.length} operators, ${towns.length} towns, ${landmarks.length} landmarks, ${lines.length} lines, ${stations.length} stations, ${services.length} services, ${issues.length} issues`,
+  );
+}
+
+async function syncSeededData(db: Db): Promise<void> {
+  await syncOperatorsTownsLandmarks(db);
+  await syncLines(db);
+  await syncStations(db);
+  await syncServices(db);
+  await syncIssues(db);
+  await finalizePull(db);
+}
+
+async function main(): Promise<void> {
+  const { DATABASE_URL } = process.env;
+  if (DATABASE_URL == null || DATABASE_URL.length === 0) {
+    throw new Error('DATABASE_URL must be set');
+  }
+
+  const fixturesBaseUrl =
+    process.env.FIXTURES_BASE_URL ?? DEFAULT_FIXTURES_BASE_URL;
+  const pool = new Pool({ connectionString: DATABASE_URL });
+  const db = drizzle(pool, { schema }) as Db;
+
+  try {
+    console.log(`Seeding preview database from ${fixturesBaseUrl}`);
+    await stageFixtures(db, fixturesBaseUrl);
+    await syncSeededData(db);
+    console.log('Preview fixture seed complete');
+  } finally {
+    await pool.end();
+  }
+}
+
+await main();

--- a/app/scripts/seedFixtures.ts
+++ b/app/scripts/seedFixtures.ts
@@ -28,6 +28,7 @@ const DEFAULT_FIXTURES_BASE_URL =
   'https://foldaway.github.io/mrtdown-data/fixtures';
 
 type Db = Parameters<typeof truncateStagingTables>[0];
+type IssueFixture = Parameters<typeof insertIssuesStaging>[1][number];
 
 function placeholderHash(entityName: string, id: string): string {
   return `preview-fixture-placeholder:${entityName}:${id}`;
@@ -46,6 +47,50 @@ const placeholderOperatingHours = {
   weekdays: { start: '05:30', end: '00:30' },
   weekends: { start: '05:30', end: '00:30' },
 };
+
+function makeEvidenceIdsUnique(issues: IssueFixture[]): IssueFixture[] {
+  const seenEvidenceIds = new Set<string>();
+
+  return issues.map((issueBundle) => {
+    const evidenceIdMap = new Map<string, string>();
+    const evidence = issueBundle.evidence.map((evidenceEntry) => {
+      let id = evidenceEntry.id;
+      if (seenEvidenceIds.has(id)) {
+        const prefix = `${issueBundle.issue.id}:${evidenceEntry.id}`;
+        id = prefix;
+        for (let suffix = 2; seenEvidenceIds.has(id); suffix += 1) {
+          id = `${prefix}:${suffix}`;
+        }
+      }
+
+      seenEvidenceIds.add(id);
+      evidenceIdMap.set(evidenceEntry.id, id);
+      return id === evidenceEntry.id ? evidenceEntry : { ...evidenceEntry, id };
+    });
+
+    const impactEvents = issueBundle.impactEvents.map((impactEvent) => {
+      const evidenceId =
+        evidenceIdMap.get(impactEvent.basis.evidenceId) ??
+        impactEvent.basis.evidenceId;
+      if (evidenceId === impactEvent.basis.evidenceId) {
+        return impactEvent;
+      }
+      return {
+        ...impactEvent,
+        basis: {
+          ...impactEvent.basis,
+          evidenceId,
+        },
+      };
+    });
+
+    return {
+      ...issueBundle,
+      evidence,
+      impactEvents,
+    };
+  });
+}
 
 async function stageFixtures(db: Db, baseUrl: string): Promise<void> {
   const manifest = await fetchManifest(baseUrl);
@@ -173,14 +218,16 @@ async function stageFixtures(db: Db, baseUrl: string): Promise<void> {
   await insertLinesStaging(db, lines);
   store.clearCache();
 
-  const issues = repo.issues.list().map((issue) => ({
-    issue: {
-      ...issue.issue,
-      hash: manifest.issues[issue.issue.id] ?? '',
-    },
-    evidence: issue.evidence,
-    impactEvents: issue.impactEvents,
-  }));
+  const issues = makeEvidenceIdsUnique(
+    repo.issues.list().map((issue) => ({
+      issue: {
+        ...issue.issue,
+        hash: manifest.issues[issue.issue.id] ?? '',
+      },
+      evidence: issue.evidence,
+      impactEvents: issue.impactEvents,
+    })),
+  );
   await insertIssuesStaging(db, issues);
   store.clearCache();
 

--- a/app/scripts/seedFixtures.ts
+++ b/app/scripts/seedFixtures.ts
@@ -34,39 +34,49 @@ async function stageFixtures(db: Db, baseUrl: string): Promise<void> {
   const archiveBuffer = await fetchArchive(baseUrl);
   const store = new ZipStore(archiveBuffer);
   const repo = new MRTDownRepository({ store });
+  const requireHash = (
+    kind: string,
+    id: string,
+    hash: string | undefined,
+  ): string => {
+    if (hash == null || hash.length === 0) {
+      throw new Error(`Missing ${kind} hash in fixture manifest: ${id}`);
+    }
+    return hash;
+  };
 
   await truncateStagingTables(db);
 
   const stations = repo.stations.list().map((station) => ({
     ...station,
-    hash: manifest.stations[station.id] ?? '',
+    hash: requireHash('station', station.id, manifest.stations[station.id]),
   }));
   const services = repo.services.list().map((service) => ({
     ...service,
-    hash: manifest.services[service.id] ?? '',
+    hash: requireHash('service', service.id, manifest.services[service.id]),
   }));
   const lines = repo.lines.list().map((line) => ({
     ...line,
-    hash: manifest.lines[line.id] ?? '',
+    hash: requireHash('line', line.id, manifest.lines[line.id]),
   }));
 
   const operators = repo.operators.list().map((operator) => ({
     ...operator,
-    hash: manifest.operators[operator.id] ?? '',
+    hash: requireHash('operator', operator.id, manifest.operators[operator.id]),
   }));
   await insertOperatorsStaging(db, operators);
   store.clearCache();
 
   const towns = repo.towns.list().map((town) => ({
     ...town,
-    hash: manifest.towns[town.id] ?? '',
+    hash: requireHash('town', town.id, manifest.towns[town.id]),
   }));
   await insertTownsStaging(db, towns);
   store.clearCache();
 
   const landmarks = repo.landmarks.list().map((landmark) => ({
     ...landmark,
-    hash: manifest.landmarks[landmark.id] ?? '',
+    hash: requireHash('landmark', landmark.id, manifest.landmarks[landmark.id]),
   }));
   await insertLandmarksStaging(db, landmarks);
   store.clearCache();
@@ -77,7 +87,11 @@ async function stageFixtures(db: Db, baseUrl: string): Promise<void> {
   const issues = repo.issues.list().map((issue) => ({
     issue: {
       ...issue.issue,
-      hash: manifest.issues[issue.issue.id] ?? '',
+      hash: requireHash(
+        'issue',
+        issue.issue.id,
+        manifest.issues[issue.issue.id],
+      ),
     },
     evidence: issue.evidence,
     impactEvents: issue.impactEvents,

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -2391,7 +2391,7 @@ export async function getStatisticsData() {
       );
       const counts = pickIssueTypes(stationIssues);
       return {
-        name: station.memberships[0]?.code ?? station.name,
+        name: station.id,
         payload: {
           disruption: counts.disruption ?? 0,
           maintenance: counts.maintenance ?? 0,

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -33,15 +33,15 @@ import {
   impactEventCausesTable,
   impactEventEntityFacilitiesTable,
   impactEventEntityServicesTable,
-  issueDayFactsTable,
   impactEventPeriodsTable,
   impactEventsTable,
+  issueDayFactsTable,
   issuesTable,
   landmarksTable,
+  lineDayFactsTable,
   lineOperatorsTable,
   linesTable,
   metadataTable,
-  lineDayFactsTable,
   operatorsTable,
   publicHolidaysTable,
   serviceRevisionPathStationEntriesTable,
@@ -1563,30 +1563,53 @@ function buildCountChartsFromIssueFacts(
   });
 }
 
+function isUndefinedTableError(error: unknown) {
+  return (
+    error != null &&
+    typeof error === 'object' &&
+    'code' in error &&
+    error.code === '42P01'
+  );
+}
+
 async function getIssueDayFactsInRange(start: DateTime, end: DateTime) {
   const db = getDb();
-  return db
-    .select()
-    .from(issueDayFactsTable)
-    .where(
-      and(
-        gte(issueDayFactsTable.date, start.toISODate()!),
-        lte(issueDayFactsTable.date, end.toISODate()!),
-      ),
-    );
+  try {
+    return await db
+      .select()
+      .from(issueDayFactsTable)
+      .where(
+        and(
+          gte(issueDayFactsTable.date, start.toISODate()!),
+          lte(issueDayFactsTable.date, end.toISODate()!),
+        ),
+      );
+  } catch (error) {
+    if (isUndefinedTableError(error)) {
+      return [];
+    }
+    throw error;
+  }
 }
 
 async function getLineDayFactsInRange(start: DateTime, end: DateTime) {
   const db = getDb();
-  return db
-    .select()
-    .from(lineDayFactsTable)
-    .where(
-      and(
-        gte(lineDayFactsTable.date, start.toISODate()!),
-        lte(lineDayFactsTable.date, end.toISODate()!),
-      ),
-    );
+  try {
+    return await db
+      .select()
+      .from(lineDayFactsTable)
+      .where(
+        and(
+          gte(lineDayFactsTable.date, start.toISODate()!),
+          lte(lineDayFactsTable.date, end.toISODate()!),
+        ),
+      );
+  } catch (error) {
+    if (isUndefinedTableError(error)) {
+      return [];
+    }
+    throw error;
+  }
 }
 
 export async function rebuildOperationalFactsForDate(date: DateTime) {

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -1,0 +1,2471 @@
+import { resolvePeriods } from '@mrtdown/core';
+import { and, eq, gte, lte, sql } from 'drizzle-orm';
+import { DateTime, Interval } from 'luxon';
+import type {
+  Chart,
+  ChartEntry,
+  Granularity,
+  IncludedEntities,
+  Issue,
+  IssueAffectedBranch,
+  IssueInterval,
+  IssueType,
+  IssueUpdate,
+  Line,
+  LineBranch,
+  LineProfile,
+  LineSummary,
+  LineSummaryDayType,
+  LineSummaryStatus,
+  Operator,
+  OperatorLinePerformance,
+  OperatorProfile,
+  Station,
+  StationProfile,
+  SystemAnalytics,
+  SystemOverview,
+  TimeScale,
+  TimeScaleChart,
+} from '~/client';
+import { getDb } from '~/db';
+import {
+  evidencesTable,
+  impactEventCausesTable,
+  impactEventEntityFacilitiesTable,
+  impactEventEntityServicesTable,
+  issueDayFactsTable,
+  impactEventPeriodsTable,
+  impactEventsTable,
+  issuesTable,
+  landmarksTable,
+  lineOperatorsTable,
+  linesTable,
+  metadataTable,
+  lineDayFactsTable,
+  operatorsTable,
+  publicHolidaysTable,
+  serviceRevisionPathStationEntriesTable,
+  serviceRevisionsTable,
+  servicesTable,
+  stationCodesTable,
+  stationLandmarksTable,
+  stationsTable,
+  townsTable,
+} from '~/db/schema';
+
+const SG_TIMEZONE = 'Asia/Singapore';
+
+type BaseIncludedEntities = Omit<IncludedEntities, 'issues'>;
+
+type BranchWithEntries = LineBranch & {
+  entries: Array<{
+    stationId: string;
+    displayCode: string;
+    pathIndex: number;
+  }>;
+};
+
+type BaseDataset = {
+  included: BaseIncludedEntities;
+  branchesByLineId: Record<string, BranchWithEntries[]>;
+  branchByServiceId: Record<string, BranchWithEntries>;
+  metadata: Record<string, string>;
+  publicHolidaySet: Set<string>;
+  allIssues: Record<string, Issue>;
+  issueUpdatesById: Record<string, IssueUpdate[]>;
+};
+
+type IssueIntervalBounds = {
+  start: DateTime;
+  end: DateTime | null;
+};
+
+function nowSg() {
+  return DateTime.now().setZone(SG_TIMEZONE);
+}
+
+function parseDateTime(value: string) {
+  const iso = DateTime.fromISO(value, { setZone: true });
+  if (iso.isValid) {
+    return iso.setZone(SG_TIMEZONE);
+  }
+
+  const sqlDateTime = DateTime.fromSQL(value, { setZone: true });
+  if (sqlDateTime.isValid) {
+    return sqlDateTime.setZone(SG_TIMEZONE);
+  }
+
+  return DateTime.fromJSDate(new Date(value)).setZone(SG_TIMEZONE);
+}
+
+function parseTranslations(value: unknown) {
+  const translations =
+    value != null && typeof value === 'object'
+      ? (value as Record<string, string>)
+      : {};
+  const fallback =
+    translations['en-SG'] ??
+    translations.en ??
+    Object.values(translations)[0] ??
+    '';
+  return {
+    fallback,
+    translations,
+  };
+}
+
+function mergeIntervals(intervals: IssueIntervalBounds[]) {
+  if (intervals.length === 0) {
+    return [];
+  }
+
+  const sorted = [...intervals].sort(
+    (a, b) => a.start.toMillis() - b.start.toMillis(),
+  );
+  const merged: IssueIntervalBounds[] = [];
+
+  for (const interval of sorted) {
+    const current = merged.at(-1);
+    if (current == null) {
+      merged.push({ ...interval });
+      continue;
+    }
+
+    const currentEnd = current.end?.toMillis() ?? Number.POSITIVE_INFINITY;
+    const nextEnd = interval.end?.toMillis() ?? Number.POSITIVE_INFINITY;
+
+    if (interval.start.toMillis() <= currentEnd) {
+      if (current.end == null || interval.end == null) {
+        current.end = null;
+      } else if (nextEnd > currentEnd) {
+        current.end = interval.end;
+      }
+      continue;
+    }
+
+    merged.push({ ...interval });
+  }
+
+  return merged;
+}
+
+function sumIntervalSeconds(
+  intervals: IssueIntervalBounds[],
+  referenceNow = nowSg(),
+) {
+  return mergeIntervals(intervals).reduce((total, interval) => {
+    const end = interval.end ?? referenceNow;
+    return total + Math.max(0, end.diff(interval.start, 'seconds').seconds);
+  }, 0);
+}
+
+function overlapSeconds(
+  start: DateTime,
+  end: DateTime | null,
+  windowStart: DateTime,
+  windowEnd: DateTime,
+  referenceNow = nowSg(),
+) {
+  const boundedEnd = end ?? referenceNow;
+  const overlapStart = start > windowStart ? start : windowStart;
+  const overlapEnd = boundedEnd < windowEnd ? boundedEnd : windowEnd;
+  return Math.max(0, overlapEnd.diff(overlapStart, 'seconds').seconds);
+}
+
+function classifyInterval(
+  startAt: string,
+  endAt: string | null,
+  referenceNow = nowSg(),
+): IssueInterval['status'] {
+  const start = parseDateTime(startAt);
+  if (start > referenceNow) {
+    return 'future';
+  }
+
+  if (endAt == null) {
+    return 'ongoing';
+  }
+
+  const end = parseDateTime(endAt);
+  return end > referenceNow ? 'ongoing' : 'ended';
+}
+
+function buildIssueIntervals(
+  rows: Array<{
+    start_at: string;
+    end_at_resolved: string | null;
+    end_at: string | null;
+  }>,
+  referenceNow = nowSg(),
+) {
+  const unique = new Map<string, IssueInterval>();
+
+  for (const row of rows) {
+    const normalizedStartAt = parseDateTime(row.start_at).toISO()!;
+    const resolvedEndAtRaw = row.end_at_resolved ?? row.end_at ?? null;
+    const normalizedEndAt =
+      resolvedEndAtRaw != null ? parseDateTime(resolvedEndAtRaw).toISO()! : null;
+    const key = `${normalizedStartAt}::${normalizedEndAt ?? 'null'}`;
+    if (unique.has(key)) {
+      continue;
+    }
+
+    unique.set(key, {
+      startAt: normalizedStartAt,
+      endAt: normalizedEndAt,
+      status: classifyInterval(normalizedStartAt, normalizedEndAt, referenceNow),
+    });
+  }
+
+  return [...unique.values()].sort((a, b) => {
+    return parseDateTime(a.startAt).toMillis() - parseDateTime(b.startAt).toMillis();
+  });
+}
+
+function resolveOperationalIssueIntervals(
+  rows: Array<{
+    start_at: string;
+    end_at: string | null;
+  }>,
+  lastEvidenceAt: DateTime | null,
+  asOf = nowSg(),
+) {
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const resolved = resolvePeriods({
+    periods: rows.map((row) => ({
+      kind: 'fixed' as const,
+      startAt: parseDateTime(row.start_at).toISO()!,
+      endAt: row.end_at != null ? parseDateTime(row.end_at).toISO()! : null,
+    })),
+    asOf: asOf.toISO()!,
+    mode: {
+      kind: 'operational',
+      lastEvidenceAt: lastEvidenceAt?.toISO() ?? null,
+    },
+  });
+
+  return buildIssueIntervals(
+    resolved.map((period) => ({
+      start_at: period.startAt,
+      end_at_resolved: period.endAtResolved,
+      end_at: period.endAt,
+    })),
+    asOf,
+  );
+}
+
+function lineDayType(
+  date: DateTime,
+  publicHolidaySet: Set<string>,
+): LineSummaryDayType {
+  if (publicHolidaySet.has(date.toISODate()!)) {
+    return 'public_holiday';
+  }
+  return date.weekday >= 6 ? 'weekend' : 'weekday';
+}
+
+function serviceWindowForDate(
+  line: Line,
+  date: DateTime,
+  publicHolidaySet: Set<string>,
+) {
+  const dayType = lineDayType(date, publicHolidaySet);
+  const hours =
+    dayType === 'weekday'
+      ? line.operatingHours.weekdays
+      : line.operatingHours.weekends;
+
+  const [startHour, startMinute] = hours.start.split(':').map(Number);
+  const [endHour, endMinute] = hours.end.split(':').map(Number);
+
+  const windowStart = date.startOf('day').set({
+    hour: startHour,
+    minute: startMinute,
+  });
+  let windowEnd = date.startOf('day').set({
+    hour: endHour,
+    minute: endMinute,
+  });
+  if (windowEnd <= windowStart) {
+    windowEnd = windowEnd.plus({ day: 1 });
+  }
+
+  return {
+    start: windowStart,
+    end: windowEnd,
+    seconds: Math.max(0, windowEnd.diff(windowStart, 'seconds').seconds),
+  };
+}
+
+function isLineFuture(line: Line, referenceNow = nowSg()) {
+  if (line.startedAt == null) {
+    return false;
+  }
+  return parseDateTime(line.startedAt) > referenceNow;
+}
+
+function isLineOperatingNow(
+  line: Line,
+  publicHolidaySet: Set<string>,
+  referenceNow = nowSg(),
+) {
+  if (isLineFuture(line, referenceNow)) {
+    return false;
+  }
+
+  if (line.startedAt != null) {
+    const start = parseDateTime(line.startedAt);
+    if (referenceNow < start) {
+      return false;
+    }
+  }
+
+  const window = serviceWindowForDate(line, referenceNow, publicHolidaySet);
+  return referenceNow >= window.start && referenceNow <= window.end;
+}
+
+function pickIssueTypes<T extends { type: IssueType }>(items: T[]) {
+  const counts: Partial<Record<IssueType, number>> = {};
+  for (const item of items) {
+    counts[item.type] = (counts[item.type] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function pickIssueDurationByType<
+  T extends { type: IssueType; durationSeconds: number },
+>(items: T[]) {
+  const counts: Partial<Record<IssueType, number>> = {};
+  for (const item of items) {
+    counts[item.type] = (counts[item.type] ?? 0) + item.durationSeconds;
+  }
+  return counts;
+}
+
+function getIssueBounds(issue: Issue): IssueIntervalBounds[] {
+  return issue.intervals.map((interval) => ({
+    start: parseDateTime(interval.startAt),
+    end: interval.endAt != null ? parseDateTime(interval.endAt) : null,
+  }));
+}
+
+function issueTouchesDate(issue: Issue, date: DateTime) {
+  const dayStart = date.startOf('day');
+  const dayEnd = dayStart.plus({ day: 1 });
+  return getIssueBounds(issue).some((interval) => {
+    return overlapSeconds(interval.start, interval.end, dayStart, dayEnd) > 0;
+  });
+}
+
+function issueOverlapsRange(
+  issue: Issue,
+  rangeStart: DateTime,
+  rangeEnd: DateTime,
+) {
+  return getIssueBounds(issue).some((interval) => {
+    return overlapSeconds(interval.start, interval.end, rangeStart, rangeEnd) > 0;
+  });
+}
+
+function issueActiveNow(issue: Issue, referenceNow = nowSg()) {
+  return issue.intervals.some((interval) => interval.status === 'ongoing');
+}
+
+function issueActiveToday(issue: Issue, referenceNow = nowSg()) {
+  const dayStart = referenceNow.startOf('day');
+  const dayEnd = dayStart.plus({ day: 1 });
+  return getIssueBounds(issue).some((interval) => {
+    return overlapSeconds(interval.start, interval.end, dayStart, dayEnd) > 0;
+  });
+}
+
+function sortIssuesByLatestActivity(
+  issueIds: string[],
+  issuesById: Record<string, Issue>,
+) {
+  return [...issueIds].sort((a, b) => {
+    const issueA = issuesById[a];
+    const issueB = issuesById[b];
+    const latestA = Math.max(
+      ...issueA.intervals.map((interval) =>
+        parseDateTime(interval.endAt ?? interval.startAt).toMillis(),
+      ),
+    );
+    const latestB = Math.max(
+      ...issueB.intervals.map((interval) =>
+        parseDateTime(interval.endAt ?? interval.startAt).toMillis(),
+      ),
+    );
+    return latestB - latestA;
+  });
+}
+
+function makeTimeScale(granularity: Granularity, count: number): TimeScale {
+  return { granularity, count };
+}
+
+function buildCountChart(
+  title: string,
+  entries: ChartEntry[],
+  cumulative: ChartEntry[],
+  dataTimeScale: TimeScale,
+  displayTimeScale?: TimeScale,
+): TimeScaleChart {
+  return {
+    title,
+    data: entries,
+    dataCumulative: cumulative,
+    dataTimeScale,
+    displayTimeScale,
+  };
+}
+
+async function buildBaseDataset(referenceNow = nowSg()): Promise<BaseDataset> {
+  const db = getDb();
+
+  const [
+    metadataRows,
+    linesRows,
+    lineOperatorsRows,
+    operatorsRows,
+    townsRows,
+    landmarksRows,
+    stationRows,
+    stationCodesRows,
+    stationLandmarksRows,
+    serviceRows,
+    serviceRevisionRows,
+    servicePathRows,
+    publicHolidayRows,
+    issueRows,
+    evidenceRows,
+    impactEventRows,
+    impactEventPeriodRows,
+    impactEventServiceRows,
+    impactEventFacilityRows,
+    impactEventCauseRows,
+  ] = await Promise.all([
+    db.select().from(metadataTable),
+    db.select().from(linesTable),
+    db.select().from(lineOperatorsTable),
+    db.select().from(operatorsTable),
+    db.select().from(townsTable),
+    db.select().from(landmarksTable),
+    db
+      .select({
+        id: stationsTable.id,
+        name: stationsTable.name,
+        townId: stationsTable.townId,
+        latitude: sql<number>`ST_Y(${stationsTable.geo})`,
+        longitude: sql<number>`ST_X(${stationsTable.geo})`,
+      })
+      .from(stationsTable),
+    db.select().from(stationCodesTable),
+    db.select().from(stationLandmarksTable),
+    db.select().from(servicesTable),
+    db.select().from(serviceRevisionsTable),
+    db.select().from(serviceRevisionPathStationEntriesTable),
+    db.select().from(publicHolidaysTable),
+    db.select().from(issuesTable),
+    db.select().from(evidencesTable),
+    db.select().from(impactEventsTable),
+    db.select().from(impactEventPeriodsTable),
+    db.select().from(impactEventEntityServicesTable),
+    db.select().from(impactEventEntityFacilitiesTable),
+    db.select().from(impactEventCausesTable),
+  ]);
+
+  const metadata = Object.fromEntries(
+    metadataRows.map((row) => [row.key, row.value]),
+  );
+  const publicHolidaySet = new Set(publicHolidayRows.map((row) => row.date));
+
+  const operatorsById = Object.fromEntries(
+    operatorsRows.map((row) => {
+      const { fallback, translations } = parseTranslations(row.name);
+      const operator: Operator = {
+        id: row.id,
+        name: fallback,
+        nameTranslations: translations,
+        foundedAt: row.founded_at,
+        url: row.url,
+      };
+      return [row.id, operator];
+    }),
+  );
+
+  const townsById = Object.fromEntries(
+    townsRows.map((row) => {
+      const { fallback, translations } = parseTranslations(row.name);
+      return [
+        row.id,
+        {
+          id: row.id,
+          name: fallback,
+          nameTranslations: translations,
+        },
+      ];
+    }),
+  ) as IncludedEntities['towns'];
+
+  const landmarksById = Object.fromEntries(
+    landmarksRows.map((row) => {
+      const { fallback, translations } = parseTranslations(row.name);
+      return [
+        row.id,
+        {
+          id: row.id,
+          name: fallback,
+          nameTranslations: translations,
+        },
+      ];
+    }),
+  ) as IncludedEntities['landmarks'];
+
+  const operatorIdsByLineId = lineOperatorsRows.reduce<
+    Record<string, Line['operators']>
+  >((acc, row) => {
+    if (acc[row.line_id] == null) {
+      acc[row.line_id] = [];
+    }
+    acc[row.line_id].push({
+      operatorId: row.operator_id,
+      startedAt: row.started_at,
+      endedAt: row.ended_at,
+    });
+    return acc;
+  }, {});
+
+  const linesById = Object.fromEntries(
+    linesRows.map((row) => {
+      const { fallback, translations } = parseTranslations(row.name);
+      const line: Line = {
+        id: row.id,
+        title: fallback,
+        titleTranslations: translations,
+        type: row.type,
+        color: row.color,
+        startedAt: row.started_at,
+        operatingHours: row.operating_hours,
+        operators: operatorIdsByLineId[row.id] ?? [],
+      };
+      return [row.id, line];
+    }),
+  ) as IncludedEntities['lines'];
+
+  const revisionsByServiceId = serviceRevisionRows.reduce<
+    Record<string, typeof serviceRevisionRows>
+  >((acc, row) => {
+    if (acc[row.service_id] == null) {
+      acc[row.service_id] = [];
+    }
+    acc[row.service_id].push(row);
+    return acc;
+  }, {});
+
+  const pathEntriesByRevisionKey = servicePathRows.reduce<
+    Record<string, typeof servicePathRows>
+  >((acc, row) => {
+    const key = `${row.service_revision_id}::${row.service_id}`;
+    if (acc[key] == null) {
+      acc[key] = [];
+    }
+    acc[key].push(row);
+    return acc;
+  }, {});
+
+  const stationCodeLookup = new Map<
+    string,
+    (typeof stationCodesRows)[number]
+  >();
+  const serviceById = Object.fromEntries(
+    serviceRows.map((service) => [service.id, service]),
+  ) as Record<string, (typeof serviceRows)[number]>;
+  for (const row of stationCodesRows) {
+    stationCodeLookup.set(
+      `${row.station_id}::${row.line_id}::${row.code}`,
+      row,
+    );
+  }
+
+  const branchesByLineId: Record<string, BranchWithEntries[]> = {};
+  const branchByServiceId: Record<string, BranchWithEntries> = {};
+
+  for (const service of serviceRows) {
+    const revisions = revisionsByServiceId[service.id] ?? [];
+    if (revisions.length === 0) {
+      continue;
+    }
+
+    const latestRevision = [...revisions].sort((a, b) => {
+      const aTs = new Date(a.updated_at).getTime();
+      const bTs = new Date(b.updated_at).getTime();
+      if (aTs !== bTs) {
+        return bTs - aTs;
+      }
+      return b.id.localeCompare(a.id);
+    })[0];
+
+    const revisionKey = `${latestRevision.id}::${service.id}`;
+    const entries = [...(pathEntriesByRevisionKey[revisionKey] ?? [])].sort(
+      (a, b) => a.path_index - b.path_index,
+    );
+
+    if (entries.length === 0) {
+      continue;
+    }
+
+    const startedDates = entries
+      .map(
+        (entry) =>
+          stationCodeLookup.get(
+            `${entry.station_id}::${service.line_id}::${entry.display_code}`,
+          )?.started_at,
+      )
+      .filter((value): value is string => value != null)
+      .map((value) => parseDateTime(value));
+
+    const endedDates = entries
+      .map(
+        (entry) =>
+          stationCodeLookup.get(
+            `${entry.station_id}::${service.line_id}::${entry.display_code}`,
+          )?.ended_at,
+      )
+      .filter((value): value is string => value != null)
+      .map((value) => parseDateTime(value));
+
+    const { fallback, translations } = parseTranslations(service.name);
+    const referenceNow = nowSg();
+    const minStart = startedDates.sort(
+      (a, b) => a.toMillis() - b.toMillis(),
+    )[0];
+    const allStartsInFuture =
+      minStart != null && startedDates.every((date) => date > referenceNow);
+    const branch: BranchWithEntries = {
+      id: service.id,
+      title: fallback,
+      titleTranslations: translations,
+      startedAt:
+        minStart != null && !allStartsInFuture ? minStart.toISODate() : null,
+      endedAt:
+        endedDates.length === entries.length
+          ? (endedDates
+              .sort((a, b) => b.toMillis() - a.toMillis())[0]
+              ?.toISODate() ?? null)
+          : null,
+      stationIds: [...new Set(entries.map((entry) => entry.station_id))],
+      entries: entries.map((entry) => ({
+        stationId: entry.station_id,
+        displayCode: entry.display_code,
+        pathIndex: entry.path_index,
+      })),
+    };
+
+    branchByServiceId[service.id] = branch;
+    if (branchesByLineId[service.line_id] == null) {
+      branchesByLineId[service.line_id] = [];
+    }
+    branchesByLineId[service.line_id].push(branch);
+  }
+
+  const membershipByStationId: Record<string, Station['memberships']> = {};
+
+  for (const [lineId, branches] of Object.entries(branchesByLineId)) {
+    for (const branch of branches) {
+      branch.entries.forEach((entry, index) => {
+        if (membershipByStationId[entry.stationId] == null) {
+          membershipByStationId[entry.stationId] = [];
+        }
+
+        const codeInfo = stationCodeLookup.get(
+          `${entry.stationId}::${lineId}::${entry.displayCode}`,
+        );
+
+        const membership = {
+          lineId,
+          branchId: branch.id,
+          code: entry.displayCode,
+          startedAt:
+            codeInfo?.started_at ??
+            linesById[lineId]?.startedAt ??
+            '1970-01-01',
+          endedAt: codeInfo?.ended_at ?? undefined,
+          structureType: codeInfo?.structure_type ?? 'underground',
+          sequenceOrder: index,
+        };
+
+        const existing = membershipByStationId[entry.stationId].some(
+          (candidate) =>
+            candidate.lineId === membership.lineId &&
+            candidate.branchId === membership.branchId &&
+            candidate.code === membership.code,
+        );
+        if (!existing) {
+          membershipByStationId[entry.stationId].push(membership);
+        }
+      });
+    }
+  }
+
+  for (const code of stationCodesRows) {
+    if (membershipByStationId[code.station_id] == null) {
+      membershipByStationId[code.station_id] = [];
+    }
+
+    const existing = membershipByStationId[code.station_id].some(
+      (membership) =>
+        membership.lineId === code.line_id && membership.code === code.code,
+    );
+    if (existing) {
+      continue;
+    }
+
+    membershipByStationId[code.station_id].push({
+      lineId: code.line_id,
+      branchId: `${code.line_id}:${code.code}`,
+      code: code.code,
+      startedAt: code.started_at,
+      endedAt: code.ended_at ?? undefined,
+      structureType: code.structure_type,
+      sequenceOrder: 0,
+    });
+  }
+
+  const landmarkIdsByStationId = stationLandmarksRows.reduce<
+    Record<string, string[]>
+  >((acc, row) => {
+    if (acc[row.station_id] == null) {
+      acc[row.station_id] = [];
+    }
+    acc[row.station_id].push(row.landmark_id);
+    return acc;
+  }, {});
+
+  const stationsById = Object.fromEntries(
+    stationRows.map((row) => {
+      const { fallback, translations } = parseTranslations(row.name);
+      const station: Station = {
+        id: row.id,
+        name: fallback,
+        nameTranslations: translations,
+        geo: {
+          latitude: Number(row.latitude),
+          longitude: Number(row.longitude),
+        },
+        memberships: (membershipByStationId[row.id] ?? []).sort((a, b) => {
+          if (a.lineId !== b.lineId) {
+            return a.lineId.localeCompare(b.lineId);
+          }
+          return a.sequenceOrder - b.sequenceOrder;
+        }),
+        townId: row.townId,
+        landmarkIds: landmarkIdsByStationId[row.id] ?? [],
+      };
+      return [row.id, station];
+    }),
+  ) as IncludedEntities['stations'];
+
+  const impactEventsByIssueId = impactEventRows.reduce<
+    Record<string, typeof impactEventRows>
+  >((acc, row) => {
+    if (acc[row.issue_id] == null) {
+      acc[row.issue_id] = [];
+    }
+    acc[row.issue_id].push(row);
+    return acc;
+  }, {});
+
+  const periodsByImpactEventId = impactEventPeriodRows.reduce<
+    Record<string, typeof impactEventPeriodRows>
+  >((acc, row) => {
+    if (acc[row.impact_event_id] == null) {
+      acc[row.impact_event_id] = [];
+    }
+    acc[row.impact_event_id].push(row);
+    return acc;
+  }, {});
+
+  const serviceRowsByImpactEventId = impactEventServiceRows.reduce<
+    Record<string, typeof impactEventServiceRows>
+  >((acc, row) => {
+    if (acc[row.impact_event_id] == null) {
+      acc[row.impact_event_id] = [];
+    }
+    acc[row.impact_event_id].push(row);
+    return acc;
+  }, {});
+
+  const facilityRowsByImpactEventId = impactEventFacilityRows.reduce<
+    Record<string, typeof impactEventFacilityRows>
+  >((acc, row) => {
+    if (acc[row.impact_event_id] == null) {
+      acc[row.impact_event_id] = [];
+    }
+    acc[row.impact_event_id].push(row);
+    return acc;
+  }, {});
+
+  const causesByImpactEventId = impactEventCauseRows.reduce<
+    Record<string, typeof impactEventCauseRows>
+  >((acc, row) => {
+    if (acc[row.impact_event_id] == null) {
+      acc[row.impact_event_id] = [];
+    }
+    acc[row.impact_event_id].push(row);
+    return acc;
+  }, {});
+
+  const evidenceByIssueId = evidenceRows.reduce<
+    Record<string, typeof evidenceRows>
+  >((acc, row) => {
+    if (acc[row.issue_id] == null) {
+      acc[row.issue_id] = [];
+    }
+    acc[row.issue_id].push(row);
+    return acc;
+  }, {});
+  const latestEvidenceAtByIssueId = Object.fromEntries(
+    Object.entries(evidenceByIssueId).map(([issueId, rows]) => [
+      issueId,
+      rows
+        .map((row) => parseDateTime(row.ts))
+        .sort((a, b) => b.toMillis() - a.toMillis())[0] ?? null,
+    ]),
+  ) as Record<string, DateTime | null>;
+
+  const allIssues: Record<string, Issue> = {};
+  const issueUpdatesById: Record<string, IssueUpdate[]> = {};
+  for (const row of issueRows) {
+    const { fallback, translations } = parseTranslations(row.title);
+    const events = [...(impactEventsByIssueId[row.id] ?? [])].sort((a, b) => {
+      const tsDiff = parseDateTime(b.ts).toMillis() - parseDateTime(a.ts).toMillis();
+      if (tsDiff !== 0) {
+        return tsDiff;
+      }
+      return b.id.localeCompare(a.id);
+    });
+    const latestEventByType = events.reduce<
+      Partial<Record<(typeof events)[number]['type'], (typeof events)[number]>>
+    >((acc, event) => {
+      if (acc[event.type] == null) {
+        acc[event.type] = event;
+      }
+      return acc;
+    }, {});
+    const selectedStateEvents = [
+      latestEventByType['periods.set'],
+      latestEventByType['causes.set'],
+      latestEventByType['service_scopes.set'],
+      latestEventByType['service_effects.set'],
+      latestEventByType['facility_effects.set'],
+    ].filter((event): event is (typeof events)[number] => event != null);
+    const serviceBranches = new Map<string, IssueAffectedBranch>();
+    const facilityBranches = new Map<string, IssueAffectedBranch>();
+    const causeSet = new Set<Issue['subtypes'][number]>();
+
+    const periodEvents =
+      latestEventByType['periods.set'] != null
+        ? [latestEventByType['periods.set']]
+        : [];
+    const canonicalPeriods = periodEvents.flatMap((event) => {
+      return periodsByImpactEventId[event.id] ?? [];
+    });
+
+    for (const event of selectedStateEvents) {
+      for (const cause of causesByImpactEventId[event.id] ?? []) {
+        causeSet.add(cause.type as Issue['subtypes'][number]);
+      }
+
+      for (const serviceRef of serviceRowsByImpactEventId[event.id] ?? []) {
+        const branch = branchByServiceId[serviceRef.service_id];
+        const service = serviceById[serviceRef.service_id];
+        if (branch == null || service == null) {
+          continue;
+        }
+        serviceBranches.set(branch.id, {
+          lineId: service.line_id,
+          branchId: branch.id,
+          stationIds: branch.stationIds,
+        });
+      }
+
+      for (const facilityRef of facilityRowsByImpactEventId[event.id] ?? []) {
+        const station = stationsById[facilityRef.station_id];
+        if (station == null) {
+          continue;
+        }
+
+        const stationMemberships =
+          station.memberships.length > 0 ? station.memberships : [];
+        for (const membership of stationMemberships) {
+          const key = `${membership.lineId}::${station.id}`;
+          if (!facilityBranches.has(key)) {
+            facilityBranches.set(key, {
+              lineId: membership.lineId,
+              branchId: `${membership.lineId}:${station.id}`,
+              stationIds: [station.id],
+            });
+          }
+        }
+      }
+    }
+
+    const branchesAffected = [
+      ...serviceBranches.values(),
+      ...facilityBranches.values(),
+    ]
+      .map((branch) => {
+        if (branch.lineId !== '') {
+          return branch;
+        }
+        const resolvedBranch = branchByServiceId[branch.branchId];
+        return {
+          ...branch,
+          lineId:
+            resolvedBranch != null
+              ? (serviceRows.find((service) => service.id === resolvedBranch.id)
+                  ?.line_id ?? branch.lineId)
+              : branch.lineId,
+        };
+      })
+      .filter((branch) => branch.lineId !== '');
+
+    const lineIds = [
+      ...new Set(branchesAffected.map((branch) => branch.lineId)),
+    ];
+    const latestEvidenceAt = latestEvidenceAtByIssueId[row.id];
+    const intervals = resolveOperationalIssueIntervals(
+      canonicalPeriods.map((period) => ({
+        start_at: period.start_at,
+        end_at: period.end_at,
+      })),
+      row.type === 'infra' ? null : latestEvidenceAt,
+      referenceNow,
+    );
+
+    const durationSeconds = sumIntervalSeconds(
+      intervals.map((interval) => ({
+        start: parseDateTime(interval.startAt),
+        end: interval.endAt != null ? parseDateTime(interval.endAt) : null,
+      })),
+      referenceNow,
+    );
+
+    allIssues[row.id] = {
+      id: row.id,
+      title: fallback,
+      titleTranslations: translations,
+      type: row.type,
+      subtypes: [...causeSet],
+      durationSeconds,
+      lineIds,
+      branchesAffected,
+      intervals,
+    };
+
+    issueUpdatesById[row.id] = [...(evidenceByIssueId[row.id] ?? [])]
+      .sort((a, b) => new Date(b.ts).getTime() - new Date(a.ts).getTime())
+      .map((evidence) => ({
+        type: evidence.type,
+        text: evidence.text,
+        sourceUrl: evidence.source_url,
+        createdAt: evidence.ts,
+      }));
+  }
+
+  return {
+    included: {
+      lines: linesById,
+      stations: stationsById,
+      operators: operatorsById,
+      towns: townsById,
+      landmarks: landmarksById,
+    },
+    branchesByLineId,
+    branchByServiceId,
+    metadata,
+    publicHolidaySet,
+    allIssues,
+    issueUpdatesById,
+  };
+}
+
+function withIssues(
+  baseIncluded: BaseIncludedEntities,
+  allIssues: Record<string, Issue>,
+  issueIds?: string[],
+): IncludedEntities {
+  const selectedIssues =
+    issueIds == null
+      ? allIssues
+      : Object.fromEntries(
+          issueIds
+            .filter((issueId) => allIssues[issueId] != null)
+            .map((issueId) => [issueId, allIssues[issueId]]),
+        );
+
+  return {
+    ...baseIncluded,
+    issues: selectedIssues,
+  };
+}
+
+function buildLineSummary(
+  line: Line,
+  issues: Issue[],
+  days: number,
+  publicHolidaySet: Set<string>,
+  referenceNow = nowSg(),
+): LineSummary {
+  const startDate = referenceNow.startOf('day').minus({ days: days - 1 });
+  const breakdownByDates: LineSummary['breakdownByDates'] = {};
+  const durationSecondsByIssueType: Partial<Record<IssueType, number>> = {};
+
+  let totalServiceSeconds = 0;
+  let totalDowntimeSeconds = 0;
+
+  for (let offset = 0; offset < days; offset++) {
+    const date = startDate.plus({ days: offset });
+    const dayWindow = serviceWindowForDate(line, date, publicHolidaySet);
+    const dayBreakdown: LineSummary['breakdownByDates'][string] = {
+      breakdownByIssueTypes: {},
+      dayType: lineDayType(date, publicHolidaySet),
+    };
+
+    if (!isLineFuture(line, date.endOf('day'))) {
+      totalServiceSeconds += dayWindow.seconds;
+    }
+
+    const dailyDowntimeIntervals: IssueIntervalBounds[] = [];
+
+    for (const issue of issues) {
+      const issueBounds = getIssueBounds(issue);
+      const contributingBounds: IssueIntervalBounds[] = [];
+      const dayOverlap = issueBounds.reduce((total, interval) => {
+        const clippedStart =
+          interval.start > dayWindow.start ? interval.start : dayWindow.start;
+        const intervalEnd = interval.end ?? referenceNow;
+        const clippedEnd =
+          intervalEnd < dayWindow.end ? intervalEnd : dayWindow.end;
+        if (clippedEnd > clippedStart) {
+          contributingBounds.push({
+            start: clippedStart,
+            end: clippedEnd,
+          });
+        }
+        return (
+          total +
+          overlapSeconds(
+            interval.start,
+            interval.end,
+            dayWindow.start,
+            dayWindow.end,
+            referenceNow,
+          )
+        );
+      }, 0);
+
+      if (dayOverlap <= 0) {
+        continue;
+      }
+
+      durationSecondsByIssueType[issue.type] =
+        (durationSecondsByIssueType[issue.type] ?? 0) + dayOverlap;
+
+      if (issue.type === 'disruption' || issue.type === 'maintenance') {
+        dailyDowntimeIntervals.push(...contributingBounds);
+      }
+
+      const current = dayBreakdown.breakdownByIssueTypes[issue.type] ?? {
+        totalDurationSeconds: 0,
+        issueIds: [],
+      };
+      current.totalDurationSeconds += dayOverlap;
+      if (!current.issueIds.includes(issue.id)) {
+        current.issueIds.push(issue.id);
+      }
+      dayBreakdown.breakdownByIssueTypes[issue.type] = current;
+    }
+
+    totalDowntimeSeconds += sumIntervalSeconds(
+      dailyDowntimeIntervals,
+      referenceNow,
+    );
+
+    breakdownByDates[date.toISODate()!] = dayBreakdown;
+  }
+
+  const activeNow = issues.filter((issue) =>
+    issueActiveNow(issue, referenceNow),
+  );
+  let status: LineSummaryStatus = 'normal';
+  if (isLineFuture(line, referenceNow)) {
+    status = 'future_service';
+  } else if (!isLineOperatingNow(line, publicHolidaySet, referenceNow)) {
+    status = 'closed_for_day';
+  } else if (activeNow.some((issue) => issue.type === 'disruption')) {
+    status = 'ongoing_disruption';
+  } else if (activeNow.some((issue) => issue.type === 'maintenance')) {
+    status = 'ongoing_maintenance';
+  } else if (activeNow.some((issue) => issue.type === 'infra')) {
+    status = 'ongoing_infra';
+  }
+
+  return {
+    lineId: line.id,
+    status,
+    durationSecondsByIssueType,
+    durationSecondsTotalForIssues: Object.values(
+      durationSecondsByIssueType,
+    ).reduce((sum, value) => sum + (value ?? 0), 0),
+    breakdownByDates,
+    uptimeRatio:
+      totalServiceSeconds > 0
+        ? Math.max(0, 1 - totalDowntimeSeconds / totalServiceSeconds)
+        : null,
+    totalServiceSeconds: totalServiceSeconds > 0 ? totalServiceSeconds : null,
+    totalDowntimeSeconds: totalServiceSeconds > 0 ? totalDowntimeSeconds : null,
+    downtimeBreakdown:
+      totalServiceSeconds > 0
+        ? (['disruption', 'maintenance', 'infra'] as IssueType[]).map(
+            (type) => ({
+              type,
+              downtimeSeconds: durationSecondsByIssueType[type] ?? 0,
+            }),
+          )
+        : null,
+    uptimeRank: null,
+    totalLines: null,
+  };
+}
+
+function rankLineSummaries(lineSummaries: LineSummary[]) {
+  const ranked = lineSummaries
+    .filter((summary) => summary.uptimeRatio != null)
+    .sort((a, b) => (b.uptimeRatio ?? 0) - (a.uptimeRatio ?? 0));
+
+  return lineSummaries.map((summary) => {
+    const rank = ranked.findIndex((item) => item.lineId === summary.lineId);
+    return {
+      ...summary,
+      uptimeRank: summary.uptimeRatio != null ? rank + 1 : null,
+      totalLines: ranked.length > 0 ? ranked.length : null,
+    };
+  });
+}
+
+function buildWindowCountEntries(
+  issues: Issue[],
+  start: DateTime,
+  count: number,
+  stepUnit: Granularity,
+  durationMode = false,
+) {
+  const entries: ChartEntry[] = [];
+
+  for (let index = 0; index < count; index++) {
+    const bucketStart = start.plus({ [stepUnit]: index } as Record<
+      Granularity,
+      number
+    >);
+    const bucketEnd = bucketStart.plus({ [stepUnit]: 1 } as Record<
+      Granularity,
+      number
+    >);
+    const payload: Record<string, number> = {
+      disruption: 0,
+      maintenance: 0,
+      infra: 0,
+    };
+
+    for (const issue of issues) {
+      if (!durationMode) {
+        const firstStart = issue.intervals[0]?.startAt;
+        if (firstStart == null) {
+          continue;
+        }
+
+        const firstStartAt = parseDateTime(firstStart);
+        if (firstStartAt >= bucketStart && firstStartAt < bucketEnd) {
+          payload[issue.type] += 1;
+        }
+        continue;
+      }
+
+      const seconds = getIssueBounds(issue).reduce((total, interval) => {
+        return (
+          total +
+          overlapSeconds(interval.start, interval.end, bucketStart, bucketEnd)
+        );
+      }, 0);
+      payload[issue.type] += seconds;
+    }
+
+    entries.push({
+      name: bucketStart.toISODate()!,
+      payload,
+    });
+  }
+
+  return entries;
+}
+
+function buildPreviousWindowSummary(
+  issues: Issue[],
+  currentStart: DateTime,
+  count: number,
+  stepUnit: Granularity,
+  durationMode = false,
+) {
+  const currentEntries = buildWindowCountEntries(
+    issues,
+    currentStart,
+    count,
+    stepUnit,
+    durationMode,
+  );
+  const previousStart = currentStart.minus({ [stepUnit]: count } as Record<
+    Granularity,
+    number
+  >);
+  const previousEntries = buildWindowCountEntries(
+    issues,
+    previousStart,
+    count,
+    stepUnit,
+    durationMode,
+  );
+
+  const summarize = (entries: ChartEntry[]) => {
+    return entries.reduce<Record<string, number>>(
+      (acc, entry) => {
+        acc.disruption += entry.payload.disruption ?? 0;
+        acc.maintenance += entry.payload.maintenance ?? 0;
+        acc.infra += entry.payload.infra ?? 0;
+        return acc;
+      },
+      { disruption: 0, maintenance: 0, infra: 0 },
+    );
+  };
+
+  return {
+    data: currentEntries,
+    cumulative: [
+      {
+        name: 'current',
+        payload: summarize(currentEntries),
+      },
+      {
+        name: 'previous',
+        payload: summarize(previousEntries),
+      },
+    ],
+  };
+}
+
+function buildUptimeGraph(
+  line: Line,
+  issues: Issue[],
+  publicHolidaySet: Set<string>,
+  count: number,
+): TimeScaleChart {
+  const end = nowSg().startOf('day');
+  const start = end.minus({ days: count - 1 });
+  const data: ChartEntry[] = [];
+
+  for (let offset = 0; offset < count; offset++) {
+    const date = start.plus({ days: offset });
+    const serviceWindow = serviceWindowForDate(line, date, publicHolidaySet);
+    let breakdownDisruption = 0;
+    let breakdownMaintenance = 0;
+    let breakdownInfra = 0;
+
+    for (const issue of issues) {
+      const overlap = getIssueBounds(issue).reduce((total, interval) => {
+        return (
+          total +
+          overlapSeconds(
+            interval.start,
+            interval.end,
+            serviceWindow.start,
+            serviceWindow.end,
+          )
+        );
+      }, 0);
+      if (overlap <= 0) {
+        continue;
+      }
+
+      if (issue.type === 'disruption') breakdownDisruption += overlap;
+      if (issue.type === 'maintenance') breakdownMaintenance += overlap;
+      if (issue.type === 'infra') breakdownInfra += overlap;
+    }
+
+    const totalDowntime = breakdownDisruption + breakdownMaintenance;
+    data.push({
+      name: date.toISODate()!,
+      payload: {
+        uptimeRatio:
+          serviceWindow.seconds > 0
+            ? Math.max(0, 1 - totalDowntime / serviceWindow.seconds)
+            : 1,
+        'breakdown.disruption': breakdownDisruption,
+        'breakdown.maintenance': breakdownMaintenance,
+        'breakdown.infra': breakdownInfra,
+      },
+    });
+  }
+
+  const buildAggregate = (windowStart: DateTime, windowCount: number) => {
+    let serviceSeconds = 0;
+    let downtime = 0;
+    for (let offset = 0; offset < windowCount; offset++) {
+      const date = windowStart.plus({ days: offset });
+      const serviceWindow = serviceWindowForDate(line, date, publicHolidaySet);
+      serviceSeconds += serviceWindow.seconds;
+      for (const issue of issues) {
+        if (issue.type === 'infra') {
+          continue;
+        }
+        downtime += getIssueBounds(issue).reduce((total, interval) => {
+          return (
+            total +
+            overlapSeconds(
+              interval.start,
+              interval.end,
+              serviceWindow.start,
+              serviceWindow.end,
+            )
+          );
+        }, 0);
+      }
+    }
+    return serviceSeconds > 0 ? Math.max(0, 1 - downtime / serviceSeconds) : 1;
+  };
+
+  return buildCountChart(
+    `${count}d`,
+    data,
+    [
+      {
+        name: 'current',
+        payload: { uptimeRatio: buildAggregate(start, count) },
+      },
+      {
+        name: 'previous',
+        payload: {
+          uptimeRatio: buildAggregate(start.minus({ days: count }), count),
+        },
+      },
+    ],
+    makeTimeScale('day', count),
+  );
+}
+
+function buildOperatorUptimeGraph(
+  lines: Line[],
+  issuesByLineId: Record<string, Issue[]>,
+  publicHolidaySet: Set<string>,
+  count: number,
+): TimeScaleChart {
+  const end = nowSg().startOf('day');
+  const start = end.minus({ days: count - 1 });
+  const data: ChartEntry[] = [];
+
+  const computeWindow = (windowStart: DateTime, windowCount: number) => {
+    let serviceSeconds = 0;
+    let downtimeSeconds = 0;
+
+    for (let offset = 0; offset < windowCount; offset++) {
+      const date = windowStart.plus({ days: offset });
+
+      for (const line of lines) {
+        if (isLineFuture(line, date.endOf('day'))) {
+          continue;
+        }
+
+        const serviceWindow = serviceWindowForDate(line, date, publicHolidaySet);
+        serviceSeconds += serviceWindow.seconds;
+
+        for (const issue of issuesByLineId[line.id] ?? []) {
+          if (issue.type === 'infra') {
+            continue;
+          }
+
+          downtimeSeconds += getIssueBounds(issue).reduce((total, interval) => {
+            return (
+              total +
+              overlapSeconds(
+                interval.start,
+                interval.end,
+                serviceWindow.start,
+                serviceWindow.end,
+              )
+            );
+          }, 0);
+        }
+      }
+    }
+
+    return {
+      serviceSeconds,
+      downtimeSeconds,
+      uptimeRatio:
+        serviceSeconds > 0
+          ? Math.max(0, 1 - downtimeSeconds / serviceSeconds)
+          : 1,
+    };
+  };
+
+  for (let offset = 0; offset < count; offset++) {
+    const date = start.plus({ days: offset });
+    const summary = computeWindow(date, 1);
+    data.push({
+      name: date.toISODate()!,
+      payload: { uptimeRatio: summary.uptimeRatio },
+    });
+  }
+
+  const current = computeWindow(start, count);
+  const previous = computeWindow(start.minus({ days: count }), count);
+
+  return buildCountChart(
+    `${count}d`,
+    data,
+    [
+      { name: 'current', payload: { uptimeRatio: current.uptimeRatio } },
+      { name: 'previous', payload: { uptimeRatio: previous.uptimeRatio } },
+    ],
+    makeTimeScale('day', count),
+  );
+}
+
+function buildIssueCountGraphs(issues: Issue[]) {
+  const end = nowSg().startOf('day');
+  return [7, 30, 90].map((count) => {
+    const start = end.minus({ days: count - 1 });
+    const { data, cumulative } = buildPreviousWindowSummary(
+      issues,
+      start,
+      count,
+      'day',
+      false,
+    );
+    return buildCountChart(
+      `${count}d`,
+      data,
+      cumulative,
+      makeTimeScale('day', count),
+    );
+  });
+}
+
+function buildIssueDurationGraphs(issues: Issue[]) {
+  const end = nowSg().startOf('day');
+  return [7, 30, 90].map((count) => {
+    const start = end.minus({ days: count - 1 });
+    const { data, cumulative } = buildPreviousWindowSummary(
+      issues,
+      start,
+      count,
+      'day',
+      true,
+    );
+    return buildCountChart(
+      `${count}d`,
+      data,
+      cumulative,
+      makeTimeScale('day', count),
+    );
+  });
+}
+
+function chunk<T>(items: T[], size: number) {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
+function buildCountChartsFromIssueFacts(
+  rows: Array<{
+    date: string;
+    issue_type: IssueType;
+    duration_seconds: number;
+    active_anytime: boolean;
+  }>,
+  durationMode = false,
+) {
+  const end = nowSg().startOf('day');
+  const aggregateForRange = (
+    start: DateTime,
+    count: number,
+    previous = false,
+  ): Record<string, number> => {
+    const rangeStart = previous
+      ? start.minus({ days: count })
+      : start;
+    const rangeEnd = rangeStart.plus({ days: count });
+    return rows.reduce<Record<string, number>>(
+      (acc, row) => {
+        const date = DateTime.fromISO(row.date, { zone: SG_TIMEZONE });
+        if (date < rangeStart || date >= rangeEnd) {
+          return acc;
+        }
+
+        if (durationMode) {
+          acc[row.issue_type] += row.duration_seconds;
+        } else if (row.active_anytime) {
+          acc[row.issue_type] += 1;
+        }
+        return acc;
+      },
+      { disruption: 0, maintenance: 0, infra: 0 },
+    );
+  };
+
+  return [7, 30, 90].map((count) => {
+    const start = end.minus({ days: count - 1 });
+    const data: ChartEntry[] = [];
+    for (let offset = 0; offset < count; offset++) {
+      const date = start.plus({ days: offset }).toISODate()!;
+      const dayRows = rows.filter((row) => row.date === date);
+      data.push({
+        name: date,
+        payload: dayRows.reduce<Record<string, number>>(
+          (acc, row) => {
+            acc[row.issue_type] += durationMode
+              ? row.duration_seconds
+              : row.active_anytime
+                ? 1
+                : 0;
+            return acc;
+          },
+          { disruption: 0, maintenance: 0, infra: 0 },
+        ),
+      });
+    }
+
+    return buildCountChart(
+      `${count}d`,
+      data,
+      [
+        { name: 'current', payload: aggregateForRange(start, count, false) },
+        { name: 'previous', payload: aggregateForRange(start, count, true) },
+      ],
+      makeTimeScale('day', count),
+    );
+  });
+}
+
+async function getIssueDayFactsInRange(start: DateTime, end: DateTime) {
+  const db = getDb();
+  return db
+    .select()
+    .from(issueDayFactsTable)
+    .where(
+      and(
+        gte(issueDayFactsTable.date, start.toISODate()!),
+        lte(issueDayFactsTable.date, end.toISODate()!),
+      ),
+    );
+}
+
+async function getLineDayFactsInRange(start: DateTime, end: DateTime) {
+  const db = getDb();
+  return db
+    .select()
+    .from(lineDayFactsTable)
+    .where(
+      and(
+        gte(lineDayFactsTable.date, start.toISODate()!),
+        lte(lineDayFactsTable.date, end.toISODate()!),
+      ),
+    );
+}
+
+export async function rebuildOperationalFactsForDate(date: DateTime) {
+  const normalizedDate = date.setZone(SG_TIMEZONE).startOf('day');
+  const asOf = normalizedDate.endOf('day');
+  const dataset = await buildBaseDataset(asOf);
+  const db = getDb();
+  const dateKey = normalizedDate.toISODate()!;
+  const dayEnd = normalizedDate.plus({ days: 1 });
+  const issues = Object.values(dataset.allIssues);
+
+  const issueRows = issues
+    .map((issue) => {
+      const durationSeconds = getIssueBounds(issue).reduce((total, interval) => {
+        return (
+          total +
+          overlapSeconds(
+            interval.start,
+            interval.end,
+            normalizedDate,
+            dayEnd,
+            asOf,
+          )
+        );
+      }, 0);
+
+      return {
+        date: dateKey,
+        issue_id: issue.id,
+        issue_type: issue.type,
+        as_of: asOf.toISO()!,
+        active_anytime: durationSeconds > 0,
+        active_end_of_day: issueActiveNow(issue, asOf),
+        duration_seconds: Math.round(durationSeconds),
+        inferred_interval_count: 0,
+      };
+    })
+    .filter((row) => row.active_anytime || row.active_end_of_day);
+
+  const lineRows = Object.values(dataset.included.lines).map((line) => {
+    const lineIssues = issues.filter((issue) => issue.lineIds.includes(line.id));
+    const summary = buildLineSummary(
+      line,
+      lineIssues,
+      1,
+      dataset.publicHolidaySet,
+      asOf,
+    );
+    const dayBreakdown = summary.breakdownByDates[dateKey];
+    const counts = lineIssues.reduce<Record<IssueType, number>>(
+      (acc, issue) => {
+        if (issueTouchesDate(issue, normalizedDate)) {
+          acc[issue.type] += 1;
+        }
+        return acc;
+      },
+      { disruption: 0, maintenance: 0, infra: 0 },
+    );
+
+    return {
+      date: dateKey,
+      line_id: line.id,
+      as_of: asOf.toISO()!,
+      service_seconds: Math.round(
+        isLineFuture(line, normalizedDate.endOf('day'))
+          ? 0
+          : serviceWindowForDate(line, normalizedDate, dataset.publicHolidaySet)
+              .seconds,
+      ),
+      downtime_disruption_seconds: Math.round(
+        dayBreakdown?.breakdownByIssueTypes.disruption?.totalDurationSeconds ?? 0,
+      ),
+      downtime_maintenance_seconds: Math.round(
+        dayBreakdown?.breakdownByIssueTypes.maintenance?.totalDurationSeconds ?? 0,
+      ),
+      downtime_infra_seconds: Math.round(
+        dayBreakdown?.breakdownByIssueTypes.infra?.totalDurationSeconds ?? 0,
+      ),
+      issue_count_disruption: counts.disruption,
+      issue_count_maintenance: counts.maintenance,
+      issue_count_infra: counts.infra,
+    };
+  });
+
+  await db.delete(issueDayFactsTable).where(eq(issueDayFactsTable.date, dateKey));
+  await db.delete(lineDayFactsTable).where(eq(lineDayFactsTable.date, dateKey));
+
+  for (const batch of chunk(issueRows, 500)) {
+    if (batch.length > 0) {
+      await db.insert(issueDayFactsTable).values(batch);
+    }
+  }
+  for (const batch of chunk(lineRows, 500)) {
+    if (batch.length > 0) {
+      await db.insert(lineDayFactsTable).values(batch);
+    }
+  }
+
+  return {
+    date: dateKey,
+    issueCount: issueRows.length,
+    lineCount: lineRows.length,
+  };
+}
+
+export async function rebuildOperationalFactsRange(days: number, end = nowSg()) {
+  const normalizedEnd = end.setZone(SG_TIMEZONE).startOf('day');
+  const results: Array<{ date: string; issueCount: number; lineCount: number }> = [];
+  for (let offset = days - 1; offset >= 0; offset--) {
+    const date = normalizedEnd.minus({ days: offset });
+    results.push(await rebuildOperationalFactsForDate(date));
+  }
+  return results;
+}
+
+export async function getRootData() {
+  const dataset = await buildBaseDataset();
+  return {
+    lineIds: Object.keys(dataset.included.lines).sort(),
+    included: withIssues(dataset.included, dataset.allIssues, []),
+    metadata: Object.entries(dataset.metadata).map(([key, value]) => ({
+      key,
+      value,
+    })),
+    operatorIds: Object.keys(dataset.included.operators).sort(),
+    operatorsIncluded: dataset.included.operators,
+  };
+}
+
+export async function getOverviewData(days: number) {
+  const dataset = await buildBaseDataset();
+  const issues = Object.values(dataset.allIssues);
+  const lineSummaries = rankLineSummaries(
+    Object.values(dataset.included.lines).map((line) => {
+      const lineIssues = issues.filter((issue) =>
+        issue.lineIds.includes(line.id),
+      );
+      return buildLineSummary(line, lineIssues, days, dataset.publicHolidaySet);
+    }),
+  );
+
+  const overview: SystemOverview = {
+    issueIdsActiveNow: issues
+      .filter(
+        (issue) => issue.type === 'disruption' && issueActiveNow(issue),
+      )
+      .map((issue) => issue.id),
+    issueIdsActiveToday: issues
+      .filter(
+        (issue) =>
+          (issue.type === 'maintenance' || issue.type === 'infra') &&
+          issueActiveToday(issue),
+      )
+      .map((issue) => issue.id),
+    lineSummaries,
+  };
+
+  const overviewIssueIds = [
+    ...new Set([
+      ...overview.issueIdsActiveNow,
+      ...overview.issueIdsActiveToday,
+      ...overview.lineSummaries.flatMap((summary) =>
+        Object.values(summary.breakdownByDates).flatMap((entry) =>
+          Object.values(entry.breakdownByIssueTypes).flatMap(
+            (breakdown) => breakdown.issueIds,
+          ),
+        ),
+      ),
+    ]),
+  ];
+
+  return {
+    data: overview,
+    included: withIssues(dataset.included, dataset.allIssues, overviewIssueIds),
+  };
+}
+
+export async function getLineProfileData(lineId: string, days: number) {
+  const dataset = await buildBaseDataset();
+  const line = dataset.included.lines[lineId];
+  if (line == null) {
+    throw new Response('Line not found', {
+      status: 404,
+      statusText: 'Not Found',
+    });
+  }
+
+  const allLineSummaries = rankLineSummaries(
+    Object.values(dataset.included.lines).map((candidateLine) => {
+      const candidateIssues = Object.values(dataset.allIssues).filter((issue) =>
+        issue.lineIds.includes(candidateLine.id),
+      );
+      return buildLineSummary(
+        candidateLine,
+        candidateIssues,
+        days,
+        dataset.publicHolidaySet,
+      );
+    }),
+  );
+
+  const lineIssues = Object.values(dataset.allIssues).filter((issue) =>
+    issue.lineIds.includes(lineId),
+  );
+  const rankedSummary = allLineSummaries.find(
+    (summary) => summary.lineId === lineId,
+  )!;
+  const issueIdsRecent = [...lineIssues]
+    .filter((issue) =>
+      issue.intervals.some((interval) => parseDateTime(interval.startAt) <= nowSg()),
+    )
+    .sort((a, b) => {
+      const earliestA = Math.min(
+        ...a.intervals.map((interval) => parseDateTime(interval.startAt).toMillis()),
+      );
+      const earliestB = Math.min(
+        ...b.intervals.map((interval) => parseDateTime(interval.startAt).toMillis()),
+      );
+      return earliestB - earliestA;
+    })
+    .slice(0, 5)
+    .map((issue) => issue.id);
+
+  const futureMaintenance = lineIssues
+    .filter((issue) => issue.type === 'maintenance')
+    .flatMap((issue) =>
+      issue.intervals
+        .filter((interval) => interval.status === 'future')
+        .map((interval) => ({ issueId: issue.id, startAt: interval.startAt })),
+    )
+    .sort(
+      (a, b) =>
+        parseDateTime(a.startAt).toMillis() -
+        parseDateTime(b.startAt).toMillis(),
+    )[0];
+
+  const stationIdsInterchanges = [
+    ...new Set(
+      Object.values(dataset.included.stations)
+        .filter((station) => {
+          const lineMemberships = station.memberships.filter(
+            (membership) => membership.lineId === lineId,
+          );
+          if (lineMemberships.length === 0) {
+            return false;
+          }
+
+          return station.memberships.some(
+            (membership) => membership.lineId !== lineId,
+          );
+        })
+        .map((station) => station.id),
+    ),
+  ];
+
+  const profile: LineProfile = {
+    lineId,
+    lineSummary: rankedSummary,
+    branches: dataset.branchesByLineId[lineId] ?? [],
+    issueIdNextMaintenance: futureMaintenance?.issueId ?? null,
+    issueIdsRecent,
+    issueCountByType: pickIssueTypes(lineIssues),
+    timeScaleGraphsIssueCount: buildIssueCountGraphs(lineIssues),
+    timeScaleGraphsUptimeRatios: [7, 30, days].map((window) =>
+      buildUptimeGraph(line, lineIssues, dataset.publicHolidaySet, window),
+    ),
+    stationIdsInterchanges,
+  };
+
+  return {
+    data: profile,
+    included: withIssues(dataset.included, dataset.allIssues, [
+      ...new Set(
+        [...issueIdsRecent, profile.issueIdNextMaintenance].filter(
+          (value): value is string => value != null,
+        ),
+      ),
+    ]),
+  };
+}
+
+export async function getIssueData(issueId: string) {
+  const dataset = await buildBaseDataset();
+  const issue = dataset.allIssues[issueId];
+  if (issue == null) {
+    throw new Response('Issue not found', {
+      status: 404,
+      statusText: 'Not Found',
+    });
+  }
+
+  return {
+    data: {
+      id: issueId,
+      updates: dataset.issueUpdatesById[issueId] ?? [],
+    },
+    included: withIssues(dataset.included, dataset.allIssues, [issueId]),
+  };
+}
+
+export async function getStationProfileData(stationId: string) {
+  const dataset = await buildBaseDataset();
+  const station = dataset.included.stations[stationId];
+  if (station == null) {
+    throw new Response('Station not found', {
+      status: 404,
+      statusText: 'Not Found',
+    });
+  }
+
+  const issues = Object.values(dataset.allIssues).filter((issue) =>
+    issue.branchesAffected.some((branch) =>
+      branch.stationIds.includes(stationId),
+    ),
+  );
+  const activeNow = issues.filter((issue) => issueActiveNow(issue));
+
+  let status: StationProfile['status'] = 'normal';
+  if (activeNow.some((issue) => issue.type === 'disruption')) {
+    status = 'ongoing_disruption';
+  } else if (activeNow.some((issue) => issue.type === 'maintenance')) {
+    status = 'ongoing_maintenance';
+  } else if (activeNow.some((issue) => issue.type === 'infra')) {
+    status = 'ongoing_infra';
+  }
+
+  const issueIdsRecent = sortIssuesByLatestActivity(
+    issues.map((issue) => issue.id),
+    dataset.allIssues,
+  ).slice(0, 15);
+
+  return {
+    data: {
+      stationId,
+      status,
+      issueIdsRecent,
+      issueCountByType: pickIssueTypes(issues),
+    } satisfies StationProfile,
+    included: withIssues(dataset.included, dataset.allIssues, issueIdsRecent),
+  };
+}
+
+export async function getOperatorProfileData(operatorId: string, days: number) {
+  const dataset = await buildBaseDataset();
+  const operator = dataset.included.operators[operatorId];
+  if (operator == null) {
+    throw new Response('Operator not found', {
+      status: 404,
+      statusText: 'Not Found',
+    });
+  }
+
+  const lineIds = Object.values(dataset.included.lines)
+    .filter((line) =>
+      line.operators.some((entry) => entry.operatorId === operatorId),
+    )
+    .map((line) => line.id);
+
+  const lineSummaries = Object.fromEntries(
+    lineIds.map((lineId) => {
+      const line = dataset.included.lines[lineId];
+      const lineIssues = Object.values(dataset.allIssues).filter((issue) =>
+        issue.lineIds.includes(lineId),
+      );
+      return [
+        lineId,
+        buildLineSummary(line, lineIssues, days, dataset.publicHolidaySet),
+      ];
+    }),
+  ) as Record<string, LineSummary>;
+  const operatorLines = lineIds.map((lineId) => dataset.included.lines[lineId]);
+  const operatorIssuesByLineId = Object.fromEntries(
+    lineIds.map((lineId) => [
+      lineId,
+      Object.values(dataset.allIssues).filter((issue) =>
+        issue.lineIds.includes(lineId),
+      ),
+    ]),
+  ) as Record<string, Issue[]>;
+
+  const operatorIssues = Object.values(dataset.allIssues).filter((issue) =>
+    issue.lineIds.some((lineId) => lineIds.includes(lineId)),
+  );
+
+  const totalStationsOperated = new Set(
+    lineIds.flatMap((lineId) =>
+      (dataset.branchesByLineId[lineId] ?? []).flatMap(
+        (branch) => branch.stationIds,
+      ),
+    ),
+  ).size;
+
+  const linePerformanceComparison: OperatorLinePerformance[] = lineIds.map(
+    (lineId) => ({
+      lineId,
+      status: lineSummaries[lineId].status,
+      uptimeRatio: lineSummaries[lineId].uptimeRatio,
+      issueCount: operatorIssues.filter((issue) =>
+        issue.lineIds.includes(lineId),
+      ).length,
+    }),
+  );
+
+  const activeSummaries = Object.values(lineSummaries);
+  const linesAffected = activeSummaries
+    .filter((summary) =>
+      ['ongoing_disruption', 'ongoing_maintenance', 'ongoing_infra'].includes(
+        summary.status,
+      ),
+    )
+    .map((summary) => summary.lineId);
+
+  let currentOperationalStatus: OperatorProfile['currentOperationalStatus'] =
+    'all_operational';
+  if (
+    activeSummaries.length > 0 &&
+    activeSummaries.every((summary) =>
+      ['closed_for_day', 'future_service'].includes(summary.status),
+    )
+  ) {
+    currentOperationalStatus = 'all_lines_closed_for_day';
+  } else if (
+    activeSummaries.some((summary) => summary.status === 'ongoing_disruption')
+  ) {
+    currentOperationalStatus = 'some_lines_disrupted';
+  } else if (
+    activeSummaries.some((summary) =>
+      ['ongoing_maintenance', 'ongoing_infra'].includes(summary.status),
+    )
+  ) {
+    currentOperationalStatus = 'some_lines_under_maintenance';
+  }
+
+  const totalServiceSeconds = activeSummaries.reduce(
+    (sum, summary) => sum + (summary.totalServiceSeconds ?? 0),
+    0,
+  );
+  const totalDowntimeSeconds = activeSummaries.reduce(
+    (sum, summary) => sum + (summary.totalDowntimeSeconds ?? 0),
+    0,
+  );
+
+  const profile: OperatorProfile = {
+    operatorId,
+    lineIds,
+    aggregateUptimeRatio:
+      totalServiceSeconds > 0
+        ? Math.max(0, 1 - totalDowntimeSeconds / totalServiceSeconds)
+        : null,
+    currentOperationalStatus,
+    linesAffected,
+    totalIssuesByType: pickIssueTypes(operatorIssues),
+    totalStationsOperated,
+    issueIdsRecent: sortIssuesByLatestActivity(
+      operatorIssues.map((issue) => issue.id),
+      dataset.allIssues,
+    ).slice(0, 15),
+    timeScaleGraphsIssueCount: buildIssueCountGraphs(operatorIssues),
+    timeScaleGraphsUptimeRatios: [7, 30, days].map((window) =>
+      buildOperatorUptimeGraph(
+        operatorLines,
+        operatorIssuesByLineId,
+        dataset.publicHolidaySet,
+        window,
+      ),
+    ),
+    linePerformanceComparison,
+    totalDowntimeDurationSeconds: totalDowntimeSeconds,
+    downtimeDurationByIssueType: pickIssueDurationByType(operatorIssues),
+    yearsOfOperation: Math.max(
+      0,
+      Math.floor(
+        nowSg().diff(
+          parseDateTime(operator.foundedAt),
+          'years',
+        ).years,
+      ),
+    ),
+  };
+
+  return {
+    data: profile,
+    included: withIssues(
+      dataset.included,
+      dataset.allIssues,
+      profile.issueIdsRecent,
+    ),
+  };
+}
+
+export async function getSystemMapData() {
+  const overview = await getOverviewData(30);
+  return {
+    overview: overview.data,
+    included: overview.included,
+  };
+}
+
+export async function getHistoryYearSummaryData(year: number) {
+  const yearStart = DateTime.fromObject(
+    { year, month: 1, day: 1 },
+    { zone: SG_TIMEZONE },
+  ).startOf('day');
+  const yearEnd = yearStart.plus({ years: 1 });
+  const factRows = await getIssueDayFactsInRange(yearStart, yearEnd.minus({ days: 1 }));
+  if (factRows.length > 0) {
+    const dataset = await buildBaseDataset();
+    const issueIds = [...new Set(factRows.map((row) => row.issue_id))];
+    const summaryByMonth = Array.from({ length: 12 }, (_, index) => {
+      const monthStart = DateTime.fromObject(
+        { year, month: index + 1, day: 1 },
+        { zone: SG_TIMEZONE },
+      ).startOf('day');
+      const monthEnd = monthStart.plus({ months: 1 });
+      const monthRows = factRows.filter((row) => {
+        const date = DateTime.fromISO(row.date, { zone: SG_TIMEZONE });
+        return date >= monthStart && date < monthEnd;
+      });
+      const uniqueIssues = new Map<string, IssueType>();
+      for (const row of monthRows) {
+        uniqueIssues.set(row.issue_id, row.issue_type as IssueType);
+      }
+      const issueCountsByType = [...uniqueIssues.values()].reduce<
+        Partial<Record<IssueType, number>>
+      >((acc, type) => {
+        acc[type] = (acc[type] ?? 0) + 1;
+        return acc;
+      }, {});
+      return {
+        month: monthStart.toISODate()!,
+        issueCountsByType,
+        totalCount: uniqueIssues.size,
+      };
+    }).reverse();
+
+    return {
+      data: {
+        startAt: yearStart.toISODate()!,
+        endAt: yearEnd.minus({ day: 1 }).toISODate()!,
+        summaryByMonth,
+      },
+      included: withIssues(dataset.included, dataset.allIssues, issueIds),
+    };
+  }
+
+  const dataset = await buildBaseDataset();
+  const issues = Object.values(dataset.allIssues).filter((issue) =>
+    issueOverlapsRange(issue, yearStart, yearEnd),
+  );
+
+  const summaryByMonth = Array.from({ length: 12 }, (_, index) => {
+    const monthStart = DateTime.fromObject(
+      { year, month: index + 1, day: 1 },
+      { zone: SG_TIMEZONE },
+    ).startOf('day');
+    const monthEnd = monthStart.plus({ months: 1 });
+    const monthIssues = issues.filter((issue) =>
+      issueOverlapsRange(issue, monthStart, monthEnd),
+    );
+    return {
+      month: monthStart.toISODate()!,
+      issueCountsByType: pickIssueTypes(monthIssues),
+      totalCount: monthIssues.length,
+    };
+  }).reverse();
+
+  return {
+    data: {
+      startAt: yearStart.toISODate()!,
+      endAt: yearEnd.minus({ day: 1 }).toISODate()!,
+      summaryByMonth,
+    },
+    included: withIssues(
+      dataset.included,
+      dataset.allIssues,
+      issues.map((issue) => issue.id),
+    ),
+  };
+}
+
+export async function getHistoryYearMonthData(year: number, month: number) {
+  const monthStart = DateTime.fromObject(
+    { year, month, day: 1 },
+    { zone: SG_TIMEZONE },
+  ).startOf('day');
+  const monthEnd = monthStart.plus({ months: 1 });
+  const factRows = await getIssueDayFactsInRange(
+    monthStart,
+    monthEnd.minus({ days: 1 }),
+  );
+  if (factRows.length > 0) {
+    const dataset = await buildBaseDataset();
+    const issueIds = [...new Set(factRows.map((row) => row.issue_id))];
+    const weeks = new Map<string, string[]>();
+    for (
+      let date = monthStart.startOf('week');
+      date < monthEnd.endOf('week');
+      date = date.plus({ week: 1 })
+    ) {
+      const weekStart = date.startOf('week');
+      const weekEnd = weekStart.plus({ week: 1 });
+      const key = `${date.weekYear}-W${date.weekNumber.toString().padStart(2, '0')}`;
+      const weekIssueIds = [
+        ...new Set(
+          factRows
+            .filter((row) => {
+              const rowDate = DateTime.fromISO(row.date, { zone: SG_TIMEZONE });
+              return rowDate >= weekStart && rowDate < weekEnd;
+            })
+            .map((row) => row.issue_id),
+        ),
+      ].sort((a, b) => b.localeCompare(a));
+      if (weekIssueIds.length > 0 || !weeks.has(key)) {
+        weeks.set(key, weekIssueIds);
+      }
+    }
+
+    return {
+      data: {
+        startAt: monthStart.toISODate()!,
+        endAt: monthEnd.minus({ day: 1 }).toISODate()!,
+        issuesByWeek: [...weeks.entries()]
+          .sort(([a], [b]) => b.localeCompare(a))
+          .map(([week, ids]) => ({
+            week,
+            issueIds: ids,
+          })),
+      },
+      included: withIssues(dataset.included, dataset.allIssues, issueIds),
+    };
+  }
+
+  const dataset = await buildBaseDataset();
+
+  const issues = Object.values(dataset.allIssues).filter((issue) =>
+    issueOverlapsRange(issue, monthStart, monthEnd),
+  );
+
+  const weeks = new Map<string, string[]>();
+  for (
+    let date = monthStart.startOf('week');
+    date < monthEnd.endOf('week');
+    date = date.plus({ week: 1 })
+  ) {
+    const key = `${date.weekYear}-W${date.weekNumber.toString().padStart(2, '0')}`;
+    const issueIds = issues
+      .filter((issue) =>
+        issueOverlapsRange(issue, date.startOf('week'), date.startOf('week').plus({ week: 1 })),
+      )
+      .map((issue) => issue.id)
+      .sort((a, b) => b.localeCompare(a));
+    if (issueIds.length > 0 || !weeks.has(key)) {
+      weeks.set(key, issueIds);
+    }
+  }
+
+  return {
+    data: {
+      startAt: monthStart.toISODate()!,
+      endAt: monthEnd.minus({ day: 1 }).toISODate()!,
+      issuesByWeek: [...weeks.entries()]
+        .sort(([a], [b]) => b.localeCompare(a))
+        .map(([week, issueIds]) => ({
+          week,
+          issueIds,
+        })),
+    },
+    included: withIssues(
+      dataset.included,
+      dataset.allIssues,
+      issues.map((issue) => issue.id),
+    ),
+  };
+}
+
+export async function getHistoryDayData(
+  year: number,
+  month: number,
+  day: number,
+) {
+  const date = DateTime.fromObject({ year, month, day }, { zone: SG_TIMEZONE });
+  const factRows = await getIssueDayFactsInRange(date, date);
+  if (factRows.length > 0) {
+    const dataset = await buildBaseDataset();
+    const issueIds = [...new Set(factRows.map((row) => row.issue_id))].sort((a, b) =>
+      b.localeCompare(a),
+    );
+    return {
+      data: {
+        startAt: date.toISODate()!,
+        endAt: date.toISODate()!,
+        issueIds,
+      },
+      included: withIssues(dataset.included, dataset.allIssues, issueIds),
+    };
+  }
+
+  const dataset = await buildBaseDataset();
+  const issues = Object.values(dataset.allIssues).filter((issue) =>
+    issueTouchesDate(issue, date),
+  );
+  const issueIds = issues.map((issue) => issue.id).sort((a, b) => b.localeCompare(a));
+
+  return {
+    data: {
+      startAt: date.toISODate()!,
+      endAt: date.toISODate()!,
+      issueIds,
+    },
+    included: withIssues(dataset.included, dataset.allIssues, issueIds),
+  };
+}
+
+export async function getStatisticsData() {
+  const dataset = await buildBaseDataset();
+  const issues = Object.values(dataset.allIssues);
+  const rollingYearEnd = nowSg().startOf('day');
+  const rollingYearStart = rollingYearEnd.minus({ days: 364 });
+  const issueFactRows = await getIssueDayFactsInRange(rollingYearStart, rollingYearEnd);
+  const lineFactRows = await getLineDayFactsInRange(rollingYearStart, rollingYearEnd);
+  const longestDisruptions = [...issues]
+    .filter((issue) => issue.type === 'disruption')
+    .sort((a, b) => b.durationSeconds - a.durationSeconds)
+    .slice(0, 10)
+    .map((issue) => issue.id);
+
+  const chartTotalIssueCountByLine: Chart = {
+    title: 'Issue Count by Line',
+    data:
+      lineFactRows.length > 0
+        ? Object.values(dataset.included.lines).map((line) => {
+            const rows = lineFactRows.filter((row) => row.line_id === line.id);
+            return {
+              name: line.id,
+              payload: {
+                disruption: rows.reduce(
+                  (sum, row) => sum + row.issue_count_disruption,
+                  0,
+                ),
+                maintenance: rows.reduce(
+                  (sum, row) => sum + row.issue_count_maintenance,
+                  0,
+                ),
+                infra: rows.reduce((sum, row) => sum + row.issue_count_infra, 0),
+                totalIssues: rows.reduce(
+                  (sum, row) =>
+                    sum +
+                    row.issue_count_disruption +
+                    row.issue_count_maintenance +
+                    row.issue_count_infra,
+                  0,
+                ),
+              },
+            };
+          })
+        : Object.values(dataset.included.lines).map((line) => {
+            const lineIssues = issues.filter((issue) =>
+              issue.lineIds.includes(line.id),
+            );
+            const counts = pickIssueTypes(lineIssues);
+            return {
+              name: line.id,
+              payload: {
+                disruption: counts.disruption ?? 0,
+                maintenance: counts.maintenance ?? 0,
+                infra: counts.infra ?? 0,
+                totalIssues: lineIssues.length,
+              },
+            };
+          }),
+  };
+
+  const stationIssueCounts = Object.values(dataset.included.stations).map(
+    (station) => {
+      const stationIssues = issues.filter((issue) =>
+        issue.branchesAffected.some((branch) =>
+          branch.stationIds.includes(station.id),
+        ),
+      );
+      const counts = pickIssueTypes(stationIssues);
+      return {
+        name: station.memberships[0]?.code ?? station.name,
+        payload: {
+          disruption: counts.disruption ?? 0,
+          maintenance: counts.maintenance ?? 0,
+          infra: counts.infra ?? 0,
+          totalIssues: stationIssues.length,
+        },
+      };
+    },
+  );
+
+  const chartTotalIssueCountByStation: Chart = {
+    title: 'Issue Count by Station',
+    data: stationIssueCounts
+      .sort(
+        (a, b) =>
+          (b.payload.totalIssues as number) - (a.payload.totalIssues as number),
+      )
+      .slice(0, 15),
+  };
+
+  const chartRollingYearHeatmap: Chart = {
+    title: 'Rolling Year Heatmap',
+    data: Array.from({ length: 365 }, (_, index) => {
+      const date = rollingYearStart.plus({ days: index }).toISODate()!;
+      const dayRows =
+        issueFactRows.length > 0
+          ? issueFactRows.filter((row) => row.date === date && row.active_anytime)
+          : [];
+      if (issueFactRows.length > 0) {
+        return {
+          name: date,
+          payload: dayRows.reduce<Record<string, number>>(
+            (acc, row) => {
+              acc[row.issue_type] += 1;
+              return acc;
+            },
+            { disruption: 0, maintenance: 0, infra: 0 },
+          ),
+        };
+      }
+      const dayDate = DateTime.fromISO(date, { zone: SG_TIMEZONE });
+      const dayIssues = issues.filter((issue) => issueTouchesDate(issue, dayDate));
+      const counts = pickIssueTypes(dayIssues);
+      return {
+        name: date,
+        payload: {
+          disruption: counts.disruption ?? 0,
+          maintenance: counts.maintenance ?? 0,
+          infra: counts.infra ?? 0,
+        },
+      };
+    }),
+  };
+
+  const statistics: SystemAnalytics = {
+    timeScaleChartsIssueCount:
+      issueFactRows.length > 0
+        ? buildCountChartsFromIssueFacts(issueFactRows, false)
+        : buildIssueCountGraphs(issues),
+    timeScaleChartsIssueDuration:
+      issueFactRows.length > 0
+        ? buildCountChartsFromIssueFacts(issueFactRows, true)
+        : buildIssueDurationGraphs(issues),
+    chartTotalIssueCountByLine,
+    chartTotalIssueCountByStation,
+    chartRollingYearHeatmap,
+    issueIdsDisruptionLongest: longestDisruptions,
+  };
+
+  return {
+    data: statistics,
+    included: withIssues(
+      dataset.included,
+      dataset.allIssues,
+      longestDisruptions,
+    ),
+  };
+}
+
+export async function getSitemapData() {
+  const dataset = await buildBaseDataset();
+  const issues = Object.values(dataset.allIssues).filter(
+    (issue) => issue.intervals[0] != null,
+  );
+  const firstDates = issues.map((issue) =>
+    parseDateTime(issue.intervals[0].startAt),
+  );
+  const earliest = firstDates.sort((a, b) => a.toMillis() - b.toMillis())[0];
+  const latest = firstDates.sort((a, b) => b.toMillis() - a.toMillis())[0];
+
+  return {
+    lineIds: Object.keys(dataset.included.lines).sort(),
+    stationIds: Object.keys(dataset.included.stations).sort(),
+    operatorIds: Object.keys(dataset.included.operators).sort(),
+    issueIds: issues.map((issue) => issue.id),
+    monthEarliest:
+      earliest?.startOf('month').toISODate() ?? nowSg().toISODate()!,
+    monthLatest: latest?.startOf('month').toISODate() ?? nowSg().toISODate()!,
+  };
+}

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -1492,14 +1492,12 @@ function chunk<T>(items: T[], size: number) {
   return chunks;
 }
 
-function buildCountChartsFromIssueFacts(
+function buildDurationChartsFromIssueFacts(
   rows: Array<{
     date: string;
     issue_type: IssueType;
     duration_seconds: number;
-    active_anytime: boolean;
   }>,
-  durationMode = false,
 ) {
   const end = nowSg().startOf('day');
   const aggregateForRange = (
@@ -1507,9 +1505,7 @@ function buildCountChartsFromIssueFacts(
     count: number,
     previous = false,
   ): Record<string, number> => {
-    const rangeStart = previous
-      ? start.minus({ days: count })
-      : start;
+    const rangeStart = previous ? start.minus({ days: count }) : start;
     const rangeEnd = rangeStart.plus({ days: count });
     return rows.reduce<Record<string, number>>(
       (acc, row) => {
@@ -1518,11 +1514,7 @@ function buildCountChartsFromIssueFacts(
           return acc;
         }
 
-        if (durationMode) {
-          acc[row.issue_type] += row.duration_seconds;
-        } else if (row.active_anytime) {
-          acc[row.issue_type] += 1;
-        }
+        acc[row.issue_type] += row.duration_seconds;
         return acc;
       },
       { disruption: 0, maintenance: 0, infra: 0 },
@@ -1539,11 +1531,7 @@ function buildCountChartsFromIssueFacts(
         name: date,
         payload: dayRows.reduce<Record<string, number>>(
           (acc, row) => {
-            acc[row.issue_type] += durationMode
-              ? row.duration_seconds
-              : row.active_anytime
-                ? 1
-                : 0;
+            acc[row.issue_type] += row.duration_seconds;
             return acc;
           },
           { disruption: 0, maintenance: 0, infra: 0 },
@@ -1582,26 +1570,6 @@ async function getIssueDayFactsInRange(start: DateTime, end: DateTime) {
         and(
           gte(issueDayFactsTable.date, start.toISODate()!),
           lte(issueDayFactsTable.date, end.toISODate()!),
-        ),
-      );
-  } catch (error) {
-    if (isUndefinedTableError(error)) {
-      return [];
-    }
-    throw error;
-  }
-}
-
-async function getLineDayFactsInRange(start: DateTime, end: DateTime) {
-  const db = getDb();
-  try {
-    return await db
-      .select()
-      .from(lineDayFactsTable)
-      .where(
-        and(
-          gte(lineDayFactsTable.date, start.toISODate()!),
-          lte(lineDayFactsTable.date, end.toISODate()!),
         ),
       );
   } catch (error) {
@@ -2329,7 +2297,6 @@ export async function getStatisticsData() {
   const rollingYearEnd = nowSg().startOf('day');
   const rollingYearStart = rollingYearEnd.minus({ days: 364 });
   const issueFactRows = await getIssueDayFactsInRange(rollingYearStart, rollingYearEnd);
-  const lineFactRows = await getLineDayFactsInRange(rollingYearStart, rollingYearEnd);
   const longestDisruptions = [...issues]
     .filter((issue) => issue.type === 'disruption')
     .sort((a, b) => b.durationSeconds - a.durationSeconds)
@@ -2338,48 +2305,19 @@ export async function getStatisticsData() {
 
   const chartTotalIssueCountByLine: Chart = {
     title: 'Issue Count by Line',
-    data:
-      lineFactRows.length > 0
-        ? Object.values(dataset.included.lines).map((line) => {
-            const rows = lineFactRows.filter((row) => row.line_id === line.id);
-            return {
-              name: line.id,
-              payload: {
-                disruption: rows.reduce(
-                  (sum, row) => sum + row.issue_count_disruption,
-                  0,
-                ),
-                maintenance: rows.reduce(
-                  (sum, row) => sum + row.issue_count_maintenance,
-                  0,
-                ),
-                infra: rows.reduce((sum, row) => sum + row.issue_count_infra, 0),
-                totalIssues: rows.reduce(
-                  (sum, row) =>
-                    sum +
-                    row.issue_count_disruption +
-                    row.issue_count_maintenance +
-                    row.issue_count_infra,
-                  0,
-                ),
-              },
-            };
-          })
-        : Object.values(dataset.included.lines).map((line) => {
-            const lineIssues = issues.filter((issue) =>
-              issue.lineIds.includes(line.id),
-            );
-            const counts = pickIssueTypes(lineIssues);
-            return {
-              name: line.id,
-              payload: {
-                disruption: counts.disruption ?? 0,
-                maintenance: counts.maintenance ?? 0,
-                infra: counts.infra ?? 0,
-                totalIssues: lineIssues.length,
-              },
-            };
-          }),
+    data: Object.values(dataset.included.lines).map((line) => {
+      const lineIssues = issues.filter((issue) => issue.lineIds.includes(line.id));
+      const counts = pickIssueTypes(lineIssues);
+      return {
+        name: line.id,
+        payload: {
+          disruption: counts.disruption ?? 0,
+          maintenance: counts.maintenance ?? 0,
+          infra: counts.infra ?? 0,
+          totalIssues: lineIssues.length,
+        },
+      };
+    }),
   };
 
   const stationIssueCounts = Object.values(dataset.included.stations).map(
@@ -2447,13 +2385,10 @@ export async function getStatisticsData() {
   };
 
   const statistics: SystemAnalytics = {
-    timeScaleChartsIssueCount:
-      issueFactRows.length > 0
-        ? buildCountChartsFromIssueFacts(issueFactRows, false)
-        : buildIssueCountGraphs(issues),
+    timeScaleChartsIssueCount: buildIssueCountGraphs(issues),
     timeScaleChartsIssueDuration:
       issueFactRows.length > 0
-        ? buildCountChartsFromIssueFacts(issueFactRows, true)
+        ? buildDurationChartsFromIssueFacts(issueFactRows)
         : buildIssueDurationGraphs(issues),
     chartTotalIssueCountByLine,
     chartTotalIssueCountByStation,

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -204,7 +204,9 @@ function buildIssueIntervals(
     const normalizedStartAt = parseDateTime(row.start_at).toISO()!;
     const resolvedEndAtRaw = row.end_at_resolved ?? row.end_at ?? null;
     const normalizedEndAt =
-      resolvedEndAtRaw != null ? parseDateTime(resolvedEndAtRaw).toISO()! : null;
+      resolvedEndAtRaw != null
+        ? parseDateTime(resolvedEndAtRaw).toISO()!
+        : null;
     const key = `${normalizedStartAt}::${normalizedEndAt ?? 'null'}`;
     if (unique.has(key)) {
       continue;
@@ -213,12 +215,18 @@ function buildIssueIntervals(
     unique.set(key, {
       startAt: normalizedStartAt,
       endAt: normalizedEndAt,
-      status: classifyInterval(normalizedStartAt, normalizedEndAt, referenceNow),
+      status: classifyInterval(
+        normalizedStartAt,
+        normalizedEndAt,
+        referenceNow,
+      ),
     });
   }
 
   return [...unique.values()].sort((a, b) => {
-    return parseDateTime(a.startAt).toMillis() - parseDateTime(b.startAt).toMillis();
+    return (
+      parseDateTime(a.startAt).toMillis() - parseDateTime(b.startAt).toMillis()
+    );
   });
 }
 
@@ -300,6 +308,25 @@ function serviceWindowForDate(
   };
 }
 
+function serviceWindowAfterLineStart(
+  line: Line,
+  serviceWindow: ReturnType<typeof serviceWindowForDate>,
+) {
+  const windowStart =
+    line.startedAt == null
+      ? serviceWindow.start
+      : DateTime.max(serviceWindow.start, parseDateTime(line.startedAt));
+  const seconds = Math.max(
+    0,
+    serviceWindow.end.diff(windowStart, 'seconds').seconds,
+  );
+  return {
+    start: windowStart,
+    end: serviceWindow.end,
+    seconds,
+  };
+}
+
 function isLineFuture(line: Line, referenceNow = nowSg()) {
   if (line.startedAt == null) {
     return false;
@@ -366,7 +393,9 @@ function issueOverlapsRange(
   rangeEnd: DateTime,
 ) {
   return getIssueBounds(issue).some((interval) => {
-    return overlapSeconds(interval.start, interval.end, rangeStart, rangeEnd) > 0;
+    return (
+      overlapSeconds(interval.start, interval.end, rangeStart, rangeEnd) > 0
+    );
   });
 }
 
@@ -842,7 +871,8 @@ async function buildBaseDataset(referenceNow = nowSg()): Promise<BaseDataset> {
   for (const row of issueRows) {
     const { fallback, translations } = parseTranslations(row.title);
     const events = [...(impactEventsByIssueId[row.id] ?? [])].sort((a, b) => {
-      const tsDiff = parseDateTime(b.ts).toMillis() - parseDateTime(a.ts).toMillis();
+      const tsDiff =
+        parseDateTime(b.ts).toMillis() - parseDateTime(a.ts).toMillis();
       if (tsDiff !== 0) {
         return tsDiff;
       }
@@ -1279,30 +1309,35 @@ function buildUptimeGraph(
 
   for (let offset = 0; offset < count; offset++) {
     const date = start.plus({ days: offset });
-    const serviceWindow = serviceWindowForDate(line, date, publicHolidaySet);
+    const serviceWindow = serviceWindowAfterLineStart(
+      line,
+      serviceWindowForDate(line, date, publicHolidaySet),
+    );
     let breakdownDisruption = 0;
     let breakdownMaintenance = 0;
     let breakdownInfra = 0;
 
-    for (const issue of issues) {
-      const overlap = getIssueBounds(issue).reduce((total, interval) => {
-        return (
-          total +
-          overlapSeconds(
-            interval.start,
-            interval.end,
-            serviceWindow.start,
-            serviceWindow.end,
-          )
-        );
-      }, 0);
-      if (overlap <= 0) {
-        continue;
-      }
+    if (serviceWindow.seconds > 0) {
+      for (const issue of issues) {
+        const overlap = getIssueBounds(issue).reduce((total, interval) => {
+          return (
+            total +
+            overlapSeconds(
+              interval.start,
+              interval.end,
+              serviceWindow.start,
+              serviceWindow.end,
+            )
+          );
+        }, 0);
+        if (overlap <= 0) {
+          continue;
+        }
 
-      if (issue.type === 'disruption') breakdownDisruption += overlap;
-      if (issue.type === 'maintenance') breakdownMaintenance += overlap;
-      if (issue.type === 'infra') breakdownInfra += overlap;
+        if (issue.type === 'disruption') breakdownDisruption += overlap;
+        if (issue.type === 'maintenance') breakdownMaintenance += overlap;
+        if (issue.type === 'infra') breakdownInfra += overlap;
+      }
     }
 
     const totalDowntime = breakdownDisruption + breakdownMaintenance;
@@ -1325,7 +1360,13 @@ function buildUptimeGraph(
     let downtime = 0;
     for (let offset = 0; offset < windowCount; offset++) {
       const date = windowStart.plus({ days: offset });
-      const serviceWindow = serviceWindowForDate(line, date, publicHolidaySet);
+      const serviceWindow = serviceWindowAfterLineStart(
+        line,
+        serviceWindowForDate(line, date, publicHolidaySet),
+      );
+      if (serviceWindow.seconds <= 0) {
+        continue;
+      }
       serviceSeconds += serviceWindow.seconds;
       for (const issue of issues) {
         if (issue.type === 'infra') {
@@ -1388,7 +1429,11 @@ function buildOperatorUptimeGraph(
           continue;
         }
 
-        const serviceWindow = serviceWindowForDate(line, date, publicHolidaySet);
+        const serviceWindow = serviceWindowForDate(
+          line,
+          date,
+          publicHolidaySet,
+        );
         serviceSeconds += serviceWindow.seconds;
 
         for (const issue of issuesByLineId[line.id] ?? []) {
@@ -1580,6 +1625,21 @@ async function getIssueDayFactsInRange(start: DateTime, end: DateTime) {
   }
 }
 
+function hasFullDateCoverage(
+  rows: Array<{ date: string }>,
+  start: DateTime,
+  end: DateTime,
+) {
+  const expectedDays =
+    Math.floor(end.startOf('day').diff(start.startOf('day'), 'days').days) + 1;
+  if (expectedDays <= 0) {
+    return false;
+  }
+
+  const dates = new Set(rows.map((row) => row.date));
+  return dates.size === expectedDays;
+}
+
 export async function rebuildOperationalFactsForDate(date: DateTime) {
   const normalizedDate = date.setZone(SG_TIMEZONE).startOf('day');
   const asOf = normalizedDate.endOf('day');
@@ -1591,18 +1651,21 @@ export async function rebuildOperationalFactsForDate(date: DateTime) {
 
   const issueRows = issues
     .map((issue) => {
-      const durationSeconds = getIssueBounds(issue).reduce((total, interval) => {
-        return (
-          total +
-          overlapSeconds(
-            interval.start,
-            interval.end,
-            normalizedDate,
-            dayEnd,
-            asOf,
-          )
-        );
-      }, 0);
+      const durationSeconds = getIssueBounds(issue).reduce(
+        (total, interval) => {
+          return (
+            total +
+            overlapSeconds(
+              interval.start,
+              interval.end,
+              normalizedDate,
+              dayEnd,
+              asOf,
+            )
+          );
+        },
+        0,
+      );
 
       return {
         date: dateKey,
@@ -1618,7 +1681,9 @@ export async function rebuildOperationalFactsForDate(date: DateTime) {
     .filter((row) => row.active_anytime || row.active_end_of_day);
 
   const lineRows = Object.values(dataset.included.lines).map((line) => {
-    const lineIssues = issues.filter((issue) => issue.lineIds.includes(line.id));
+    const lineIssues = issues.filter((issue) =>
+      issue.lineIds.includes(line.id),
+    );
     const summary = buildLineSummary(
       line,
       lineIssues,
@@ -1648,10 +1713,12 @@ export async function rebuildOperationalFactsForDate(date: DateTime) {
               .seconds,
       ),
       downtime_disruption_seconds: Math.round(
-        dayBreakdown?.breakdownByIssueTypes.disruption?.totalDurationSeconds ?? 0,
+        dayBreakdown?.breakdownByIssueTypes.disruption?.totalDurationSeconds ??
+          0,
       ),
       downtime_maintenance_seconds: Math.round(
-        dayBreakdown?.breakdownByIssueTypes.maintenance?.totalDurationSeconds ?? 0,
+        dayBreakdown?.breakdownByIssueTypes.maintenance?.totalDurationSeconds ??
+          0,
       ),
       downtime_infra_seconds: Math.round(
         dayBreakdown?.breakdownByIssueTypes.infra?.totalDurationSeconds ?? 0,
@@ -1662,19 +1729,25 @@ export async function rebuildOperationalFactsForDate(date: DateTime) {
     };
   });
 
-  await db.delete(issueDayFactsTable).where(eq(issueDayFactsTable.date, dateKey));
-  await db.delete(lineDayFactsTable).where(eq(lineDayFactsTable.date, dateKey));
+  await db.transaction(async (tx) => {
+    await tx
+      .delete(issueDayFactsTable)
+      .where(eq(issueDayFactsTable.date, dateKey));
+    await tx
+      .delete(lineDayFactsTable)
+      .where(eq(lineDayFactsTable.date, dateKey));
 
-  for (const batch of chunk(issueRows, 500)) {
-    if (batch.length > 0) {
-      await db.insert(issueDayFactsTable).values(batch);
+    for (const batch of chunk(issueRows, 500)) {
+      if (batch.length > 0) {
+        await tx.insert(issueDayFactsTable).values(batch);
+      }
     }
-  }
-  for (const batch of chunk(lineRows, 500)) {
-    if (batch.length > 0) {
-      await db.insert(lineDayFactsTable).values(batch);
+    for (const batch of chunk(lineRows, 500)) {
+      if (batch.length > 0) {
+        await tx.insert(lineDayFactsTable).values(batch);
+      }
     }
-  }
+  });
 
   return {
     date: dateKey,
@@ -1683,9 +1756,16 @@ export async function rebuildOperationalFactsForDate(date: DateTime) {
   };
 }
 
-export async function rebuildOperationalFactsRange(days: number, end = nowSg()) {
+export async function rebuildOperationalFactsRange(
+  days: number,
+  end = nowSg(),
+) {
   const normalizedEnd = end.setZone(SG_TIMEZONE).startOf('day');
-  const results: Array<{ date: string; issueCount: number; lineCount: number }> = [];
+  const results: Array<{
+    date: string;
+    issueCount: number;
+    lineCount: number;
+  }> = [];
   for (let offset = days - 1; offset >= 0; offset--) {
     const date = normalizedEnd.minus({ days: offset });
     results.push(await rebuildOperationalFactsForDate(date));
@@ -1721,9 +1801,7 @@ export async function getOverviewData(days: number) {
 
   const overview: SystemOverview = {
     issueIdsActiveNow: issues
-      .filter(
-        (issue) => issue.type === 'disruption' && issueActiveNow(issue),
-      )
+      .filter((issue) => issue.type === 'disruption' && issueActiveNow(issue))
       .map((issue) => issue.id),
     issueIdsActiveToday: issues
       .filter(
@@ -1787,14 +1865,20 @@ export async function getLineProfileData(lineId: string, days: number) {
   )!;
   const issueIdsRecent = [...lineIssues]
     .filter((issue) =>
-      issue.intervals.some((interval) => parseDateTime(interval.startAt) <= nowSg()),
+      issue.intervals.some(
+        (interval) => parseDateTime(interval.startAt) <= nowSg(),
+      ),
     )
     .sort((a, b) => {
       const earliestA = Math.min(
-        ...a.intervals.map((interval) => parseDateTime(interval.startAt).toMillis()),
+        ...a.intervals.map((interval) =>
+          parseDateTime(interval.startAt).toMillis(),
+        ),
       );
       const earliestB = Math.min(
-        ...b.intervals.map((interval) => parseDateTime(interval.startAt).toMillis()),
+        ...b.intervals.map((interval) =>
+          parseDateTime(interval.startAt).toMillis(),
+        ),
       );
       return earliestB - earliestA;
     })
@@ -2050,10 +2134,7 @@ export async function getOperatorProfileData(operatorId: string, days: number) {
     yearsOfOperation: Math.max(
       0,
       Math.floor(
-        nowSg().diff(
-          parseDateTime(operator.foundedAt),
-          'years',
-        ).years,
+        nowSg().diff(parseDateTime(operator.foundedAt), 'years').years,
       ),
     ),
   };
@@ -2082,8 +2163,11 @@ export async function getHistoryYearSummaryData(year: number) {
     { zone: SG_TIMEZONE },
   ).startOf('day');
   const yearEnd = yearStart.plus({ years: 1 });
-  const factRows = await getIssueDayFactsInRange(yearStart, yearEnd.minus({ days: 1 }));
-  if (factRows.length > 0) {
+  const factRows = await getIssueDayFactsInRange(
+    yearStart,
+    yearEnd.minus({ days: 1 }),
+  );
+  if (hasFullDateCoverage(factRows, yearStart, yearEnd.minus({ days: 1 }))) {
     const dataset = await buildBaseDataset();
     const issueIds = [...new Set(factRows.map((row) => row.issue_id))];
     const summaryByMonth = Array.from({ length: 12 }, (_, index) => {
@@ -2168,7 +2252,7 @@ export async function getHistoryYearMonthData(year: number, month: number) {
     monthStart,
     monthEnd.minus({ days: 1 }),
   );
-  if (factRows.length > 0) {
+  if (hasFullDateCoverage(factRows, monthStart, monthEnd.minus({ days: 1 }))) {
     const dataset = await buildBaseDataset();
     const issueIds = [...new Set(factRows.map((row) => row.issue_id))];
     const weeks = new Map<string, string[]>();
@@ -2225,7 +2309,11 @@ export async function getHistoryYearMonthData(year: number, month: number) {
     const key = `${date.weekYear}-W${date.weekNumber.toString().padStart(2, '0')}`;
     const issueIds = issues
       .filter((issue) =>
-        issueOverlapsRange(issue, date.startOf('week'), date.startOf('week').plus({ week: 1 })),
+        issueOverlapsRange(
+          issue,
+          date.startOf('week'),
+          date.startOf('week').plus({ week: 1 }),
+        ),
       )
       .map((issue) => issue.id)
       .sort((a, b) => b.localeCompare(a));
@@ -2262,8 +2350,8 @@ export async function getHistoryDayData(
   const factRows = await getIssueDayFactsInRange(date, date);
   if (factRows.length > 0) {
     const dataset = await buildBaseDataset();
-    const issueIds = [...new Set(factRows.map((row) => row.issue_id))].sort((a, b) =>
-      b.localeCompare(a),
+    const issueIds = [...new Set(factRows.map((row) => row.issue_id))].sort(
+      (a, b) => b.localeCompare(a),
     );
     return {
       data: {
@@ -2279,7 +2367,9 @@ export async function getHistoryDayData(
   const issues = Object.values(dataset.allIssues).filter((issue) =>
     issueTouchesDate(issue, date),
   );
-  const issueIds = issues.map((issue) => issue.id).sort((a, b) => b.localeCompare(a));
+  const issueIds = issues
+    .map((issue) => issue.id)
+    .sort((a, b) => b.localeCompare(a));
 
   return {
     data: {
@@ -2296,7 +2386,15 @@ export async function getStatisticsData() {
   const issues = Object.values(dataset.allIssues);
   const rollingYearEnd = nowSg().startOf('day');
   const rollingYearStart = rollingYearEnd.minus({ days: 364 });
-  const issueFactRows = await getIssueDayFactsInRange(rollingYearStart, rollingYearEnd);
+  const issueFactRows = await getIssueDayFactsInRange(
+    rollingYearStart,
+    rollingYearEnd,
+  );
+  const hasIssueFactCoverage = hasFullDateCoverage(
+    issueFactRows,
+    rollingYearStart,
+    rollingYearEnd,
+  );
   const longestDisruptions = [...issues]
     .filter((issue) => issue.type === 'disruption')
     .sort((a, b) => b.durationSeconds - a.durationSeconds)
@@ -2306,7 +2404,9 @@ export async function getStatisticsData() {
   const chartTotalIssueCountByLine: Chart = {
     title: 'Issue Count by Line',
     data: Object.values(dataset.included.lines).map((line) => {
-      const lineIssues = issues.filter((issue) => issue.lineIds.includes(line.id));
+      const lineIssues = issues.filter((issue) =>
+        issue.lineIds.includes(line.id),
+      );
       const counts = pickIssueTypes(lineIssues);
       return {
         name: line.id,
@@ -2354,11 +2454,10 @@ export async function getStatisticsData() {
     title: 'Rolling Year Heatmap',
     data: Array.from({ length: 365 }, (_, index) => {
       const date = rollingYearStart.plus({ days: index }).toISODate()!;
-      const dayRows =
-        issueFactRows.length > 0
-          ? issueFactRows.filter((row) => row.date === date && row.active_anytime)
-          : [];
-      if (issueFactRows.length > 0) {
+      const dayRows = hasIssueFactCoverage
+        ? issueFactRows.filter((row) => row.date === date && row.active_anytime)
+        : [];
+      if (hasIssueFactCoverage) {
         return {
           name: date,
           payload: dayRows.reduce<Record<string, number>>(
@@ -2371,7 +2470,9 @@ export async function getStatisticsData() {
         };
       }
       const dayDate = DateTime.fromISO(date, { zone: SG_TIMEZONE });
-      const dayIssues = issues.filter((issue) => issueTouchesDate(issue, dayDate));
+      const dayIssues = issues.filter((issue) =>
+        issueTouchesDate(issue, dayDate),
+      );
       const counts = pickIssueTypes(dayIssues);
       return {
         name: date,
@@ -2386,10 +2487,9 @@ export async function getStatisticsData() {
 
   const statistics: SystemAnalytics = {
     timeScaleChartsIssueCount: buildIssueCountGraphs(issues),
-    timeScaleChartsIssueDuration:
-      issueFactRows.length > 0
-        ? buildDurationChartsFromIssueFacts(issueFactRows)
-        : buildIssueDurationGraphs(issues),
+    timeScaleChartsIssueDuration: hasIssueFactCoverage
+      ? buildDurationChartsFromIssueFacts(issueFactRows)
+      : buildIssueDurationGraphs(issues),
     chartTotalIssueCountByLine,
     chartTotalIssueCountByStation,
     chartRollingYearHeatmap,

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -85,6 +85,10 @@ function nowSg() {
 }
 
 function parseDateTime(value: string) {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return DateTime.fromISO(value, { zone: SG_TIMEZONE });
+  }
+
   const iso = DateTime.fromISO(value, { setZone: true });
   if (iso.isValid) {
     return iso.setZone(SG_TIMEZONE);

--- a/app/util/history.functions.ts
+++ b/app/util/history.functions.ts
@@ -2,10 +2,9 @@ import { createServerFn } from '@tanstack/react-start';
 import { DateTime } from 'luxon';
 import z from 'zod';
 import {
-  getIssuesHistoryYearMonth,
-  getIssuesHistoryYearSummary,
-} from '~/client';
-import { assert } from './assert';
+  getHistoryYearMonthData,
+  getHistoryYearSummaryData,
+} from './db.queries';
 
 const YearSchema = z.coerce.number().refine(
   (year) => {
@@ -24,24 +23,7 @@ const YearInputSchema = z.object({
 
 export const getIssuesHistoryYearFn = createServerFn({ method: 'GET' })
   .inputValidator(YearInputSchema)
-  .handler(async (val) => {
-    const { data, error } = await getIssuesHistoryYearSummary({
-      auth: () => process.env.API_TOKEN,
-      baseUrl: process.env.API_ENDPOINT,
-      path: {
-        year: val.data.year.toString(),
-      },
-    });
-    if (error != null) {
-      console.error('Error fetching issues for year:', error);
-      throw new Response('Failed to fetch issues for year', {
-        status: 500,
-        statusText: 'Internal Server Error',
-      });
-    }
-    assert(data != null);
-    return data;
-  });
+  .handler((val) => getHistoryYearSummaryData(val.data.year));
 
 const YearMonthInputSchema = z.object({
   year: YearSchema,
@@ -50,22 +32,4 @@ const YearMonthInputSchema = z.object({
 
 export const getIssuesHistoryYearMonthFn = createServerFn({ method: 'GET' })
   .inputValidator(YearMonthInputSchema)
-  .handler(async (val) => {
-    const { data, error } = await getIssuesHistoryYearMonth({
-      auth: () => process.env.API_TOKEN,
-      baseUrl: process.env.API_ENDPOINT,
-      path: {
-        year: val.data.year.toString(),
-        month: val.data.month.toString().padStart(2, '0'),
-      },
-    });
-    if (error != null) {
-      console.error('Error fetching issues for year-month:', error);
-      throw new Response('Failed to fetch issues for year-month', {
-        status: 500,
-        statusText: 'Internal Server Error',
-      });
-    }
-    assert(data != null);
-    return data;
-  });
+  .handler((val) => getHistoryYearMonthData(val.data.year, val.data.month));

--- a/app/util/issue.functions.ts
+++ b/app/util/issue.functions.ts
@@ -1,7 +1,6 @@
 import { createServerFn } from '@tanstack/react-start';
 import { z } from 'zod';
-import { getIssuesIssueId } from '~/client';
-import { assert } from './assert';
+import { getIssueData } from './db.queries';
 
 const InputSchema = z.object({
   issueId: z.string(),
@@ -10,22 +9,5 @@ const InputSchema = z.object({
 export const getIssueFn = createServerFn({ method: 'GET' })
   .inputValidator((val) => InputSchema.parse(val))
   .handler(async (val) => {
-    const { issueId } = val.data;
-
-    const { data, error } = await getIssuesIssueId({
-      auth: () => process.env.API_TOKEN,
-      baseUrl: process.env.API_ENDPOINT,
-      path: {
-        issueId,
-      },
-    });
-    if (error != null) {
-      console.error('Error fetching issue:', error);
-      throw new Response('Failed to fetch issue', {
-        status: 500,
-        statusText: 'Internal Server Error',
-      });
-    }
-    assert(data != null);
-    return data;
+    return getIssueData(val.data.issueId);
   });

--- a/app/util/lines.functions.ts
+++ b/app/util/lines.functions.ts
@@ -1,7 +1,6 @@
 import { createServerFn } from '@tanstack/react-start';
 import z from 'zod';
-import { getLinesLineIdProfile } from '~/client';
-import { assert } from './assert';
+import { getLineProfileData } from './db.queries';
 
 const InputSchema = z.object({
   lineId: z.string(),
@@ -11,25 +10,5 @@ const InputSchema = z.object({
 export const getLineProfileFn = createServerFn({ method: 'GET' })
   .inputValidator((val) => InputSchema.parse(val))
   .handler(async (val) => {
-    const { lineId } = val.data;
-
-    const { data, error } = await getLinesLineIdProfile({
-      auth: () => process.env.API_TOKEN,
-      baseUrl: process.env.API_ENDPOINT,
-      path: {
-        lineId,
-      },
-      query: {
-        days: val.data.days,
-      },
-    });
-    if (error != null) {
-      console.error('Error fetching line profile:', error);
-      throw new Response('Failed to fetch line profile', {
-        status: 500,
-        statusText: 'Internal Server Error',
-      });
-    }
-    assert(data != null);
-    return data;
+    return getLineProfileData(val.data.lineId, val.data.days);
   });

--- a/app/util/operator.functions.ts
+++ b/app/util/operator.functions.ts
@@ -1,7 +1,6 @@
 import { createServerFn } from '@tanstack/react-start';
 import { z } from 'zod';
-import { getOperatorsOperatorIdProfile } from '~/client/sdk.gen';
-import { assert } from './assert';
+import { getOperatorProfileData } from './db.queries';
 
 const InputSchema = z.object({
   operatorId: z.string(),
@@ -12,23 +11,6 @@ export const getOperatorProfileFn = createServerFn({ method: 'GET' })
   .inputValidator((val) => InputSchema.parse(val))
   .handler(async (val) => {
     const { operatorId, days } = val.data;
-    const { data, error, response } = await getOperatorsOperatorIdProfile({
-      auth: () => process.env.API_TOKEN,
-      baseUrl: process.env.API_ENDPOINT,
-      path: {
-        operatorId,
-      },
-      query: {
-        days,
-      },
-    });
-    if (error != null) {
-      console.error('Error fetching operator profile:', error);
-      throw new Response('Failed to fetch operator profile', {
-        status: response.status,
-        statusText: response.statusText,
-      });
-    }
-    assert(data != null);
+    const data = await getOperatorProfileData(operatorId, days);
     return { ...data, dateCount: days };
   });

--- a/app/util/overview.functions.ts
+++ b/app/util/overview.functions.ts
@@ -1,9 +1,8 @@
 import { createServerFn } from '@tanstack/react-start';
 import z from 'zod';
-import { getOverview } from '~/client';
 import { getDateCountForViewport } from '~/helpers/getDateCountForViewport';
 import { ViewportSchema } from '~/hooks/useViewport';
-import { assert } from './assert';
+import { getOverviewData } from './db.queries';
 
 const RequestSchema = z.object({
   viewport: ViewportSchema.optional(),
@@ -14,22 +13,5 @@ export const getOverviewFn = createServerFn({ method: 'GET' })
   .handler(async (val) => {
     const viewport = val.data.viewport ?? 'xs';
     const dateCount = getDateCountForViewport(viewport);
-
-    const { data, error } = await getOverview({
-      auth: () => process.env.API_TOKEN,
-      baseUrl: process.env.API_ENDPOINT,
-      query: {
-        days: dateCount,
-      },
-    });
-    if (error != null) {
-      console.error('Error fetching overview:', error);
-      throw new Response('Failed to fetch overview', {
-        status: 500,
-        statusText: 'Internal Server Error',
-      });
-    }
-    assert(data != null);
-
-    return data;
+    return getOverviewData(dateCount);
   });

--- a/app/util/root.functions.ts
+++ b/app/util/root.functions.ts
@@ -1,12 +1,6 @@
 import { createServerFn } from '@tanstack/react-start';
 import z from 'zod';
-import {
-  getLines,
-  getMetadata,
-  getOperators,
-  type IncludedEntities,
-} from '~/client';
-import { assert } from './assert';
+import { getRootData } from './db.queries';
 
 const InputSchema = z.object({
   lang: z.string().optional().default('en-SG'),
@@ -16,56 +10,8 @@ export const getRootFn = createServerFn({ method: 'GET' })
   .inputValidator((val) => InputSchema.parse(val))
   .handler(async (val) => {
     const { lang } = val.data;
-
-    const { data, error, response } = await getLines({
-      auth: () => process.env.API_TOKEN,
-      baseUrl: process.env.API_ENDPOINT,
-    });
-    if (error != null) {
-      console.error('Error fetching lines:', error);
-      throw new Response('Failed to fetch lines', {
-        status: response.status,
-        statusText: response.statusText,
-      });
-    }
-    assert(data != null);
-
-    const metadataResponse = await getMetadata({
-      auth: () => process.env.API_TOKEN,
-      baseUrl: process.env.API_ENDPOINT,
-    });
-    if (metadataResponse.error != null) {
-      console.error('Error fetching metadata:', metadataResponse.error);
-      throw new Response('Failed to fetch metadata', {
-        status: metadataResponse.response.status,
-        statusText: metadataResponse.response.statusText,
-      });
-    }
-    assert(metadataResponse.data != null);
-
-    const metadata = metadataResponse.data.data;
-
-    const { lineIds } = data.data;
-    const { included } = data;
-
-    const operatorsResponse = await getOperators({
-      auth: () => process.env.API_TOKEN,
-      baseUrl: process.env.API_ENDPOINT,
-    });
-    if (operatorsResponse.error != null) {
-      console.error('Error fetching operators:', operatorsResponse.error);
-      throw new Response('Failed to fetch operators', {
-        status: operatorsResponse.response.status,
-        statusText: operatorsResponse.response.statusText,
-      });
-    }
-    assert(operatorsResponse.data != null);
-    // Type assertion needed since GetOperatorsResponses[200] is unknown
-    const operatorsData = operatorsResponse.data as {
-      success: true;
-      included: IncludedEntities;
-      data: { operatorIds: Array<string> };
-    };
+    const { lineIds, included, metadata, operatorIds, operatorsIncluded } =
+      await getRootData();
 
     const { default: messages } = await import(`../../lang/${lang}.json`);
 
@@ -73,8 +19,8 @@ export const getRootFn = createServerFn({ method: 'GET' })
       lineIds,
       included,
       metadata,
-      operatorIds: operatorsData.data.operatorIds,
-      operatorsIncluded: operatorsData.included.operators,
+      operatorIds,
+      operatorsIncluded,
       messages,
     };
   });

--- a/app/util/sitemap.functions.ts
+++ b/app/util/sitemap.functions.ts
@@ -2,10 +2,9 @@ import { createServerFn } from '@tanstack/react-start';
 import { DateTime, Interval } from 'luxon';
 import type { Element, Root } from 'xast';
 import { toXml } from 'xast-util-to-xml';
-import { getIssues, getLines, getOperators, getStations } from '~/client';
 import { LANGUAGES_NON_DEFAULT } from '~/constants';
 import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
-import { assert } from './assert';
+import { getSitemapData } from './db.queries';
 
 function buildEntries(path: string, rootUrl: string): Element {
   return {
@@ -55,6 +54,8 @@ function buildEntries(path: string, rootUrl: string): Element {
 
 export const getSitemapFn = createServerFn({ method: 'GET' }).handler(
   async () => {
+    const { lineIds, stationIds, operatorIds, issueIds, monthEarliest, monthLatest } =
+      await getSitemapData();
     const paths: string[] = [
       '/',
       '/history',
@@ -63,106 +64,38 @@ export const getSitemapFn = createServerFn({ method: 'GET' }).handler(
       '/about',
     ];
 
-    // Lines
-    {
-      const { data, error, response } = await getLines({
-        auth: () => process.env.API_TOKEN,
-        baseUrl: process.env.API_ENDPOINT,
-      });
-      if (error != null) {
-        console.error('Error fetching lines:', error);
-        throw new Response('Failed to fetch lines', {
-          status: response.status,
-          statusText: response.statusText,
-        });
-      }
-      assert(data != null);
-      for (const lineId of data.data.lineIds) {
-        paths.push(`/lines/${lineId}`);
-      }
+    for (const lineId of lineIds) {
+      paths.push(`/lines/${lineId}`);
+    }
+    for (const stationId of stationIds) {
+      paths.push(`/stations/${stationId}`);
+    }
+    for (const operatorId of operatorIds) {
+      paths.push(`/operators/${operatorId}`);
+    }
+    for (const issueId of issueIds) {
+      paths.push(`/issues/${issueId}`);
     }
 
-    // Stations
-    {
-      const { data, error, response } = await getStations({
-        auth: () => process.env.API_TOKEN,
-        baseUrl: process.env.API_ENDPOINT,
-      });
-      if (error != null) {
-        console.error('Error fetching stations:', error);
-        throw new Response('Failed to fetch stations', {
-          status: response.status,
-          statusText: response.statusText,
-        });
-      }
-      assert(data != null);
-      for (const stationId of data.data.stationIds) {
-        paths.push(`/stations/${stationId}`);
-      }
-    }
-
-    // Operators
-    {
-      const { data, error, response } = await getOperators({
-        auth: () => process.env.API_TOKEN,
-        baseUrl: process.env.API_ENDPOINT,
-      });
-      if (error != null) {
-        console.error('Error fetching operators:', error);
-        throw new Response('Failed to fetch operators', {
-          status: response.status,
-          statusText: response.statusText,
-        });
-      }
-      assert(data != null);
-      // Type assertion needed since GetOperatorsResponses[200] is unknown
-      const operatorsResponse = data as {
-        success: true;
-        included: unknown;
-        data: { operatorIds: Array<string> };
-      };
-      for (const operatorId of operatorsResponse.data.operatorIds) {
-        paths.push(`/operators/${operatorId}`);
-      }
-    }
-
-    // Issue pages
-    {
-      const { data, error, response } = await getIssues({
-        auth: () => process.env.API_TOKEN,
-        baseUrl: process.env.API_ENDPOINT,
-      });
-      if (error != null) {
-        console.error('Error fetching issues:', error);
-        throw new Response('Failed to fetch issues', {
-          status: response.status,
-          statusText: response.statusText,
-        });
-      }
-      assert(data != null);
-      for (const issueId of data.data.issueIds) {
-        paths.push(`/issues/${issueId}`);
+    const monthEarliestDateTime = DateTime.fromISO(monthEarliest);
+    const monthLatestDateTime = DateTime.fromISO(monthLatest);
+    const interval = Interval.fromDateTimes(
+      monthEarliestDateTime,
+      monthLatestDateTime.plus({ month: 1 }),
+    );
+    for (const monthInterval of interval.splitBy({ month: 1 })) {
+      const monthDateTime = monthInterval.start;
+      if (monthDateTime == null) {
+        continue;
       }
 
-      const monthEarliestDateTime = DateTime.fromISO(data.data.monthEarliest);
-      const monthLatestDateTime = DateTime.fromISO(data.data.monthLatest);
+      if (!paths.includes(`/history/${monthDateTime.toFormat('yyyy')}`)) {
+        paths.push(`/history/${monthDateTime.toFormat('yyyy')}`);
+      }
 
-      const interval = Interval.fromDateTimes(
-        monthEarliestDateTime,
-        monthLatestDateTime,
+      paths.push(
+        `/history/${monthDateTime.toFormat('yyyy')}/${monthDateTime.toFormat('MM')}`,
       );
-      for (const monthInterval of interval.splitBy({ month: 1 })) {
-        const monthDateTime = monthInterval.start;
-        assert(monthDateTime != null);
-
-        if (!paths.includes(`/history/${monthDateTime.toFormat('yyyy')}`)) {
-          paths.push(`/history/${monthDateTime.toFormat('yyyy')}`);
-        }
-
-        paths.push(
-          `/history/${monthDateTime.toFormat('yyyy')}/${monthDateTime.toFormat('MM')}`,
-        );
-      }
     }
 
     const elementUrlSet: Element = {

--- a/app/util/station.functions.ts
+++ b/app/util/station.functions.ts
@@ -1,7 +1,6 @@
 import { createServerFn } from '@tanstack/react-start';
 import { z } from 'zod';
-import { getStationsStationIdProfile } from '~/client';
-import { assert } from './assert';
+import { getStationProfileData } from './db.queries';
 
 const InputSchema = z.object({
   stationId: z.string(),
@@ -9,23 +8,4 @@ const InputSchema = z.object({
 
 export const getStationProfileFn = createServerFn({ method: 'GET' })
   .inputValidator((val) => InputSchema.parse(val))
-  .handler(async (val) => {
-    const { stationId } = val.data;
-
-    const { data, error } = await getStationsStationIdProfile({
-      auth: () => process.env.API_TOKEN,
-      baseUrl: process.env.API_ENDPOINT,
-      path: {
-        stationId,
-      },
-    });
-    if (error != null) {
-      console.error('Error fetching station profile:', error);
-      throw new Response('Failed to fetch station profile', {
-        status: 500,
-        statusText: 'Internal Server Error',
-      });
-    }
-    assert(data != null);
-    return data;
-  });
+  .handler((val) => getStationProfileData(val.data.stationId));

--- a/app/util/statistics.functions.ts
+++ b/app/util/statistics.functions.ts
@@ -1,21 +1,6 @@
 import { createServerFn } from '@tanstack/react-start';
-import { getAnalytics } from '~/client';
-import { assert } from './assert';
+import { getStatisticsData } from './db.queries';
 
 export const getStatisticsFn = createServerFn({ method: 'GET' }).handler(
-  async () => {
-    const { data, error } = await getAnalytics({
-      auth: () => process.env.API_TOKEN,
-      baseUrl: process.env.API_ENDPOINT,
-    });
-    if (error != null) {
-      console.error('Error fetching analytics:', error);
-      throw new Response('Failed to fetch analytics', {
-        status: 500,
-        statusText: 'Internal Server Error',
-      });
-    }
-    assert(data != null);
-    return data;
-  },
+  () => getStatisticsData(),
 );

--- a/app/util/system-map.functions.ts
+++ b/app/util/system-map.functions.ts
@@ -1,64 +1,6 @@
 import { createServerFn } from '@tanstack/react-start';
-import { getOverview, getStations } from '~/client';
-import { assert } from './assert';
+import { getSystemMapData } from './db.queries';
 
-export const getSystemMapFn = createServerFn({ method: 'GET' }).handler(
-  async () => {
-    const activeIssuesResponse = await getOverview({
-      auth: () => process.env.API_TOKEN,
-      baseUrl: process.env.API_ENDPOINT,
-    });
-    if (activeIssuesResponse.error != null) {
-      console.error(
-        'Error fetching active issues:',
-        activeIssuesResponse.error,
-      );
-      throw new Response('Failed to fetch active issues', {
-        status: 500,
-        statusText: 'Internal Server Error',
-      });
-    }
-    assert(activeIssuesResponse.data != null);
-
-    const { data: overview } = activeIssuesResponse.data;
-
-    const stationsResponse = await getStations({
-      auth: () => process.env.API_TOKEN,
-      baseUrl: process.env.API_ENDPOINT,
-    });
-    if (stationsResponse.error != null) {
-      console.error('Error fetching stations:', stationsResponse.error);
-      throw new Response('Failed to fetch stations', {
-        status: 500,
-        statusText: 'Internal Server Error',
-      });
-    }
-    assert(stationsResponse.data != null);
-
-    return {
-      overview,
-      included: {
-        issues: {
-          ...activeIssuesResponse.data.included.issues,
-          ...stationsResponse.data.included.issues,
-        },
-        landmarks: {
-          ...activeIssuesResponse.data.included.landmarks,
-          ...stationsResponse.data.included.landmarks,
-        },
-        lines: {
-          ...activeIssuesResponse.data.included.lines,
-          ...stationsResponse.data.included.lines,
-        },
-        stations: {
-          ...activeIssuesResponse.data.included.stations,
-          ...stationsResponse.data.included.stations,
-        },
-        towns: {
-          ...activeIssuesResponse.data.included.towns,
-          ...stationsResponse.data.included.towns,
-        },
-      },
-    };
-  },
+export const getSystemMapFn = createServerFn({ method: 'GET' }).handler(() =>
+  getSystemMapData(),
 );

--- a/drizzle/0002_fair_marvel_boy.sql
+++ b/drizzle/0002_fair_marvel_boy.sql
@@ -1,0 +1,38 @@
+CREATE TABLE "issue_day_facts" (
+	"date" date NOT NULL,
+	"issue_id" text NOT NULL,
+	"issue_type" "issue_type" NOT NULL,
+	"as_of" timestamp with time zone NOT NULL,
+	"active_anytime" boolean NOT NULL,
+	"active_end_of_day" boolean NOT NULL,
+	"duration_seconds" integer NOT NULL,
+	"inferred_interval_count" integer NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "issue_day_facts_date_issue_id_pk" PRIMARY KEY("date","issue_id")
+);
+--> statement-breakpoint
+CREATE TABLE "line_day_facts" (
+	"date" date NOT NULL,
+	"line_id" text NOT NULL,
+	"as_of" timestamp with time zone NOT NULL,
+	"service_seconds" integer NOT NULL,
+	"downtime_disruption_seconds" integer NOT NULL,
+	"downtime_maintenance_seconds" integer NOT NULL,
+	"downtime_infra_seconds" integer NOT NULL,
+	"issue_count_disruption" integer NOT NULL,
+	"issue_count_maintenance" integer NOT NULL,
+	"issue_count_infra" integer NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "line_day_facts_date_line_id_pk" PRIMARY KEY("date","line_id")
+);
+--> statement-breakpoint
+ALTER TABLE "issue_day_facts" ADD CONSTRAINT "issue_day_facts_issue_id_issues_id_fk" FOREIGN KEY ("issue_id") REFERENCES "public"."issues"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "line_day_facts" ADD CONSTRAINT "line_day_facts_line_id_lines_id_fk" FOREIGN KEY ("line_id") REFERENCES "public"."lines"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "issue_day_facts_issue_id_idx" ON "issue_day_facts" USING btree ("issue_id");--> statement-breakpoint
+CREATE INDEX "issue_day_facts_date_issue_type_idx" ON "issue_day_facts" USING btree ("date","issue_type");--> statement-breakpoint
+CREATE INDEX "issue_day_facts_as_of_idx" ON "issue_day_facts" USING btree ("as_of");--> statement-breakpoint
+CREATE INDEX "line_day_facts_line_id_idx" ON "line_day_facts" USING btree ("line_id");--> statement-breakpoint
+CREATE INDEX "line_day_facts_date_idx" ON "line_day_facts" USING btree ("date");--> statement-breakpoint
+CREATE INDEX "line_day_facts_as_of_idx" ON "line_day_facts" USING btree ("as_of");

--- a/drizzle/0002_fair_marvel_boy.sql
+++ b/drizzle/0002_fair_marvel_boy.sql
@@ -28,8 +28,8 @@ CREATE TABLE "line_day_facts" (
 	CONSTRAINT "line_day_facts_date_line_id_pk" PRIMARY KEY("date","line_id")
 );
 --> statement-breakpoint
-ALTER TABLE "issue_day_facts" ADD CONSTRAINT "issue_day_facts_issue_id_issues_id_fk" FOREIGN KEY ("issue_id") REFERENCES "public"."issues"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "line_day_facts" ADD CONSTRAINT "line_day_facts_line_id_lines_id_fk" FOREIGN KEY ("line_id") REFERENCES "public"."lines"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "issue_day_facts" ADD CONSTRAINT "issue_day_facts_issue_id_issues_id_fk" FOREIGN KEY ("issue_id") REFERENCES "public"."issues"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+ALTER TABLE "line_day_facts" ADD CONSTRAINT "line_day_facts_line_id_lines_id_fk" FOREIGN KEY ("line_id") REFERENCES "public"."lines"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
 CREATE INDEX "issue_day_facts_issue_id_idx" ON "issue_day_facts" USING btree ("issue_id");--> statement-breakpoint
 CREATE INDEX "issue_day_facts_date_issue_type_idx" ON "issue_day_facts" USING btree ("date","issue_type");--> statement-breakpoint
 CREATE INDEX "issue_day_facts_as_of_idx" ON "issue_day_facts" USING btree ("as_of");--> statement-breakpoint

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,2999 @@
+{
+  "id": "52eaf43c-c91b-46cb-b8b0-090601aec53b",
+  "prevId": "ae29e7d2-7f12-4bb8-8ef6-c7cff5a26183",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.evidences": {
+      "name": "evidences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "evidence_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "render": {
+          "name": "render",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "evidences_issue_id_idx": {
+          "name": "evidences_issue_id_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "evidences_ts_idx": {
+          "name": "evidences_ts_idx",
+          "columns": [
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evidences_issue_id_issues_id_fk": {
+          "name": "evidences_issue_id_issues_id_fk",
+          "tableFrom": "evidences",
+          "tableTo": "issues",
+          "columnsFrom": ["issue_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_basis_evidences": {
+      "name": "impact_event_basis_evidences",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_id": {
+          "name": "evidence_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_basis_evidences_impact_event_id_idx": {
+          "name": "impact_event_basis_evidences_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_basis_evidences_evidence_id_idx": {
+          "name": "impact_event_basis_evidences_evidence_id_idx",
+          "columns": [
+            {
+              "expression": "evidence_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_event_basis_evidences_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_basis_evidences_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_basis_evidences",
+          "tableTo": "impact_events",
+          "columnsFrom": ["impact_event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "impact_event_basis_evidences_evidence_id_evidences_id_fk": {
+          "name": "impact_event_basis_evidences_evidence_id_evidences_id_fk",
+          "tableFrom": "impact_event_basis_evidences",
+          "tableTo": "evidences",
+          "columnsFrom": ["evidence_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_basis_evidences_impact_event_id_evidence_id_pk": {
+          "name": "impact_event_basis_evidences_impact_event_id_evidence_id_pk",
+          "columns": ["impact_event_id", "evidence_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_causes": {
+      "name": "impact_event_causes",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "impact_event_cause_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_causes_impact_event_id_idx": {
+          "name": "impact_event_causes_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_event_causes_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_causes_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_causes",
+          "tableTo": "impact_events",
+          "columnsFrom": ["impact_event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_causes_impact_event_id_type_pk": {
+          "name": "impact_event_causes_impact_event_id_type_pk",
+          "columns": ["impact_event_id", "type"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_entity_facilities": {
+      "name": "impact_event_entity_facilities",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "affected_entity_facility_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_entity_facilities_impact_event_id_idx": {
+          "name": "impact_event_entity_facilities_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_entity_facilities_station_id_idx": {
+          "name": "impact_event_entity_facilities_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_event_entity_facilities_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_entity_facilities_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_entity_facilities",
+          "tableTo": "impact_events",
+          "columnsFrom": ["impact_event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "impact_event_entity_facilities_station_id_stations_id_fk": {
+          "name": "impact_event_entity_facilities_station_id_stations_id_fk",
+          "tableFrom": "impact_event_entity_facilities",
+          "tableTo": "stations",
+          "columnsFrom": ["station_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_entity_facilities_impact_event_id_station_id_kind_pk": {
+          "name": "impact_event_entity_facilities_impact_event_id_station_id_kind_pk",
+          "columns": ["impact_event_id", "station_id", "kind"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_entity_services": {
+      "name": "impact_event_entity_services",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_entity_services_impact_event_id_idx": {
+          "name": "impact_event_entity_services_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_entity_services_service_id_idx": {
+          "name": "impact_event_entity_services_service_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_event_entity_services_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_entity_services_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_entity_services",
+          "tableTo": "impact_events",
+          "columnsFrom": ["impact_event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "impact_event_entity_services_service_id_services_id_fk": {
+          "name": "impact_event_entity_services_service_id_services_id_fk",
+          "tableFrom": "impact_event_entity_services",
+          "tableTo": "services",
+          "columnsFrom": ["service_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_entity_services_impact_event_id_service_id_pk": {
+          "name": "impact_event_entity_services_impact_event_id_service_id_pk",
+          "columns": ["impact_event_id", "service_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_facility_effects": {
+      "name": "impact_event_facility_effects",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "facility_effect_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_facility_effects_impact_event_id_idx": {
+          "name": "impact_event_facility_effects_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_facility_effects_kind_idx": {
+          "name": "impact_event_facility_effects_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_event_facility_effects_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_facility_effects_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_facility_effects",
+          "tableTo": "impact_events",
+          "columnsFrom": ["impact_event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_facility_effects_impact_event_id_kind_pk": {
+          "name": "impact_event_facility_effects_impact_event_id_kind_pk",
+          "columns": ["impact_event_id", "kind"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_periods": {
+      "name": "impact_event_periods",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "resolve_periods_mode_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_ts": {
+          "name": "start_ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_ts": {
+          "name": "end_ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_ts_resolved": {
+          "name": "end_ts_resolved",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at_source": {
+          "name": "end_at_source",
+          "type": "resolve_periods_end_at_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at_reason": {
+          "name": "end_at_reason",
+          "type": "resolve_periods_end_at_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_periods_set_periods_impact_event_id_idx": {
+          "name": "impact_event_periods_set_periods_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_periods_mode_idx": {
+          "name": "impact_event_periods_mode_idx",
+          "columns": [
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_periods_start_at_idx": {
+          "name": "impact_event_periods_start_at_idx",
+          "columns": [
+            {
+              "expression": "start_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_periods_end_at_idx": {
+          "name": "impact_event_periods_end_at_idx",
+          "columns": [
+            {
+              "expression": "end_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_periods_end_at_resolved_idx": {
+          "name": "impact_event_periods_end_at_resolved_idx",
+          "columns": [
+            {
+              "expression": "end_ts_resolved",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_periods_end_at_source_idx": {
+          "name": "impact_event_periods_end_at_source_idx",
+          "columns": [
+            {
+              "expression": "end_at_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_periods_end_at_reason_idx": {
+          "name": "impact_event_periods_end_at_reason_idx",
+          "columns": [
+            {
+              "expression": "end_at_reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_event_periods_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_periods_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_periods",
+          "tableTo": "impact_events",
+          "columnsFrom": ["impact_event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_periods_impact_event_id_index_mode_pk": {
+          "name": "impact_event_periods_impact_event_id_index_mode_pk",
+          "columns": ["impact_event_id", "index", "mode"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_service_effects": {
+      "name": "impact_event_service_effects",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "service_effect_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "interval",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_service_effects_impact_event_id_idx": {
+          "name": "impact_event_service_effects_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_service_effects_kind_idx": {
+          "name": "impact_event_service_effects_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_event_service_effects_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_service_effects_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_service_effects",
+          "tableTo": "impact_events",
+          "columnsFrom": ["impact_event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_service_effects_impact_event_id_kind_pk": {
+          "name": "impact_event_service_effects_impact_event_id_kind_pk",
+          "columns": ["impact_event_id", "kind"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_service_scopes": {
+      "name": "impact_event_service_scopes",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "impact_event_service_scope_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_station_id": {
+          "name": "from_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_station_id": {
+          "name": "to_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_service_scopes_impact_event_id_idx": {
+          "name": "impact_event_service_scopes_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_service_scopes_type_idx": {
+          "name": "impact_event_service_scopes_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_service_scopes_station_id_idx": {
+          "name": "impact_event_service_scopes_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_service_scopes_from_station_id_idx": {
+          "name": "impact_event_service_scopes_from_station_id_idx",
+          "columns": [
+            {
+              "expression": "from_station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_service_scopes_to_station_id_idx": {
+          "name": "impact_event_service_scopes_to_station_id_idx",
+          "columns": [
+            {
+              "expression": "to_station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_event_service_scopes_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_service_scopes_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_service_scopes",
+          "tableTo": "impact_events",
+          "columnsFrom": ["impact_event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "impact_event_service_scopes_station_id_stations_id_fk": {
+          "name": "impact_event_service_scopes_station_id_stations_id_fk",
+          "tableFrom": "impact_event_service_scopes",
+          "tableTo": "stations",
+          "columnsFrom": ["station_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "impact_event_service_scopes_from_station_id_stations_id_fk": {
+          "name": "impact_event_service_scopes_from_station_id_stations_id_fk",
+          "tableFrom": "impact_event_service_scopes",
+          "tableTo": "stations",
+          "columnsFrom": ["from_station_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "impact_event_service_scopes_to_station_id_stations_id_fk": {
+          "name": "impact_event_service_scopes_to_station_id_stations_id_fk",
+          "tableFrom": "impact_event_service_scopes",
+          "tableTo": "stations",
+          "columnsFrom": ["to_station_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_service_scopes_impact_event_id_index_pk": {
+          "name": "impact_event_service_scopes_impact_event_id_index_pk",
+          "columns": ["impact_event_id", "index"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "impact_event_service_scopes_type_station_shape_check": {
+          "name": "impact_event_service_scopes_type_station_shape_check",
+          "value": "\n          (\n            \"impact_event_service_scopes\".\"type\" = 'service.whole'\n            and \"impact_event_service_scopes\".\"station_id\" is null\n            and \"impact_event_service_scopes\".\"from_station_id\" is null\n            and \"impact_event_service_scopes\".\"to_station_id\" is null\n          )\n          or (\n            \"impact_event_service_scopes\".\"type\" = 'service.point'\n            and \"impact_event_service_scopes\".\"station_id\" is not null\n            and \"impact_event_service_scopes\".\"from_station_id\" is null\n            and \"impact_event_service_scopes\".\"to_station_id\" is null\n          )\n          or (\n            \"impact_event_service_scopes\".\"type\" = 'service.segment'\n            and \"impact_event_service_scopes\".\"station_id\" is null\n            and \"impact_event_service_scopes\".\"from_station_id\" is not null\n            and \"impact_event_service_scopes\".\"to_station_id\" is not null\n          )\n        "
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.impact_events": {
+      "name": "impact_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_events_issue_id_idx": {
+          "name": "impact_events_issue_id_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_events_issue_id_issues_id_fk": {
+          "name": "impact_events_issue_id_issues_id_fk",
+          "tableFrom": "impact_events",
+          "tableTo": "issues",
+          "columnsFrom": ["issue_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_day_facts": {
+      "name": "issue_day_facts",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "issue_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_anytime": {
+          "name": "active_anytime",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_end_of_day": {
+          "name": "active_end_of_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inferred_interval_count": {
+          "name": "inferred_interval_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_day_facts_issue_id_idx": {
+          "name": "issue_day_facts_issue_id_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_day_facts_date_issue_type_idx": {
+          "name": "issue_day_facts_date_issue_type_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_day_facts_as_of_idx": {
+          "name": "issue_day_facts_as_of_idx",
+          "columns": [
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_day_facts_issue_id_issues_id_fk": {
+          "name": "issue_day_facts_issue_id_issues_id_fk",
+          "tableFrom": "issue_day_facts",
+          "tableTo": "issues",
+          "columnsFrom": ["issue_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_day_facts_date_issue_id_pk": {
+          "name": "issue_day_facts_date_issue_id_pk",
+          "columns": ["date", "issue_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues_next": {
+      "name": "issues_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "issue_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_meta": {
+          "name": "title_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidences": {
+          "name": "evidences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impact_events": {
+          "name": "impact_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "issue_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_meta": {
+          "name": "title_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.landmarks_next": {
+      "name": "landmarks_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.landmarks": {
+      "name": "landmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.line_day_facts": {
+      "name": "line_day_facts",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_seconds": {
+          "name": "service_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downtime_disruption_seconds": {
+          "name": "downtime_disruption_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downtime_maintenance_seconds": {
+          "name": "downtime_maintenance_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downtime_infra_seconds": {
+          "name": "downtime_infra_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_count_disruption": {
+          "name": "issue_count_disruption",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_count_maintenance": {
+          "name": "issue_count_maintenance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_count_infra": {
+          "name": "issue_count_infra",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "line_day_facts_line_id_idx": {
+          "name": "line_day_facts_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "line_day_facts_date_idx": {
+          "name": "line_day_facts_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "line_day_facts_as_of_idx": {
+          "name": "line_day_facts_as_of_idx",
+          "columns": [
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "line_day_facts_line_id_lines_id_fk": {
+          "name": "line_day_facts_line_id_lines_id_fk",
+          "tableFrom": "line_day_facts",
+          "tableTo": "lines",
+          "columnsFrom": ["line_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "line_day_facts_date_line_id_pk": {
+          "name": "line_day_facts_date_line_id_pk",
+          "columns": ["date", "line_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.line_operators": {
+      "name": "line_operators",
+      "schema": "",
+      "columns": {
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator_id": {
+          "name": "operator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "line_operators_line_id_idx": {
+          "name": "line_operators_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "line_operators_operator_id_idx": {
+          "name": "line_operators_operator_id_idx",
+          "columns": [
+            {
+              "expression": "operator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "line_operators_line_id_lines_id_fk": {
+          "name": "line_operators_line_id_lines_id_fk",
+          "tableFrom": "line_operators",
+          "tableTo": "lines",
+          "columnsFrom": ["line_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "line_operators_operator_id_operators_id_fk": {
+          "name": "line_operators_operator_id_operators_id_fk",
+          "tableFrom": "line_operators",
+          "tableTo": "operators",
+          "columnsFrom": ["operator_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "line_operators_line_id_operator_id_pk": {
+          "name": "line_operators_line_id_operator_id_pk",
+          "columns": ["line_id", "operator_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.line_services": {
+      "name": "line_services",
+      "schema": "",
+      "columns": {
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "line_services_line_id_idx": {
+          "name": "line_services_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "line_services_service_id_idx": {
+          "name": "line_services_service_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "line_services_line_id_lines_id_fk": {
+          "name": "line_services_line_id_lines_id_fk",
+          "tableFrom": "line_services",
+          "tableTo": "lines",
+          "columnsFrom": ["line_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "line_services_service_id_services_id_fk": {
+          "name": "line_services_service_id_services_id_fk",
+          "tableFrom": "line_services",
+          "tableTo": "services",
+          "columnsFrom": ["service_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "line_services_line_id_service_id_pk": {
+          "name": "line_services_line_id_service_id_pk",
+          "columns": ["line_id", "service_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lines_next": {
+      "name": "lines_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "line_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operating_hours": {
+          "name": "operating_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operators": {
+          "name": "operators",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lines": {
+      "name": "lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "line_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operating_hours": {
+          "name": "operating_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metadata": {
+      "name": "metadata",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operators_next": {
+      "name": "operators_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "founded_at": {
+          "name": "founded_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operators": {
+      "name": "operators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "founded_at": {
+          "name": "founded_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.public_holidays": {
+      "name": "public_holidays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "holiday_name": {
+          "name": "holiday_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_revision_path_station_entries": {
+      "name": "service_revision_path_station_entries",
+      "schema": "",
+      "columns": {
+        "service_revision_id": {
+          "name": "service_revision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_code": {
+          "name": "display_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_index": {
+          "name": "path_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "service_revision_path_entries_service_revision_id_idx": {
+          "name": "service_revision_path_entries_service_revision_id_idx",
+          "columns": [
+            {
+              "expression": "service_revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_revision_path_entries_service_id_idx": {
+          "name": "service_revision_path_entries_service_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_revision_path_entries_station_id_idx": {
+          "name": "service_revision_path_entries_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_revision_path_entries_path_index_idx": {
+          "name": "service_revision_path_entries_path_index_idx",
+          "columns": [
+            {
+              "expression": "path_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sr_path_entries_revision_fk": {
+          "name": "sr_path_entries_revision_fk",
+          "tableFrom": "service_revision_path_station_entries",
+          "tableTo": "service_revisions",
+          "columnsFrom": ["service_revision_id", "service_id"],
+          "columnsTo": ["id", "service_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sr_path_entries_station_fk": {
+          "name": "sr_path_entries_station_fk",
+          "tableFrom": "service_revision_path_station_entries",
+          "tableTo": "stations",
+          "columnsFrom": ["station_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "sr_path_entries_pk": {
+          "name": "sr_path_entries_pk",
+          "columns": [
+            "service_revision_id",
+            "service_id",
+            "station_id",
+            "path_index"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_revisions": {
+      "name": "service_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operating_hours": {
+          "name": "operating_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "service_revisions_service_id_idx": {
+          "name": "service_revisions_service_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_revisions_service_id_services_id_fk": {
+          "name": "service_revisions_service_id_services_id_fk",
+          "tableFrom": "service_revisions",
+          "tableTo": "services",
+          "columnsFrom": ["service_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "service_revisions_id_service_id_pk": {
+          "name": "service_revisions_id_service_id_pk",
+          "columns": ["id", "service_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services_next": {
+      "name": "services_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revisions": {
+          "name": "revisions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "services_line_id_idx": {
+          "name": "services_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "services_line_id_lines_id_fk": {
+          "name": "services_line_id_lines_id_fk",
+          "tableFrom": "services",
+          "tableTo": "lines",
+          "columnsFrom": ["line_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_codes": {
+      "name": "station_codes",
+      "schema": "",
+      "columns": {
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structure_type": {
+          "name": "structure_type",
+          "type": "station_structure_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_codes_line_id_idx": {
+          "name": "station_codes_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_codes_station_id_idx": {
+          "name": "station_codes_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "station_codes_line_id_lines_id_fk": {
+          "name": "station_codes_line_id_lines_id_fk",
+          "tableFrom": "station_codes",
+          "tableTo": "lines",
+          "columnsFrom": ["line_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "station_codes_station_id_stations_id_fk": {
+          "name": "station_codes_station_id_stations_id_fk",
+          "tableFrom": "station_codes",
+          "tableTo": "stations",
+          "columnsFrom": ["station_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "station_codes_line_id_station_id_code_pk": {
+          "name": "station_codes_line_id_station_id_code_pk",
+          "columns": ["line_id", "station_id", "code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_landmarks": {
+      "name": "station_landmarks",
+      "schema": "",
+      "columns": {
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "landmark_id": {
+          "name": "landmark_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_landmarks_station_id_idx": {
+          "name": "station_landmarks_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_landmarks_landmark_id_idx": {
+          "name": "station_landmarks_landmark_id_idx",
+          "columns": [
+            {
+              "expression": "landmark_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "station_landmarks_station_id_stations_id_fk": {
+          "name": "station_landmarks_station_id_stations_id_fk",
+          "tableFrom": "station_landmarks",
+          "tableTo": "stations",
+          "columnsFrom": ["station_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "station_landmarks_landmark_id_landmarks_id_fk": {
+          "name": "station_landmarks_landmark_id_landmarks_id_fk",
+          "tableFrom": "station_landmarks",
+          "tableTo": "landmarks",
+          "columnsFrom": ["landmark_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "station_landmarks_station_id_landmark_id_pk": {
+          "name": "station_landmarks_station_id_landmark_id_pk",
+          "columns": ["station_id", "landmark_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations_next": {
+      "name": "stations_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geo": {
+          "name": "geo",
+          "type": "geometry(point)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "town_id": {
+          "name": "town_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_codes": {
+          "name": "station_codes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "landmark_ids": {
+          "name": "landmark_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "stations_next_geo_idx": {
+          "name": "stations_next_geo_idx",
+          "columns": [
+            {
+              "expression": "geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geo": {
+          "name": "geo",
+          "type": "geometry(point)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "town_id": {
+          "name": "town_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stations_geo_idx": {
+          "name": "stations_geo_idx",
+          "columns": [
+            {
+              "expression": "geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stations_town_id_towns_id_fk": {
+          "name": "stations_town_id_towns_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "towns",
+          "columnsFrom": ["town_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towns_next": {
+      "name": "towns_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towns": {
+      "name": "towns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.affected_entity_facility_kind": {
+      "name": "affected_entity_facility_kind",
+      "schema": "public",
+      "values": ["lift", "escalator", "screen-door"]
+    },
+    "public.evidence_type": {
+      "name": "evidence_type",
+      "schema": "public",
+      "values": ["statement.official", "report.public", "report.media"]
+    },
+    "public.facility_effect_kind": {
+      "name": "facility_effect_kind",
+      "schema": "public",
+      "values": ["out-of-service", "degraded"]
+    },
+    "public.impact_event_cause_type": {
+      "name": "impact_event_cause_type",
+      "schema": "public",
+      "values": [
+        "signal.fault",
+        "track.fault",
+        "train.fault",
+        "power.fault",
+        "station.fault",
+        "security",
+        "weather",
+        "passenger.incident",
+        "platform_door.fault",
+        "delay",
+        "track.work",
+        "system.upgrade",
+        "elevator.outage",
+        "escalator.outage",
+        "air_conditioning.issue",
+        "station.renovation"
+      ]
+    },
+    "public.impact_event_service_scope_type": {
+      "name": "impact_event_service_scope_type",
+      "schema": "public",
+      "values": ["service.whole", "service.segment", "service.point"]
+    },
+    "public.issue_type": {
+      "name": "issue_type",
+      "schema": "public",
+      "values": ["disruption", "maintenance", "infra"]
+    },
+    "public.line_type": {
+      "name": "line_type",
+      "schema": "public",
+      "values": ["mrt.high", "mrt.medium", "lrt"]
+    },
+    "public.resolve_periods_end_at_reason": {
+      "name": "resolve_periods_end_at_reason",
+      "schema": "public",
+      "values": ["crowd_decay", "evidence_timeout"]
+    },
+    "public.resolve_periods_end_at_source": {
+      "name": "resolve_periods_end_at_source",
+      "schema": "public",
+      "values": ["fact", "inferred", "none"]
+    },
+    "public.resolve_periods_mode_kind": {
+      "name": "resolve_periods_mode_kind",
+      "schema": "public",
+      "values": ["canonical", "operational"]
+    },
+    "public.service_effect_kind": {
+      "name": "service_effect_kind",
+      "schema": "public",
+      "values": [
+        "delay",
+        "no-service",
+        "reduced-service",
+        "service-hours-adjustment"
+      ]
+    },
+    "public.station_structure_type": {
+      "name": "station_structure_type",
+      "schema": "public",
+      "values": ["elevated", "underground", "at_grade", "in_building"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1250,8 +1250,8 @@
           "tableTo": "issues",
           "columnsFrom": ["issue_id"],
           "columnsTo": ["id"],
-          "onDelete": "no action",
-          "onUpdate": "no action"
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
         }
       },
       "compositePrimaryKeys": {
@@ -1588,8 +1588,8 @@
           "tableTo": "lines",
           "columnsFrom": ["line_id"],
           "columnsTo": ["id"],
-          "onDelete": "no action",
-          "onUpdate": "no action"
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
         }
       },
       "compositePrimaryKeys": {

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1775689814276,
       "tag": "0001_absurd_lenny_balinger",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1778985209341,
+      "tag": "0002_fair_marvel_boy",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -12,9 +12,12 @@
     "test": "vitest",
     "dev:pull": "curl -i -X POST http://localhost:3000/internal/api/tasks/pull",
     "api:client:generate": "tsx app/scripts/generateApiClient.ts",
+    "db:reset": "tsx app/scripts/resetDatabase.ts",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
+    "db:seed:fixtures": "tsx app/scripts/seedFixtures.ts",
+    "db:preview:prepare": "npm run db:reset && npm run db:migrate && npm run db:seed:fixtures",
     "db:studio": "drizzle-kit studio",
     "cf-typegen": "wrangler types"
   },

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
+    "db:migrate:debug": "tsx app/scripts/migrateDatabase.ts",
     "db:seed:fixtures": "tsx app/scripts/seedFixtures.ts",
-    "db:preview:prepare": "npm run db:reset && npm run db:migrate && npm run db:seed:fixtures",
+    "db:preview:prepare": "npm run db:reset && npm run db:migrate:debug && npm run db:seed:fixtures",
     "db:studio": "drizzle-kit studio",
     "cf-typegen": "wrangler types"
   },


### PR DESCRIPTION
## Summary

Migrates server read paths from MRTDown API-backed reads to the local database read model, and keeps PR preview deployments usable by preparing a shared preview database before deploy.

- Adds `app/util/db.queries.ts` and rewires root, overview, issue, line, station, operator, history, statistics, system-map, sitemap, and issues-day server read paths to DB-backed query helpers.
- Adds Drizzle schema/migration coverage for read-side daily fact tables (`issue_day_facts`, `line_day_facts`) and related indexes.
- Adds preview database helper scripts for reset, migration, and fixture seeding, plus `npm run db:preview:prepare`.
- Updates the Deploy Preview workflow to reset, migrate, and seed the shared preview DB before building, then deploy with top-level `wrangler deploy` so Worker and Workflow resources stay in sync.
- Keeps `wrangler.jsonc` out of this PR; those environment and binding changes were moved directly to `main` in `2de2d9a`.

Related: https://github.com/foldaway/mrtdown-data/issues/156

## Validation

- GitHub Deploy Preview passed for this PR.
- CodeRabbit status is passing.
- Local strict validation remains covered by the downstream harness PR in this stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved localization of station names in the statistics view for better regional accuracy.

* **Chores**
  * Enhanced database infrastructure for operational analytics.
  * Updated preview environment deployment workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-site/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->