### PR TITLE
fix(workflows): harden pull orphan cleanup

### DIFF
--- a/app/workflows/pull/helpers/stagingSync.ts
+++ b/app/workflows/pull/helpers/stagingSync.ts
@@ -491,6 +491,11 @@ export async function syncLines(db: Db): Promise<void> {
             set: {
               hash: row.hash,
               name: row.name,
+              type: row.type,
+              color: row.color,
+              started_at: row.started_at,
+              ended_at: row.ended_at,
+              operating_hours: row.operating_hours,
               updated_at: new Date(),
             },
           });

--- a/app/workflows/pull/helpers/stagingSync.ts
+++ b/app/workflows/pull/helpers/stagingSync.ts
@@ -39,10 +39,12 @@ import {
   impactEventServiceEffectsTable,
   impactEventServiceScopesTable,
   impactEventsTable,
+  issueDayFactsTable,
   issuesNextTable,
   issuesTable,
   landmarksNextTable,
   landmarksTable,
+  lineDayFactsTable,
   lineOperatorsTable,
   lineServicesTable,
   linesNextTable,
@@ -281,7 +283,7 @@ async function deleteImpactEventChildren(
   }
 }
 
-/** Hash diff staging vs live; upsert changed rows; delete live rows absent from staging. */
+/** Hash diff staging vs live; upsert changed rows. */
 async function upsertChangedOperators(
   tx: Parameters<Parameters<Db['transaction']>[0]>[0],
 ): Promise<void> {
@@ -328,6 +330,21 @@ async function upsertChangedOperators(
         },
       });
   }
+}
+
+async function deleteOrphanOperators(
+  tx: Parameters<Parameters<Db['transaction']>[0]>[0],
+): Promise<void> {
+  await tx
+    .delete(lineOperatorsTable)
+    .where(
+      notExists(
+        tx
+          .select()
+          .from(operatorsNextTable)
+          .where(eq(operatorsNextTable.id, lineOperatorsTable.operator_id)),
+      ),
+    );
   await tx
     .delete(operatorsTable)
     .where(
@@ -378,6 +395,11 @@ async function upsertChangedTowns(
         });
     }
   }
+}
+
+async function deleteOrphanTowns(
+  tx: Parameters<Parameters<Db['transaction']>[0]>[0],
+): Promise<void> {
   await tx
     .delete(townsTable)
     .where(
@@ -428,6 +450,21 @@ async function upsertChangedLandmarks(
         });
     }
   }
+}
+
+async function deleteOrphanLandmarks(
+  tx: Parameters<Parameters<Db['transaction']>[0]>[0],
+): Promise<void> {
+  await tx
+    .delete(stationLandmarksTable)
+    .where(
+      notExists(
+        tx
+          .select()
+          .from(landmarksNextTable)
+          .where(eq(landmarksNextTable.id, stationLandmarksTable.landmark_id)),
+      ),
+    );
   await tx
     .delete(landmarksTable)
     .where(
@@ -440,8 +477,10 @@ async function upsertChangedLandmarks(
     );
 }
 
-/** Operators, towns, landmarks — independent order; single transaction. */
-export async function syncOperatorsTownsLandmarks(db: Db): Promise<void> {
+/** Upsert parent tables before child syncs so new FK targets are available. */
+export async function syncOperatorsTownsLandmarksUpserts(
+  db: Db,
+): Promise<void> {
   await db.transaction(async (tx) => {
     await upsertChangedOperators(tx);
     await upsertChangedTowns(tx);
@@ -449,9 +488,26 @@ export async function syncOperatorsTownsLandmarks(db: Db): Promise<void> {
   });
 }
 
+/** Delete parent-table orphans after dependent tables have been reconciled. */
+export async function deleteOperatorsTownsLandmarksOrphans(
+  db: Db,
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    await deleteOrphanOperators(tx);
+    await deleteOrphanTowns(tx);
+    await deleteOrphanLandmarks(tx);
+  });
+}
+
+/** Convenience full sync for callers that are not orchestrating FK-safe phases. */
+export async function syncOperatorsTownsLandmarks(db: Db): Promise<void> {
+  await syncOperatorsTownsLandmarksUpserts(db);
+  await deleteOperatorsTownsLandmarksOrphans(db);
+}
+
 /**
  * Lines plus `line_operators`. For changed lines: replace operator rows for those
- * line ids, then orphan-delete lines (and operators) not in `lines_next`.
+ * line ids. Orphan deletes run later after services/stations/issues are reconciled.
  */
 export async function syncLines(db: Db): Promise<void> {
   await db.transaction(async (tx) => {
@@ -519,7 +575,11 @@ export async function syncLines(db: Db): Promise<void> {
         }
       }
     }
+  });
+}
 
