### PR TITLE
ci: add database migration workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,10 +7,41 @@ on:
       - production
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
+  migrate-staging:
+    if: github.ref == 'refs/heads/main'
+    name: Migrate staging database
+    runs-on: ubuntu-latest
+    environment:
+      name: staging
+    concurrency:
+      group: migrate-staging
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run database migrations
+        run: npm run db:migrate
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
   deploy-staging:
     if: github.ref == 'refs/heads/main'
     name: Deploy staging
+    needs: migrate-staging
     runs-on: ubuntu-latest
     environment:
       name: staging
@@ -59,9 +90,37 @@ jobs:
           DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
         run: echo $DEPLOYMENT_URL
 
+  migrate-production:
+    if: github.ref == 'refs/heads/production'
+    name: Migrate production database
+    runs-on: ubuntu-latest
+    concurrency:
+      group: migrate-production
+      cancel-in-progress: false
+    environment:
+      name: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run database migrations
+        run: npm run db:migrate
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
   deploy-production:
     if: github.ref == 'refs/heads/production'
     name: Deploy production
+    needs: migrate-production
     runs-on: ubuntu-latest
     concurrency:
       group: deploy-production

--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.environment == 'production' && 'production' || 'main' }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -1,0 +1,44 @@
+name: Migrate Database
+
+run-name: Migrate ${{ inputs.environment }} database
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Database environment to migrate
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+
+permissions:
+  contents: read
+
+jobs:
+  migrate:
+    name: Migrate ${{ inputs.environment }} database
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment }}
+    concurrency:
+      group: migrate-${{ inputs.environment }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run database migrations
+        run: npm run db:migrate
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}


### PR DESCRIPTION
## Summary

Adds GitHub Actions support for running Drizzle database migrations against staging and production.

## Changes

- Adds staging and production migration jobs to the deploy workflow before their respective Worker deploy jobs.
- Adds a manual `Migrate Database` workflow with an environment selector for `staging` or `production`.
- Pins the manual workflow checkout ref to `main` for staging and `production` for production so selected DB credentials match the migration code branch.
- Uses environment-scoped `DATABASE_URL` secrets and read-only GitHub token permissions.
- Keeps migration concurrency serialized per environment and avoids canceling in-progress migrations.

## Impact

Deploys to `main` and `production` now wait for `npm run db:migrate` to succeed before deploying. Operators can also run migrations manually from GitHub Actions without triggering a Worker deployment, while production manual runs use the `production` branch migration code.

## Validation

- Parsed both workflow YAML files locally with Ruby YAML.
- Ran `git diff --check`.
- `actionlint` was not installed locally, so semantic Actions linting was not run.