### PR TITLE
fix: cascade impact event cleanup during pull ingestion

### DIFF
--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -451,7 +451,10 @@ export const evidencesTable = pgTable(
     render: jsonb('render').$type<EvidenceRender>(),
     source_url: text('source_url').notNull(),
     issue_id: text('issue_id')
-      .references(() => issuesTable.id)
+      .references(() => issuesTable.id, {
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      })
       .notNull(),
     ...timestampColumns,
   },
@@ -470,7 +473,10 @@ export const impactEventsTable = pgTable(
     id: text('id').primaryKey(),
     ts: timestamp('ts', { withTimezone: true, mode: 'string' }).notNull(),
     issue_id: text('issue_id')
-      .references(() => issuesTable.id)
+      .references(() => issuesTable.id, {
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      })
       .notNull(),
     type: text('type').$type<ImpactEvent['type']>().notNull(),
     ...timestampColumns,
@@ -485,10 +491,16 @@ export const impactEventBasisEvidencesTable = pgTable(
   'impact_event_basis_evidences',
   {
     impact_event_id: text('impact_event_id')
-      .references(() => impactEventsTable.id)
+      .references(() => impactEventsTable.id, {
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      })
       .notNull(),
     evidence_id: text('evidence_id')
-      .references(() => evidencesTable.id)
+      .references(() => evidencesTable.id, {
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      })
       .notNull(),
     ...timestampColumns,
   },
@@ -525,7 +537,10 @@ export const impactEventPeriodsTable = pgTable(
   'impact_event_periods',
   {
     impact_event_id: text('impact_event_id')
-      .references(() => impactEventsTable.id)
+      .references(() => impactEventsTable.id, {
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      })
       .notNull(),
     index: integer('index').notNull(),
     mode: resolvePeriodsModeKindEnum().notNull(),
@@ -654,7 +669,10 @@ export const impactEventServiceScopesTable = pgTable(
   'impact_event_service_scopes',
   {
     impact_event_id: text('impact_event_id')
-      .references(() => impactEventsTable.id)
+      .references(() => impactEventsTable.id, {
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      })
       .notNull(),
     index: integer('index').notNull(),
     type: impactEventServiceScopeTypeEnum().notNull(),
@@ -715,7 +733,10 @@ export const impactEventServiceEffectsTable = pgTable(
   'impact_event_service_effects',
   {
     impact_event_id: text('impact_event_id')
-      .references(() => impactEventsTable.id)
+      .references(() => impactEventsTable.id, {
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      })
       .notNull(),
     kind: serviceEffectKindEnum().notNull(),
     // Present only when kind=delay
@@ -743,7 +764,10 @@ export const impactEventFacilityEffectsTable = pgTable(
   'impact_event_facility_effects',
   {
     impact_event_id: text('impact_event_id')
-      .references(() => impactEventsTable.id)
+      .references(() => impactEventsTable.id, {
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      })
       .notNull(),
     kind: facilityEffectKindEnum().notNull(),
     ...timestampColumns,
@@ -764,7 +788,10 @@ export const impactEventEntityServicesTable = pgTable(
   'impact_event_entity_services',
   {
     impact_event_id: text('impact_event_id')
-      .references(() => impactEventsTable.id)
+      .references(() => impactEventsTable.id, {
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      })
       .notNull(),
     service_id: text('service_id')
       .references(() => servicesTable.id)
@@ -792,7 +819,10 @@ export const impactEventEntityFacilitiesTable = pgTable(
   'impact_event_entity_facilities',
   {
     impact_event_id: text('impact_event_id')
-      .references(() => impactEventsTable.id)
+      .references(() => impactEventsTable.id, {
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      })
       .notNull(),
     station_id: text('station_id')
       .references(() => stationsTable.id)
@@ -830,7 +860,10 @@ export const impactEventCausesTable = pgTable(
   'impact_event_causes',
   {
     impact_event_id: text('impact_event_id')
-      .references(() => impactEventsTable.id)
+      .references(() => impactEventsTable.id, {
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+      })
       .notNull(),
     type: impactEventCauseTypeEnum().notNull(),
     ...timestampColumns,

--- a/app/workflows/pull/helpers/stagingSync.ts
+++ b/app/workflows/pull/helpers/stagingSync.ts
@@ -1070,16 +1070,17 @@ async function syncIssueIds(tx: Tx, issueIds: string[]): Promise<void> {
         });
     }
     if (evidenceRows.length > 0) {
-      const evidenceIds = Array.from(
-        new Set(evidenceRows.map((evidence) => evidence.id)),
+      const dedupedEvidenceRows = Array.from(
+        new Map(evidenceRows.map((evidence) => [evidence.id, evidence])).values(),
       );
+      const evidenceIds = dedupedEvidenceRows.map((evidence) => evidence.id);
       for (const ids of chunk(evidenceIds, DELETE_BATCH)) {
         await tx
           .delete(impactEventBasisEvidencesTable)
           .where(inArray(impactEventBasisEvidencesTable.evidence_id, ids));
         await tx.delete(evidencesTable).where(inArray(evidencesTable.id, ids));
       }
-      for (const rows of chunk(evidenceRows, BATCH)) {
+      for (const rows of chunk(dedupedEvidenceRows, BATCH)) {
         await tx.insert(evidencesTable).values(rows);
       }
     }

--- a/app/workflows/pull/helpers/stagingSync.ts
+++ b/app/workflows/pull/helpers/stagingSync.ts
@@ -1070,6 +1070,15 @@ async function syncIssueIds(tx: Tx, issueIds: string[]): Promise<void> {
         });
     }
     if (evidenceRows.length > 0) {
+      const evidenceIds = Array.from(
+        new Set(evidenceRows.map((evidence) => evidence.id)),
+      );
+      for (const ids of chunk(evidenceIds, DELETE_BATCH)) {
+        await tx
+          .delete(impactEventBasisEvidencesTable)
+          .where(inArray(impactEventBasisEvidencesTable.evidence_id, ids));
+        await tx.delete(evidencesTable).where(inArray(evidencesTable.id, ids));
+      }
       for (const rows of chunk(evidenceRows, BATCH)) {
         await tx.insert(evidencesTable).values(rows);
       }

--- a/app/workflows/pull/helpers/stagingSync.ts
+++ b/app/workflows/pull/helpers/stagingSync.ts
@@ -846,266 +846,302 @@ async function syncIssueIds(tx: Tx, issueIds: string[]): Promise<void> {
       .select()
       .from(issuesNextTable)
       .where(inArray(issuesNextTable.id, ch));
+
+    const issueRows: InferInsertModel<typeof issuesTable>[] = [];
+    const evidenceRows: InferInsertModel<typeof evidencesTable>[] = [];
+    const impactEventRows: InferInsertModel<typeof impactEventsTable>[] = [];
+    const basisEvidenceRows: InferInsertModel<
+      typeof impactEventBasisEvidencesTable
+    >[] = [];
+    const entityServiceRows: InferInsertModel<
+      typeof impactEventEntityServicesTable
+    >[] = [];
+    const entityFacilityRows: InferInsertModel<
+      typeof impactEventEntityFacilitiesTable
+    >[] = [];
+    const periodRows: InferInsertModel<typeof impactEventPeriodsTable>[] = [];
+    const causeRows: InferInsertModel<typeof impactEventCausesTable>[] = [];
+    const serviceScopeRows: InferInsertModel<
+      typeof impactEventServiceScopesTable
+    >[] = [];
+    const serviceEffectRows: InferInsertModel<
+      typeof impactEventServiceEffectsTable
+    >[] = [];
+    const facilityEffectRows: InferInsertModel<
+      typeof impactEventFacilityEffectsTable
+    >[] = [];
+
     for (const row of full) {
+      issueRows.push({
+        id: row.id,
+        hash: row.hash,
+        type: row.type,
+        title: row.title,
+        title_meta: row.title_meta,
+      });
+
+      for (const evidence of row.evidences) {
+        evidenceRows.push({
+          id: evidence.id,
+          ts: evidence.ts,
+          text: evidence.text,
+          type: evidence.type,
+          render: evidence.render,
+          source_url: evidence.sourceUrl,
+          issue_id: row.id,
+        });
+      }
+
+      const lastEvidenceAt = lastEvidenceAtFromList(row.evidences);
+      for (const impactEvent of row.impact_events) {
+        impactEventRows.push({
+          id: impactEvent.id,
+          ts: impactEvent.ts,
+          type: impactEvent.type,
+          issue_id: row.id,
+        });
+        basisEvidenceRows.push({
+          impact_event_id: impactEvent.id,
+          evidence_id: impactEvent.basis.evidenceId,
+        });
+
+        switch (impactEvent.entity.type) {
+          case 'service': {
+            entityServiceRows.push({
+              impact_event_id: impactEvent.id,
+              service_id: impactEvent.entity.serviceId,
+            });
+            break;
+          }
+          case 'facility': {
+            const entity = impactEvent.entity as ImpactEvent['entity'] & {
+              lineId?: string | null;
+            };
+
+            entityFacilityRows.push({
+              impact_event_id: impactEvent.id,
+              station_id: impactEvent.entity.stationId,
+              line_id: entity.lineId ?? null,
+              kind: impactEvent.entity.kind,
+            });
+            break;
+          }
+          default: {
+            assertUnreachable(
+              impactEvent.entity,
+              'Unexpected impact event entity',
+            );
+          }
+        }
+
+        switch (impactEvent.type) {
+          case 'periods.set': {
+            const resolvedPeriodsOperational = resolvePeriods({
+              mode: {
+                kind: 'operational',
+                lastEvidenceAt: lastEvidenceAt?.toISO() ?? null,
+              },
+              periods: impactEvent.periods,
+              asOf: impactEvent.ts,
+            });
+            for (const [
+              index,
+              period,
+            ] of resolvedPeriodsOperational.entries()) {
+              periodRows.push({
+                impact_event_id: impactEvent.id,
+                mode: 'operational',
+                index,
+                start_at: period.startAt,
+                end_at: period.endAt,
+                end_at_resolved: period.endAtResolved,
+                end_at_source: period.endAtSource,
+                end_at_reason: period.endAtReason,
+              });
+            }
+
+            const resolvedPeriodsCanonical = resolvePeriods({
+              mode: {
+                kind: 'canonical',
+              },
+              periods: impactEvent.periods,
+              asOf: impactEvent.ts,
+            });
+            for (const [index, period] of resolvedPeriodsCanonical.entries()) {
+              periodRows.push({
+                impact_event_id: impactEvent.id,
+                mode: 'canonical',
+                index,
+                start_at: period.startAt,
+                end_at: period.endAt,
+                end_at_resolved: period.endAtResolved,
+                end_at_source: period.endAtSource,
+                end_at_reason: period.endAtReason,
+              });
+            }
+            break;
+          }
+          case 'causes.set': {
+            for (const cause of impactEvent.causes) {
+              causeRows.push({
+                impact_event_id: impactEvent.id,
+                type: cause,
+              });
+            }
+            break;
+          }
+          case 'service_scopes.set': {
+            for (const [
+              index,
+              serviceScope,
+            ] of impactEvent.serviceScopes.entries()) {
+              const scopeBase = {
+                impact_event_id: impactEvent.id,
+                type: serviceScope.type,
+                index,
+              } satisfies InferInsertModel<
+                typeof impactEventServiceScopesTable
+              >;
+
+              switch (serviceScope.type) {
+                case 'service.whole':
+                  serviceScopeRows.push(scopeBase);
+                  break;
+                case 'service.point':
+                  serviceScopeRows.push({
+                    ...scopeBase,
+                    station_id: serviceScope.stationId,
+                  });
+                  break;
+                case 'service.segment':
+                  serviceScopeRows.push({
+                    ...scopeBase,
+                    from_station_id: serviceScope.fromStationId,
+                    to_station_id: serviceScope.toStationId,
+                  });
+                  break;
+                default:
+                  assertUnreachable(
+                    serviceScope,
+                    'Unhandled service scope type',
+                  );
+              }
+            }
+            break;
+          }
+          case 'service_effects.set': {
+            serviceEffectRows.push({
+              impact_event_id: impactEvent.id,
+              kind: impactEvent.effect.kind,
+              duration:
+                impactEvent.effect.kind === 'delay'
+                  ? impactEvent.effect.duration
+                  : null,
+            });
+            break;
+          }
+          case 'facility_effects.set': {
+            facilityEffectRows.push({
+              impact_event_id: impactEvent.id,
+              kind: impactEvent.effect.kind,
+            });
+            break;
+          }
+          default: {
+            assertUnreachable(impactEvent, 'Unexpected impact event type');
+          }
+        }
+      }
+    }
+
+    if (issueRows.length > 0) {
       await tx
         .insert(issuesTable)
-        .values({
-          id: row.id,
-          hash: row.hash,
-          type: row.type,
-          title: row.title,
-          title_meta: row.title_meta,
-        })
+        .values(issueRows)
         .onConflictDoUpdate({
           target: [issuesTable.id],
           set: {
-            hash: row.hash,
-            type: row.type,
-            title: row.title,
-            title_meta: row.title_meta,
+            hash: sql.raw(`excluded.${issuesTable.hash.name}`),
+            type: sql.raw(`excluded.${issuesTable.type.name}`),
+            title: sql.raw(`excluded.${issuesTable.title.name}`),
+            title_meta: sql.raw(`excluded.${issuesTable.title_meta.name}`),
+            updated_at: new Date(),
           },
         });
-
-      if (row.evidences.length > 0) {
-        const evidenceIds = row.evidences.map((evidence) => evidence.id);
-        await tx
-          .delete(impactEventBasisEvidencesTable)
-          .where(
-            inArray(impactEventBasisEvidencesTable.evidence_id, evidenceIds),
-          );
-        await tx
-          .delete(evidencesTable)
-          .where(inArray(evidencesTable.id, evidenceIds));
-
-        await tx.insert(evidencesTable).values(
-          row.evidences.map((evidence) => {
-            return {
-              id: evidence.id,
-              ts: evidence.ts,
-              text: evidence.text,
-              type: evidence.type,
-              render: evidence.render,
-              source_url: evidence.sourceUrl,
-              issue_id: row.id,
-            } satisfies InferInsertModel<typeof evidencesTable>;
-          }),
-        );
+    }
+    if (evidenceRows.length > 0) {
+      for (const rows of chunk(evidenceRows, BATCH)) {
+        await tx.insert(evidencesTable).values(rows);
       }
-
-      const impactEvents = row.impact_events;
-      if (impactEvents.length > 0) {
-        const lastEvidenceAt = lastEvidenceAtFromList(row.evidences);
-
+    }
+    if (impactEventRows.length > 0) {
+      for (const rows of chunk(impactEventRows, BATCH)) {
         await tx
           .insert(impactEventsTable)
-          .values(
-            impactEvents.map((impactEvent) => {
-              return {
-                id: impactEvent.id,
-                ts: impactEvent.ts,
-                type: impactEvent.type,
-                issue_id: row.id,
-              } satisfies InferInsertModel<typeof impactEventsTable>;
-            }),
-          )
+          .values(rows)
           .onConflictDoUpdate({
             target: [impactEventsTable.id],
             set: {
               ts: sql.raw(`excluded.${impactEventsTable.ts.name}`),
               type: sql.raw(`excluded.${impactEventsTable.type.name}`),
               issue_id: sql.raw(`excluded.${impactEventsTable.issue_id.name}`),
+              updated_at: new Date(),
             },
           });
-
-        // One row per impact event — `basis.evidenceId` is a single id in core schema
-        const basisEvidence = impactEvents.map((impactEvent) => ({
-          impact_event_id: impactEvent.id,
-          evidence_id: impactEvent.basis.evidenceId,
-        }));
-
-        if (basisEvidence.length > 0) {
-          await tx.insert(impactEventBasisEvidencesTable).values(basisEvidence);
-        }
-
-        for (const impactEvent of impactEvents) {
-          switch (impactEvent.entity.type) {
-            case 'service': {
-              await tx.insert(impactEventEntityServicesTable).values({
-                impact_event_id: impactEvent.id,
-                service_id: impactEvent.entity.serviceId,
-              } satisfies InferInsertModel<
-                typeof impactEventEntityServicesTable
-              >);
-              break;
-            }
-            case 'facility': {
-              const entity = impactEvent.entity as ImpactEvent['entity'] & {
-                lineId?: string | null;
-              };
-
-              await tx
-                .insert(impactEventEntityFacilitiesTable)
-                .values({
-                  impact_event_id: impactEvent.id,
-                  station_id: impactEvent.entity.stationId,
-                  line_id: entity.lineId ?? null,
-                  kind: impactEvent.entity.kind,
-                } satisfies InferInsertModel<
-                  typeof impactEventEntityFacilitiesTable
-                >)
-                .onConflictDoUpdate({
-                  target: [
-                    impactEventEntityFacilitiesTable.impact_event_id,
-                    impactEventEntityFacilitiesTable.station_id,
-                    impactEventEntityFacilitiesTable.kind,
-                  ],
-                  set: {
-                    line_id: sql.raw(
-                      `excluded.${impactEventEntityFacilitiesTable.line_id.name}`,
-                    ),
-                  },
-                });
-              break;
-            }
-            default: {
-              assertUnreachable(
-                impactEvent.entity,
-                'Unexpected impact event entity',
-              );
-            }
-          }
-
-          switch (impactEvent.type) {
-            case 'periods.set': {
-              const resolvedPeriodsOperational = resolvePeriods({
-                mode: {
-                  kind: 'operational',
-                  lastEvidenceAt: lastEvidenceAt?.toISO() ?? null,
-                },
-                periods: impactEvent.periods,
-                asOf: impactEvent.ts,
-              });
-              if (resolvedPeriodsOperational.length > 0) {
-                await tx.insert(impactEventPeriodsTable).values(
-                  resolvedPeriodsOperational.map((period, index) => {
-                    return {
-                      impact_event_id: impactEvent.id,
-                      mode: 'operational',
-                      index,
-                      start_at: period.startAt,
-                      end_at: period.endAt,
-                      end_at_resolved: period.endAtResolved,
-                      end_at_source: period.endAtSource,
-                      end_at_reason: period.endAtReason,
-                    } satisfies InferInsertModel<
-                      typeof impactEventPeriodsTable
-                    >;
-                  }),
-                );
-              }
-
-              const resolvedPeriodsCanonical = resolvePeriods({
-                mode: {
-                  kind: 'canonical',
-                },
-                periods: impactEvent.periods,
-                asOf: impactEvent.ts,
-              });
-              if (resolvedPeriodsCanonical.length > 0) {
-                await tx.insert(impactEventPeriodsTable).values(
-                  resolvedPeriodsCanonical.map((period, index) => {
-                    return {
-                      impact_event_id: impactEvent.id,
-                      mode: 'canonical',
-                      index,
-                      start_at: period.startAt,
-                      end_at: period.endAt,
-                      end_at_resolved: period.endAtResolved,
-                      end_at_source: period.endAtSource,
-                      end_at_reason: period.endAtReason,
-                    } satisfies InferInsertModel<
-                      typeof impactEventPeriodsTable
-                    >;
-                  }),
-                );
-              }
-              break;
-            }
-            case 'causes.set': {
-              await tx.insert(impactEventCausesTable).values(
-                impactEvent.causes.map((cause) => {
-                  return {
-                    impact_event_id: impactEvent.id,
-                    type: cause,
-                  } satisfies InferInsertModel<typeof impactEventCausesTable>;
-                }),
-              );
-              break;
-            }
-            case 'service_scopes.set': {
-              if (impactEvent.serviceScopes.length > 0) {
-                await tx.insert(impactEventServiceScopesTable).values(
-                  impactEvent.serviceScopes.map((serviceScope, index) => {
-                    const row = {
-                      impact_event_id: impactEvent.id,
-                      type: serviceScope.type,
-                      index,
-                    } satisfies InferInsertModel<
-                      typeof impactEventServiceScopesTable
-                    >;
-
-                    switch (serviceScope.type) {
-                      case 'service.whole':
-                        return row;
-                      case 'service.point':
-                        return {
-                          ...row,
-                          station_id: serviceScope.stationId,
-                        };
-                      case 'service.segment':
-                        return {
-                          ...row,
-                          from_station_id: serviceScope.fromStationId,
-                          to_station_id: serviceScope.toStationId,
-                        };
-                      default:
-                        return assertUnreachable(
-                          serviceScope,
-                          'Unhandled service scope type',
-                        );
-                    }
-                  }),
-                );
-              }
-              break;
-            }
-            case 'service_effects.set': {
-              await tx.insert(impactEventServiceEffectsTable).values({
-                impact_event_id: impactEvent.id,
-                kind: impactEvent.effect.kind,
-                duration:
-                  impactEvent.effect.kind === 'delay'
-                    ? impactEvent.effect.duration
-                    : null,
-              } satisfies InferInsertModel<
-                typeof impactEventServiceEffectsTable
-              >);
-              break;
-            }
-            case 'facility_effects.set': {
-              await tx.insert(impactEventFacilityEffectsTable).values({
-                impact_event_id: impactEvent.id,
-                kind: impactEvent.effect.kind,
-              } satisfies InferInsertModel<
-                typeof impactEventFacilityEffectsTable
-              >);
-              break;
-            }
-            default: {
-              assertUnreachable(impactEvent, 'Unexpected impact event type');
-            }
-          }
-        }
+      }
+    }
+    if (basisEvidenceRows.length > 0) {
+      for (const rows of chunk(basisEvidenceRows, BATCH)) {
+        await tx.insert(impactEventBasisEvidencesTable).values(rows);
+      }
+    }
+    if (entityServiceRows.length > 0) {
+      for (const rows of chunk(entityServiceRows, BATCH)) {
+        await tx.insert(impactEventEntityServicesTable).values(rows);
+      }
+    }
+    if (entityFacilityRows.length > 0) {
+      for (const rows of chunk(entityFacilityRows, BATCH)) {
+        await tx
+          .insert(impactEventEntityFacilitiesTable)
+          .values(rows)
+          .onConflictDoUpdate({
+            target: [
+              impactEventEntityFacilitiesTable.impact_event_id,
+              impactEventEntityFacilitiesTable.station_id,
+              impactEventEntityFacilitiesTable.kind,
+            ],
+            set: {
+              line_id: sql.raw(
+                `excluded.${impactEventEntityFacilitiesTable.line_id.name}`,
+              ),
+            },
+          });
+      }
+    }
+    if (periodRows.length > 0) {
+      for (const rows of chunk(periodRows, BATCH)) {
+        await tx.insert(impactEventPeriodsTable).values(rows);
+      }
+    }
+    if (causeRows.length > 0) {
+      for (const rows of chunk(causeRows, BATCH)) {
+        await tx.insert(impactEventCausesTable).values(rows);
+      }
+    }
+    if (serviceScopeRows.length > 0) {
+      for (const rows of chunk(serviceScopeRows, BATCH)) {
+        await tx.insert(impactEventServiceScopesTable).values(rows);
+      }
+    }
+    if (serviceEffectRows.length > 0) {
+      for (const rows of chunk(serviceEffectRows, BATCH)) {
+        await tx.insert(impactEventServiceEffectsTable).values(rows);
+      }
+    }
+    if (facilityEffectRows.length > 0) {
+      for (const rows of chunk(facilityEffectRows, BATCH)) {
+        await tx.insert(impactEventFacilityEffectsTable).values(rows);
       }
     }
   }

--- a/app/workflows/pull/index.ts
+++ b/app/workflows/pull/index.ts
@@ -48,7 +48,7 @@ const syncStepConfig = {
   },
 };
 
-const ISSUE_SYNC_BATCH_SIZE = 100;
+const ISSUE_SYNC_BATCH_SIZE = 500;
 
 /**
  * Durable pull pipeline: manifest → parse into staging → promote by domain →

--- a/drizzle/0004_eager_marten_broadcloak.sql
+++ b/drizzle/0004_eager_marten_broadcloak.sql
@@ -1,0 +1,33 @@
+ALTER TABLE "evidences" DROP CONSTRAINT "evidences_issue_id_issues_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_basis_evidences" DROP CONSTRAINT "impact_event_basis_evidences_impact_event_id_impact_events_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_basis_evidences" DROP CONSTRAINT "impact_event_basis_evidences_evidence_id_evidences_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_causes" DROP CONSTRAINT "impact_event_causes_impact_event_id_impact_events_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_entity_facilities" DROP CONSTRAINT "impact_event_entity_facilities_impact_event_id_impact_events_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_entity_services" DROP CONSTRAINT "impact_event_entity_services_impact_event_id_impact_events_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_facility_effects" DROP CONSTRAINT "impact_event_facility_effects_impact_event_id_impact_events_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_periods" DROP CONSTRAINT "impact_event_periods_impact_event_id_impact_events_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_service_effects" DROP CONSTRAINT "impact_event_service_effects_impact_event_id_impact_events_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_service_scopes" DROP CONSTRAINT "impact_event_service_scopes_impact_event_id_impact_events_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_events" DROP CONSTRAINT "impact_events_issue_id_issues_id_fk";
+--> statement-breakpoint
+ALTER TABLE "evidences" ADD CONSTRAINT "evidences_issue_id_issues_id_fk" FOREIGN KEY ("issue_id") REFERENCES "public"."issues"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+ALTER TABLE "impact_event_basis_evidences" ADD CONSTRAINT "impact_event_basis_evidences_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+ALTER TABLE "impact_event_basis_evidences" ADD CONSTRAINT "impact_event_basis_evidences_evidence_id_evidences_id_fk" FOREIGN KEY ("evidence_id") REFERENCES "public"."evidences"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+ALTER TABLE "impact_event_causes" ADD CONSTRAINT "impact_event_causes_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+ALTER TABLE "impact_event_entity_facilities" ADD CONSTRAINT "impact_event_entity_facilities_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+ALTER TABLE "impact_event_entity_services" ADD CONSTRAINT "impact_event_entity_services_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+ALTER TABLE "impact_event_facility_effects" ADD CONSTRAINT "impact_event_facility_effects_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+ALTER TABLE "impact_event_periods" ADD CONSTRAINT "impact_event_periods_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+ALTER TABLE "impact_event_service_effects" ADD CONSTRAINT "impact_event_service_effects_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+ALTER TABLE "impact_event_service_scopes" ADD CONSTRAINT "impact_event_service_scopes_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+ALTER TABLE "impact_events" ADD CONSTRAINT "impact_events_issue_id_issues_id_fk" FOREIGN KEY ("issue_id") REFERENCES "public"."issues"("id") ON DELETE cascade ON UPDATE cascade;

--- a/drizzle/0004_eager_marten_broadcloak.sql
+++ b/drizzle/0004_eager_marten_broadcloak.sql
@@ -20,14 +20,25 @@ ALTER TABLE "impact_event_service_scopes" DROP CONSTRAINT "impact_event_service_
 --> statement-breakpoint
 ALTER TABLE "impact_events" DROP CONSTRAINT "impact_events_issue_id_issues_id_fk";
 --> statement-breakpoint
-ALTER TABLE "evidences" ADD CONSTRAINT "evidences_issue_id_issues_id_fk" FOREIGN KEY ("issue_id") REFERENCES "public"."issues"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
-ALTER TABLE "impact_event_basis_evidences" ADD CONSTRAINT "impact_event_basis_evidences_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
-ALTER TABLE "impact_event_basis_evidences" ADD CONSTRAINT "impact_event_basis_evidences_evidence_id_evidences_id_fk" FOREIGN KEY ("evidence_id") REFERENCES "public"."evidences"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
-ALTER TABLE "impact_event_causes" ADD CONSTRAINT "impact_event_causes_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
-ALTER TABLE "impact_event_entity_facilities" ADD CONSTRAINT "impact_event_entity_facilities_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
-ALTER TABLE "impact_event_entity_services" ADD CONSTRAINT "impact_event_entity_services_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
-ALTER TABLE "impact_event_facility_effects" ADD CONSTRAINT "impact_event_facility_effects_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
-ALTER TABLE "impact_event_periods" ADD CONSTRAINT "impact_event_periods_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
-ALTER TABLE "impact_event_service_effects" ADD CONSTRAINT "impact_event_service_effects_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
-ALTER TABLE "impact_event_service_scopes" ADD CONSTRAINT "impact_event_service_scopes_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
-ALTER TABLE "impact_events" ADD CONSTRAINT "impact_events_issue_id_issues_id_fk" FOREIGN KEY ("issue_id") REFERENCES "public"."issues"("id") ON DELETE cascade ON UPDATE cascade;
+ALTER TABLE "evidences" ADD CONSTRAINT "evidences_issue_id_issues_id_fk" FOREIGN KEY ("issue_id") REFERENCES "public"."issues"("id") ON DELETE cascade ON UPDATE cascade NOT VALID;--> statement-breakpoint
+ALTER TABLE "impact_event_basis_evidences" ADD CONSTRAINT "impact_event_basis_evidences_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade NOT VALID;--> statement-breakpoint
+ALTER TABLE "impact_event_basis_evidences" ADD CONSTRAINT "impact_event_basis_evidences_evidence_id_evidences_id_fk" FOREIGN KEY ("evidence_id") REFERENCES "public"."evidences"("id") ON DELETE cascade ON UPDATE cascade NOT VALID;--> statement-breakpoint
+ALTER TABLE "impact_event_causes" ADD CONSTRAINT "impact_event_causes_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade NOT VALID;--> statement-breakpoint
+ALTER TABLE "impact_event_entity_facilities" ADD CONSTRAINT "impact_event_entity_facilities_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade NOT VALID;--> statement-breakpoint
+ALTER TABLE "impact_event_entity_services" ADD CONSTRAINT "impact_event_entity_services_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade NOT VALID;--> statement-breakpoint
+ALTER TABLE "impact_event_facility_effects" ADD CONSTRAINT "impact_event_facility_effects_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade NOT VALID;--> statement-breakpoint
+ALTER TABLE "impact_event_periods" ADD CONSTRAINT "impact_event_periods_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade NOT VALID;--> statement-breakpoint
+ALTER TABLE "impact_event_service_effects" ADD CONSTRAINT "impact_event_service_effects_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade NOT VALID;--> statement-breakpoint
+ALTER TABLE "impact_event_service_scopes" ADD CONSTRAINT "impact_event_service_scopes_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade NOT VALID;--> statement-breakpoint
+ALTER TABLE "impact_events" ADD CONSTRAINT "impact_events_issue_id_issues_id_fk" FOREIGN KEY ("issue_id") REFERENCES "public"."issues"("id") ON DELETE cascade ON UPDATE cascade NOT VALID;--> statement-breakpoint
+ALTER TABLE "evidences" VALIDATE CONSTRAINT "evidences_issue_id_issues_id_fk";--> statement-breakpoint
+ALTER TABLE "impact_event_basis_evidences" VALIDATE CONSTRAINT "impact_event_basis_evidences_impact_event_id_impact_events_id_fk";--> statement-breakpoint
+ALTER TABLE "impact_event_basis_evidences" VALIDATE CONSTRAINT "impact_event_basis_evidences_evidence_id_evidences_id_fk";--> statement-breakpoint
+ALTER TABLE "impact_event_causes" VALIDATE CONSTRAINT "impact_event_causes_impact_event_id_impact_events_id_fk";--> statement-breakpoint
+ALTER TABLE "impact_event_entity_facilities" VALIDATE CONSTRAINT "impact_event_entity_facilities_impact_event_id_impact_events_id_fk";--> statement-breakpoint
+ALTER TABLE "impact_event_entity_services" VALIDATE CONSTRAINT "impact_event_entity_services_impact_event_id_impact_events_id_fk";--> statement-breakpoint
+ALTER TABLE "impact_event_facility_effects" VALIDATE CONSTRAINT "impact_event_facility_effects_impact_event_id_impact_events_id_fk";--> statement-breakpoint
+ALTER TABLE "impact_event_periods" VALIDATE CONSTRAINT "impact_event_periods_impact_event_id_impact_events_id_fk";--> statement-breakpoint
+ALTER TABLE "impact_event_service_effects" VALIDATE CONSTRAINT "impact_event_service_effects_impact_event_id_impact_events_id_fk";--> statement-breakpoint
+ALTER TABLE "impact_event_service_scopes" VALIDATE CONSTRAINT "impact_event_service_scopes_impact_event_id_impact_events_id_fk";--> statement-breakpoint
+ALTER TABLE "impact_events" VALIDATE CONSTRAINT "impact_events_issue_id_issues_id_fk";

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,3245 @@
+{
+  "id": "bea2a294-02eb-4799-801f-234a32e91d95",
+  "prevId": "fc292000-dcba-4129-81a7-eaa6906e0bf9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.evidences": {
+      "name": "evidences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "evidence_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "render": {
+          "name": "render",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "evidences_issue_id_idx": {
+          "name": "evidences_issue_id_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "evidences_ts_idx": {
+          "name": "evidences_ts_idx",
+          "columns": [
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evidences_issue_id_issues_id_fk": {
+          "name": "evidences_issue_id_issues_id_fk",
+          "tableFrom": "evidences",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_basis_evidences": {
+      "name": "impact_event_basis_evidences",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_id": {
+          "name": "evidence_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_basis_evidences_impact_event_id_idx": {
+          "name": "impact_event_basis_evidences_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_basis_evidences_evidence_id_idx": {
+          "name": "impact_event_basis_evidences_evidence_id_idx",
+          "columns": [
+            {
+              "expression": "evidence_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_event_basis_evidences_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_basis_evidences_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_basis_evidences",
+          "tableTo": "impact_events",
+          "columnsFrom": [
+            "impact_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "impact_event_basis_evidences_evidence_id_evidences_id_fk": {
+          "name": "impact_event_basis_evidences_evidence_id_evidences_id_fk",
+          "tableFrom": "impact_event_basis_evidences",
+          "tableTo": "evidences",
+          "columnsFrom": [
+            "evidence_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_basis_evidences_impact_event_id_evidence_id_pk": {
+          "name": "impact_event_basis_evidences_impact_event_id_evidence_id_pk",
+          "columns": [
+            "impact_event_id",
+            "evidence_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_causes": {
+      "name": "impact_event_causes",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "impact_event_cause_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_causes_impact_event_id_idx": {
+          "name": "impact_event_causes_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_event_causes_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_causes_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_causes",
+          "tableTo": "impact_events",
+          "columnsFrom": [
+            "impact_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_causes_impact_event_id_type_pk": {
+          "name": "impact_event_causes_impact_event_id_type_pk",
+          "columns": [
+            "impact_event_id",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_entity_facilities": {
+      "name": "impact_event_entity_facilities",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "affected_entity_facility_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_entity_facilities_impact_event_id_idx": {
+          "name": "impact_event_entity_facilities_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_entity_facilities_station_id_idx": {
+          "name": "impact_event_entity_facilities_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_entity_facilities_line_id_idx": {
+          "name": "impact_event_entity_facilities_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_event_entity_facilities_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_entity_facilities_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_entity_facilities",
+          "tableTo": "impact_events",
+          "columnsFrom": [
+            "impact_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "impact_event_entity_facilities_station_id_stations_id_fk": {
+          "name": "impact_event_entity_facilities_station_id_stations_id_fk",
+          "tableFrom": "impact_event_entity_facilities",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "impact_event_entity_facilities_line_id_lines_id_fk": {
+          "name": "impact_event_entity_facilities_line_id_lines_id_fk",
+          "tableFrom": "impact_event_entity_facilities",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_entity_facilities_impact_event_id_station_id_kind_pk": {
+          "name": "impact_event_entity_facilities_impact_event_id_station_id_kind_pk",
+          "columns": [
+            "impact_event_id",
+            "station_id",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_entity_services": {
+      "name": "impact_event_entity_services",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_entity_services_impact_event_id_idx": {
+          "name": "impact_event_entity_services_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_entity_services_service_id_idx": {
+          "name": "impact_event_entity_services_service_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_event_entity_services_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_entity_services_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_entity_services",
+          "tableTo": "impact_events",
+          "columnsFrom": [
+            "impact_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "impact_event_entity_services_service_id_services_id_fk": {
+          "name": "impact_event_entity_services_service_id_services_id_fk",
+          "tableFrom": "impact_event_entity_services",
+          "tableTo": "services",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_entity_services_impact_event_id_service_id_pk": {
+          "name": "impact_event_entity_services_impact_event_id_service_id_pk",
+          "columns": [
+            "impact_event_id",
+            "service_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_facility_effects": {
+      "name": "impact_event_facility_effects",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "facility_effect_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_facility_effects_impact_event_id_idx": {
+          "name": "impact_event_facility_effects_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_facility_effects_kind_idx": {
+          "name": "impact_event_facility_effects_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_event_facility_effects_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_facility_effects_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_facility_effects",
+          "tableTo": "impact_events",
+          "columnsFrom": [
+            "impact_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_facility_effects_impact_event_id_kind_pk": {
+          "name": "impact_event_facility_effects_impact_event_id_kind_pk",
+          "columns": [
+            "impact_event_id",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_periods": {
+      "name": "impact_event_periods",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "resolve_periods_mode_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_ts": {
+          "name": "start_ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_ts": {
+          "name": "end_ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_ts_resolved": {
+          "name": "end_ts_resolved",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at_source": {
+          "name": "end_at_source",
+          "type": "resolve_periods_end_at_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at_reason": {
+          "name": "end_at_reason",
+          "type": "resolve_periods_end_at_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_periods_set_periods_impact_event_id_idx": {
+          "name": "impact_event_periods_set_periods_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_periods_mode_idx": {
+          "name": "impact_event_periods_mode_idx",
+          "columns": [
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_periods_start_at_idx": {
+          "name": "impact_event_periods_start_at_idx",
+          "columns": [
+            {
+              "expression": "start_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_periods_end_at_idx": {
+          "name": "impact_event_periods_end_at_idx",
+          "columns": [
+            {
+              "expression": "end_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_periods_end_at_resolved_idx": {
+          "name": "impact_event_periods_end_at_resolved_idx",
+          "columns": [
+            {
+              "expression": "end_ts_resolved",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_periods_end_at_source_idx": {
+          "name": "impact_event_periods_end_at_source_idx",
+          "columns": [
+            {
+              "expression": "end_at_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_periods_end_at_reason_idx": {
+          "name": "impact_event_periods_end_at_reason_idx",
+          "columns": [
+            {
+              "expression": "end_at_reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_event_periods_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_periods_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_periods",
+          "tableTo": "impact_events",
+          "columnsFrom": [
+            "impact_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_periods_impact_event_id_index_mode_pk": {
+          "name": "impact_event_periods_impact_event_id_index_mode_pk",
+          "columns": [
+            "impact_event_id",
+            "index",
+            "mode"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_service_effects": {
+      "name": "impact_event_service_effects",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "service_effect_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "interval",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_service_effects_impact_event_id_idx": {
+          "name": "impact_event_service_effects_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_service_effects_kind_idx": {
+          "name": "impact_event_service_effects_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_event_service_effects_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_service_effects_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_service_effects",
+          "tableTo": "impact_events",
+          "columnsFrom": [
+            "impact_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_service_effects_impact_event_id_kind_pk": {
+          "name": "impact_event_service_effects_impact_event_id_kind_pk",
+          "columns": [
+            "impact_event_id",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_service_scopes": {
+      "name": "impact_event_service_scopes",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "impact_event_service_scope_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_station_id": {
+          "name": "from_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_station_id": {
+          "name": "to_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_service_scopes_impact_event_id_idx": {
+          "name": "impact_event_service_scopes_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_service_scopes_type_idx": {
+          "name": "impact_event_service_scopes_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_service_scopes_station_id_idx": {
+          "name": "impact_event_service_scopes_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_service_scopes_from_station_id_idx": {
+          "name": "impact_event_service_scopes_from_station_id_idx",
+          "columns": [
+            {
+              "expression": "from_station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_service_scopes_to_station_id_idx": {
+          "name": "impact_event_service_scopes_to_station_id_idx",
+          "columns": [
+            {
+              "expression": "to_station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_event_service_scopes_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_service_scopes_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_service_scopes",
+          "tableTo": "impact_events",
+          "columnsFrom": [
+            "impact_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "impact_event_service_scopes_station_id_stations_id_fk": {
+          "name": "impact_event_service_scopes_station_id_stations_id_fk",
+          "tableFrom": "impact_event_service_scopes",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "impact_event_service_scopes_from_station_id_stations_id_fk": {
+          "name": "impact_event_service_scopes_from_station_id_stations_id_fk",
+          "tableFrom": "impact_event_service_scopes",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "from_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "impact_event_service_scopes_to_station_id_stations_id_fk": {
+          "name": "impact_event_service_scopes_to_station_id_stations_id_fk",
+          "tableFrom": "impact_event_service_scopes",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "to_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_service_scopes_impact_event_id_index_pk": {
+          "name": "impact_event_service_scopes_impact_event_id_index_pk",
+          "columns": [
+            "impact_event_id",
+            "index"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "impact_event_service_scopes_type_station_shape_check": {
+          "name": "impact_event_service_scopes_type_station_shape_check",
+          "value": "\n          (\n            \"impact_event_service_scopes\".\"type\" = 'service.whole'\n            and \"impact_event_service_scopes\".\"station_id\" is null\n            and \"impact_event_service_scopes\".\"from_station_id\" is null\n            and \"impact_event_service_scopes\".\"to_station_id\" is null\n          )\n          or (\n            \"impact_event_service_scopes\".\"type\" = 'service.point'\n            and \"impact_event_service_scopes\".\"station_id\" is not null\n            and \"impact_event_service_scopes\".\"from_station_id\" is null\n            and \"impact_event_service_scopes\".\"to_station_id\" is null\n          )\n          or (\n            \"impact_event_service_scopes\".\"type\" = 'service.segment'\n            and \"impact_event_service_scopes\".\"station_id\" is null\n            and \"impact_event_service_scopes\".\"from_station_id\" is not null\n            and \"impact_event_service_scopes\".\"to_station_id\" is not null\n          )\n        "
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.impact_events": {
+      "name": "impact_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_events_issue_id_idx": {
+          "name": "impact_events_issue_id_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_events_issue_id_issues_id_fk": {
+          "name": "impact_events_issue_id_issues_id_fk",
+          "tableFrom": "impact_events",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_day_facts": {
+      "name": "issue_day_facts",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "issue_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_anytime": {
+          "name": "active_anytime",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_end_of_day": {
+          "name": "active_end_of_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inferred_interval_count": {
+          "name": "inferred_interval_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_day_facts_issue_id_idx": {
+          "name": "issue_day_facts_issue_id_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_day_facts_date_issue_type_idx": {
+          "name": "issue_day_facts_date_issue_type_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_day_facts_as_of_idx": {
+          "name": "issue_day_facts_as_of_idx",
+          "columns": [
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_day_facts_issue_id_issues_id_fk": {
+          "name": "issue_day_facts_issue_id_issues_id_fk",
+          "tableFrom": "issue_day_facts",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_day_facts_date_issue_id_pk": {
+          "name": "issue_day_facts_date_issue_id_pk",
+          "columns": [
+            "date",
+            "issue_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues_next": {
+      "name": "issues_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "issue_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_meta": {
+          "name": "title_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidences": {
+          "name": "evidences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impact_events": {
+          "name": "impact_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "issue_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_meta": {
+          "name": "title_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.landmarks_next": {
+      "name": "landmarks_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.landmarks": {
+      "name": "landmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.line_day_facts": {
+      "name": "line_day_facts",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_seconds": {
+          "name": "service_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downtime_disruption_seconds": {
+          "name": "downtime_disruption_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downtime_maintenance_seconds": {
+          "name": "downtime_maintenance_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downtime_infra_seconds": {
+          "name": "downtime_infra_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_count_disruption": {
+          "name": "issue_count_disruption",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_count_maintenance": {
+          "name": "issue_count_maintenance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_count_infra": {
+          "name": "issue_count_infra",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "line_day_facts_line_id_idx": {
+          "name": "line_day_facts_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "line_day_facts_date_idx": {
+          "name": "line_day_facts_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "line_day_facts_as_of_idx": {
+          "name": "line_day_facts_as_of_idx",
+          "columns": [
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "line_day_facts_line_id_lines_id_fk": {
+          "name": "line_day_facts_line_id_lines_id_fk",
+          "tableFrom": "line_day_facts",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "line_day_facts_date_line_id_pk": {
+          "name": "line_day_facts_date_line_id_pk",
+          "columns": [
+            "date",
+            "line_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.line_operators": {
+      "name": "line_operators",
+      "schema": "",
+      "columns": {
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator_id": {
+          "name": "operator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "line_operators_line_id_idx": {
+          "name": "line_operators_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "line_operators_operator_id_idx": {
+          "name": "line_operators_operator_id_idx",
+          "columns": [
+            {
+              "expression": "operator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "line_operators_line_id_lines_id_fk": {
+          "name": "line_operators_line_id_lines_id_fk",
+          "tableFrom": "line_operators",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "line_operators_operator_id_operators_id_fk": {
+          "name": "line_operators_operator_id_operators_id_fk",
+          "tableFrom": "line_operators",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "line_operators_line_id_operator_id_pk": {
+          "name": "line_operators_line_id_operator_id_pk",
+          "columns": [
+            "line_id",
+            "operator_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.line_services": {
+      "name": "line_services",
+      "schema": "",
+      "columns": {
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "line_services_line_id_idx": {
+          "name": "line_services_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "line_services_service_id_idx": {
+          "name": "line_services_service_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "line_services_line_id_lines_id_fk": {
+          "name": "line_services_line_id_lines_id_fk",
+          "tableFrom": "line_services",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "line_services_service_id_services_id_fk": {
+          "name": "line_services_service_id_services_id_fk",
+          "tableFrom": "line_services",
+          "tableTo": "services",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "line_services_line_id_service_id_pk": {
+          "name": "line_services_line_id_service_id_pk",
+          "columns": [
+            "line_id",
+            "service_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lines_next": {
+      "name": "lines_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "line_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operating_hours": {
+          "name": "operating_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operators": {
+          "name": "operators",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lines": {
+      "name": "lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "line_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operating_hours": {
+          "name": "operating_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metadata": {
+      "name": "metadata",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operators_next": {
+      "name": "operators_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "founded_at": {
+          "name": "founded_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operators": {
+      "name": "operators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "founded_at": {
+          "name": "founded_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.public_holidays": {
+      "name": "public_holidays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "holiday_name": {
+          "name": "holiday_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_revision_path_station_entries": {
+      "name": "service_revision_path_station_entries",
+      "schema": "",
+      "columns": {
+        "service_revision_id": {
+          "name": "service_revision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_code": {
+          "name": "display_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_index": {
+          "name": "path_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "service_revision_path_entries_service_revision_id_idx": {
+          "name": "service_revision_path_entries_service_revision_id_idx",
+          "columns": [
+            {
+              "expression": "service_revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_revision_path_entries_service_id_idx": {
+          "name": "service_revision_path_entries_service_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_revision_path_entries_station_id_idx": {
+          "name": "service_revision_path_entries_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_revision_path_entries_path_index_idx": {
+          "name": "service_revision_path_entries_path_index_idx",
+          "columns": [
+            {
+              "expression": "path_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sr_path_entries_revision_fk": {
+          "name": "sr_path_entries_revision_fk",
+          "tableFrom": "service_revision_path_station_entries",
+          "tableTo": "service_revisions",
+          "columnsFrom": [
+            "service_revision_id",
+            "service_id"
+          ],
+          "columnsTo": [
+            "id",
+            "service_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sr_path_entries_station_fk": {
+          "name": "sr_path_entries_station_fk",
+          "tableFrom": "service_revision_path_station_entries",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "sr_path_entries_pk": {
+          "name": "sr_path_entries_pk",
+          "columns": [
+            "service_revision_id",
+            "service_id",
+            "station_id",
+            "path_index"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_revisions": {
+      "name": "service_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operating_hours": {
+          "name": "operating_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "service_revisions_service_id_idx": {
+          "name": "service_revisions_service_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_revisions_service_id_services_id_fk": {
+          "name": "service_revisions_service_id_services_id_fk",
+          "tableFrom": "service_revisions",
+          "tableTo": "services",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "service_revisions_id_service_id_pk": {
+          "name": "service_revisions_id_service_id_pk",
+          "columns": [
+            "id",
+            "service_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services_next": {
+      "name": "services_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revisions": {
+          "name": "revisions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "services_line_id_idx": {
+          "name": "services_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "services_line_id_lines_id_fk": {
+          "name": "services_line_id_lines_id_fk",
+          "tableFrom": "services",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_codes": {
+      "name": "station_codes",
+      "schema": "",
+      "columns": {
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structure_type": {
+          "name": "structure_type",
+          "type": "station_structure_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_codes_line_id_idx": {
+          "name": "station_codes_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_codes_station_id_idx": {
+          "name": "station_codes_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "station_codes_line_id_lines_id_fk": {
+          "name": "station_codes_line_id_lines_id_fk",
+          "tableFrom": "station_codes",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "station_codes_station_id_stations_id_fk": {
+          "name": "station_codes_station_id_stations_id_fk",
+          "tableFrom": "station_codes",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "station_codes_line_id_station_id_code_pk": {
+          "name": "station_codes_line_id_station_id_code_pk",
+          "columns": [
+            "line_id",
+            "station_id",
+            "code"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_landmarks": {
+      "name": "station_landmarks",
+      "schema": "",
+      "columns": {
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "landmark_id": {
+          "name": "landmark_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_landmarks_station_id_idx": {
+          "name": "station_landmarks_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_landmarks_landmark_id_idx": {
+          "name": "station_landmarks_landmark_id_idx",
+          "columns": [
+            {
+              "expression": "landmark_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "station_landmarks_station_id_stations_id_fk": {
+          "name": "station_landmarks_station_id_stations_id_fk",
+          "tableFrom": "station_landmarks",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "station_landmarks_landmark_id_landmarks_id_fk": {
+          "name": "station_landmarks_landmark_id_landmarks_id_fk",
+          "tableFrom": "station_landmarks",
+          "tableTo": "landmarks",
+          "columnsFrom": [
+            "landmark_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "station_landmarks_station_id_landmark_id_pk": {
+          "name": "station_landmarks_station_id_landmark_id_pk",
+          "columns": [
+            "station_id",
+            "landmark_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations_next": {
+      "name": "stations_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geo": {
+          "name": "geo",
+          "type": "geometry(point)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "town_id": {
+          "name": "town_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_codes": {
+          "name": "station_codes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "landmark_ids": {
+          "name": "landmark_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "stations_next_geo_idx": {
+          "name": "stations_next_geo_idx",
+          "columns": [
+            {
+              "expression": "geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geo": {
+          "name": "geo",
+          "type": "geometry(point)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "town_id": {
+          "name": "town_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stations_geo_idx": {
+          "name": "stations_geo_idx",
+          "columns": [
+            {
+              "expression": "geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stations_town_id_towns_id_fk": {
+          "name": "stations_town_id_towns_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "towns",
+          "columnsFrom": [
+            "town_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towns_next": {
+      "name": "towns_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towns": {
+      "name": "towns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.affected_entity_facility_kind": {
+      "name": "affected_entity_facility_kind",
+      "schema": "public",
+      "values": [
+        "lift",
+        "escalator",
+        "screen-door"
+      ]
+    },
+    "public.evidence_type": {
+      "name": "evidence_type",
+      "schema": "public",
+      "values": [
+        "statement.official",
+        "report.public",
+        "report.media"
+      ]
+    },
+    "public.facility_effect_kind": {
+      "name": "facility_effect_kind",
+      "schema": "public",
+      "values": [
+        "out-of-service",
+        "degraded"
+      ]
+    },
+    "public.impact_event_cause_type": {
+      "name": "impact_event_cause_type",
+      "schema": "public",
+      "values": [
+        "signal.fault",
+        "track.fault",
+        "train.fault",
+        "power.fault",
+        "station.fault",
+        "security",
+        "weather",
+        "passenger.incident",
+        "platform_door.fault",
+        "delay",
+        "track.work",
+        "system.upgrade",
+        "elevator.outage",
+        "escalator.outage",
+        "air_conditioning.issue",
+        "station.renovation"
+      ]
+    },
+    "public.impact_event_service_scope_type": {
+      "name": "impact_event_service_scope_type",
+      "schema": "public",
+      "values": [
+        "service.whole",
+        "service.segment",
+        "service.point"
+      ]
+    },
+    "public.issue_type": {
+      "name": "issue_type",
+      "schema": "public",
+      "values": [
+        "disruption",
+        "maintenance",
+        "infra"
+      ]
+    },
+    "public.line_type": {
+      "name": "line_type",
+      "schema": "public",
+      "values": [
+        "mrt.high",
+        "mrt.medium",
+        "lrt"
+      ]
+    },
+    "public.resolve_periods_end_at_reason": {
+      "name": "resolve_periods_end_at_reason",
+      "schema": "public",
+      "values": [
+        "crowd_decay",
+        "evidence_timeout"
+      ]
+    },
+    "public.resolve_periods_end_at_source": {
+      "name": "resolve_periods_end_at_source",
+      "schema": "public",
+      "values": [
+        "fact",
+        "inferred",
+        "none"
+      ]
+    },
+    "public.resolve_periods_mode_kind": {
+      "name": "resolve_periods_mode_kind",
+      "schema": "public",
+      "values": [
+        "canonical",
+        "operational"
+      ]
+    },
+    "public.service_effect_kind": {
+      "name": "service_effect_kind",
+      "schema": "public",
+      "values": [
+        "delay",
+        "no-service",
+        "reduced-service",
+        "service-hours-adjustment"
+      ]
+    },
+    "public.station_structure_type": {
+      "name": "station_structure_type",
+      "schema": "public",
+      "values": [
+        "elevated",
+        "underground",
+        "at_grade",
+        "in_building"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1779119431333,
       "tag": "0003_curious_vision",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1779165097689,
+      "tag": "0004_eager_marten_broadcloak",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Keeps issue ingestion work bounded by preserving the existing batched pull sync changes on this branch.
- Adds database-level cascade behavior for `issues`, `evidences`, `impact_events`, and all normalized impact-event child tables.
- Adds Drizzle migration `0004_eager_marten_broadcloak.sql` and snapshot metadata to recreate the relevant foreign keys with `ON DELETE cascade ON UPDATE cascade`.

## Why

The pull workflow can delete and reinsert changed impact events during issue ingestion. Production hit a foreign-key violation while deleting from `impact_events` because `impact_event_periods` still referenced rows being removed. The code already performs explicit child cleanup, but the database constraints still used `ON DELETE no action`, so any missed or future parent delete could fail the same way.

## Validation

- `npm run build` passed.
- `npm test -- --run` could not complete in this environment: sandboxed run failed binding `0.0.0.0:9229`; escalated run reached Vitest startup but failed in the Cloudflare runner with `TypeError: filename.replace is not a function`.
- `npx tsc --noEmit` still reports existing unrelated frontend/client type errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized issue and impact-event promotion to use in-memory batching and bulk writes, improving sync performance and reliability
  * Increased sync batch size from 100 to 500 for higher throughput

* **Chores**
  * Enforced cascading deletes/updates across related tables to maintain data integrity during removals and updates
  * Applied a migration to update foreign-key behaviors and recorded the migration in the journal

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-site/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->