+export async function deleteLineOrphans(db: Db): Promise<void> {
+  await db.transaction(async (tx) => {
     await tx
       .delete(lineOperatorsTable)
       .where(
@@ -528,6 +588,36 @@ export async function syncLines(db: Db): Promise<void> {
             .select()
             .from(linesNextTable)
             .where(eq(linesNextTable.id, lineOperatorsTable.line_id)),
+        ),
+      );
+    await tx
+      .delete(stationCodesTable)
+      .where(
+        notExists(
+          tx
+            .select()
+            .from(linesNextTable)
+            .where(eq(linesNextTable.id, stationCodesTable.line_id)),
+        ),
+      );
+    await tx
+      .delete(lineServicesTable)
+      .where(
+        notExists(
+          tx
+            .select()
+            .from(linesNextTable)
+            .where(eq(linesNextTable.id, lineServicesTable.line_id)),
+        ),
+      );
+    await tx
+      .delete(lineDayFactsTable)
+      .where(
+        notExists(
+          tx
+            .select()
+            .from(linesNextTable)
+            .where(eq(linesNextTable.id, lineDayFactsTable.line_id)),
         ),
       );
     await tx
@@ -621,7 +711,11 @@ export async function syncStations(db: Db): Promise<void> {
         }
       }
     }
+  });
+}
 
+export async function deleteStationOrphans(db: Db): Promise<void> {
+  await db.transaction(async (tx) => {
     await tx
       .delete(stationCodesTable)
       .where(
@@ -640,6 +734,50 @@ export async function syncStations(db: Db): Promise<void> {
             .select()
             .from(stationsNextTable)
             .where(eq(stationsNextTable.id, stationLandmarksTable.station_id)),
+        ),
+      );
+    await tx
+      .delete(serviceRevisionPathStationEntriesTable)
+      .where(
+        notExists(
+          tx
+            .select()
+            .from(stationsNextTable)
+            .where(
+              eq(
+                stationsNextTable.id,
+                serviceRevisionPathStationEntriesTable.station_id,
+              ),
+            ),
+        ),
+      );
+    await tx.delete(impactEventServiceScopesTable).where(sql`
+        (${impactEventServiceScopesTable.station_id} IS NOT NULL AND NOT EXISTS (
+          SELECT 1 FROM ${stationsNextTable}
+          WHERE ${stationsNextTable.id} = ${impactEventServiceScopesTable.station_id}
+        ))
+        OR (${impactEventServiceScopesTable.from_station_id} IS NOT NULL AND NOT EXISTS (
+          SELECT 1 FROM ${stationsNextTable}
+          WHERE ${stationsNextTable.id} = ${impactEventServiceScopesTable.from_station_id}
+        ))
+        OR (${impactEventServiceScopesTable.to_station_id} IS NOT NULL AND NOT EXISTS (
+          SELECT 1 FROM ${stationsNextTable}
+          WHERE ${stationsNextTable.id} = ${impactEventServiceScopesTable.to_station_id}
+        ))
+      `);
+    await tx
+      .delete(impactEventEntityFacilitiesTable)
+      .where(
+        notExists(
+          tx
+            .select()
+            .from(stationsNextTable)
+            .where(
+              eq(
+                stationsNextTable.id,
+                impactEventEntityFacilitiesTable.station_id,
+              ),
+            ),
         ),
       );
     await tx
@@ -769,7 +907,26 @@ export async function syncServices(db: Db): Promise<void> {
         }
       }
     }
+  });
+}
 
+export async function deleteServiceOrphans(db: Db): Promise<void> {
+  await db.transaction(async (tx) => {
+    await tx
+      .delete(impactEventEntityServicesTable)
+      .where(
+        notExists(
+          tx
+            .select()
+            .from(servicesNextTable)
+            .where(
+              eq(
+                servicesNextTable.id,
+                impactEventEntityServicesTable.service_id,
+              ),
+            ),
+        ),
+      );
     await tx
       .delete(serviceRevisionPathStationEntriesTable)
       .where(
@@ -1129,6 +1286,9 @@ async function deleteIssueIds(tx: Tx, issueIds: string[]): Promise<void> {
       .where(inArray(impactEventsTable.issue_id, ch));
     const orphanImpactIds = impRows.map((r) => r.id);
     await deleteImpactEventChildren(tx, orphanImpactIds);
+    await tx
+      .delete(issueDayFactsTable)
+      .where(inArray(issueDayFactsTable.issue_id, ch));
     await tx
       .delete(impactEventsTable)
       .where(inArray(impactEventsTable.issue_id, ch));

--- a/app/workflows/pull/helpers/stagingSync.ts
+++ b/app/workflows/pull/helpers/stagingSync.ts
@@ -621,6 +621,16 @@ export async function deleteLineOrphans(db: Db): Promise<void> {
         ),
       );
     await tx
+      .update(impactEventEntityFacilitiesTable)
+      .set({ line_id: null })
+      .where(sql`
+        ${impactEventEntityFacilitiesTable.line_id} IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM ${linesNextTable}
+          WHERE ${linesNextTable.id} = ${impactEventEntityFacilitiesTable.line_id}
+        )
+      `);
+    await tx
       .delete(linesTable)
       .where(
         notExists(

--- a/app/workflows/pull/helpers/stagingSync.ts
+++ b/app/workflows/pull/helpers/stagingSync.ts
@@ -142,7 +142,7 @@ export async function insertLandmarksStaging(
 
 export async function insertLinesStaging(
   db: Db,
-  lines: readonly (Line & { hash: string })[],
+  lines: readonly (Line & { hash: string; endedAt?: string | null })[],
 ): Promise<void> {
   const skippedLines = lines.flatMap((l) => {
     const missing = [
@@ -172,7 +172,7 @@ export async function insertLinesStaging(
         type: l.type,
         color: l.color,
         started_at: l.startedAt,
-        ended_at: null,
+        ended_at: l.endedAt ?? null,
         operating_hours: l.operatingHours,
         operators: l.operators,
       },
@@ -540,6 +540,7 @@ export async function syncLines(db: Db): Promise<void> {
             type: row.type,
             color: row.color,
             started_at: row.started_at,
+            ended_at: row.ended_at,
             operating_hours: row.operating_hours,
           })
           .onConflictDoUpdate({

--- a/app/workflows/pull/index.ts
+++ b/app/workflows/pull/index.ts
@@ -12,6 +12,10 @@ import { fetchArchive } from './helpers/fetchArchive.js';
 import { fetchManifest } from './helpers/fetchManifest.js';
 import {
   deleteOrphanIssuesBatch,
+  deleteLineOrphans,
+  deleteOperatorsTownsLandmarksOrphans,
+  deleteServiceOrphans,
+  deleteStationOrphans,
   finalizePull,
   insertIssuesStaging,
   insertLandmarksStaging,
@@ -22,7 +26,7 @@ import {
   insertTownsStaging,
   syncChangedIssuesBatch,
   syncLines,
-  syncOperatorsTownsLandmarks,
+  syncOperatorsTownsLandmarksUpserts,
   syncServices,
   syncStations,
   truncateStagingTables,
@@ -183,11 +187,11 @@ class PullWorkflowBase extends WorkflowEntrypoint<Env, Params> {
     });
 
     await step.do(
-      'sync-operators-towns-landmarks',
+      'sync-operators-towns-landmarks-upserts',
       syncStepConfig,
       async () => {
         const db = getDb();
-        await syncOperatorsTownsLandmarks(db);
+        await syncOperatorsTownsLandmarksUpserts(db);
       },
     );
 
@@ -244,6 +248,34 @@ class PullWorkflowBase extends WorkflowEntrypoint<Env, Params> {
       );
       if (processed === 0) break;
     }
+
+    await step.do('delete-service-orphans', syncStepConfig, async () => {
+      const db = getDb();
+      console.log('Deleting service orphans...');
+      await deleteServiceOrphans(db);
+    });
+
+    await step.do('delete-station-orphans', syncStepConfig, async () => {
+      const db = getDb();
+      console.log('Deleting station orphans...');
+      await deleteStationOrphans(db);
+    });
+
+    await step.do('delete-line-orphans', syncStepConfig, async () => {
+      const db = getDb();
+      console.log('Deleting line orphans...');
+      await deleteLineOrphans(db);
+    });
+
+    await step.do(
+      'delete-operators-towns-landmarks-orphans',
+      syncStepConfig,
+      async () => {
+        const db = getDb();
+        console.log('Deleting operators, towns and landmarks orphans...');
+        await deleteOperatorsTownsLandmarksOrphans(db);
+      },
+    );
 
     await step.do('finalize', syncStepConfig, async () => {
       const db = getDb();


### PR DESCRIPTION
## Summary

Hardens pull workflow promotion and orphan cleanup to avoid FK violations during larger Cloudflare runs.

- Refreshes mutable line fields during line upsert.
- Splits parent-table upserts from orphan deletes so FK targets are created before dependent syncs.
- Moves service, station, line, operator, town, and landmark orphan deletes after dependent issue/service/station sync work.
- Cleans dependent rows for orphan services, stations, lines, and issues, including operational fact rows and impact-event references.
- Clears nullable facility impact-event line references before deleting orphan lines.

Related: https://github.com/foldaway/mrtdown-data/issues/156

## Validation

- `npm run verify`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Line records now retain end dates and additional attributes (type, color, operating hours) during sync for more accurate display.
* **Bug Fixes**
  * Expanded orphan cleanup so removed services, stations, lines, operators/towns/landmarks and related issue day facts are fully cleared, preventing dangling references and improving data consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-site/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->