### PR TITLE
perf: remove hot history statistics fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ This is the web app that presents data on MRT/LRT disruptions in Singapore.
 
 ### Contributions
 
-Pull request titles should follow Conventional Commits, for example
+Pull request titles should follow [Conventional Commits](https://www.conventionalcommits.org/), for example
 `feat: add station history filters` or `fix: handle missing fact coverage`.

--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@ This is the web app that presents data on MRT/LRT disruptions in Singapore.
 1. Clone this repository
 2. `cd` and run `npm install`
 3. Run `npm run dev` and visit http://localhost:3000 in the browser.
+
+### Contributions
+
+Pull request titles should follow Conventional Commits, for example
+`feat: add station history filters` or `fix: handle missing fact coverage`.

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -1871,66 +1871,6 @@ function buildDurationChartsFromIssueFacts(
   });
 }
 
-function buildIssueCountChartsFromIssueFacts(
-  rows: Array<{
-    date: string;
-    issue_id: string;
-    issue_type: IssueType;
-    active_anytime: boolean;
-  }>,
-) {
-  const end = nowSg().startOf('day');
-  const activeRowsByDate = groupIssueFactRowsByDate(
-    rows.filter((row) => row.active_anytime),
-  );
-  const aggregateForRange = (
-    start: DateTime,
-    count: number,
-    previous = false,
-  ): Record<string, number> => {
-    const rangeStart = previous ? start.minus({ days: count }) : start;
-    const issueTypesById = new Map<string, IssueType>();
-    for (let offset = 0; offset < count; offset++) {
-      const date = rangeStart.plus({ days: offset }).toFormat('yyyy-MM-dd');
-      for (const row of activeRowsByDate.get(date) ?? []) {
-        issueTypesById.set(row.issue_id, row.issue_type);
-      }
-    }
-    return [...issueTypesById.values()].reduce<Record<IssueType, number>>(
-      (payload, issueType) => {
-        payload[issueType] += 1;
-        return payload;
-      },
-      emptyIssueTypePayload(),
-    );
-  };
-
-  return [7, 30, 90].map((count) => {
-    const start = end.minus({ days: count - 1 });
-    const data: ChartEntry[] = [];
-    for (let offset = 0; offset < count; offset++) {
-      const date = start.plus({ days: offset }).toFormat('yyyy-MM-dd');
-      data.push({
-        name: date,
-        payload: summarizeIssueFactRows(
-          activeRowsByDate.get(date) ?? [],
-          'count',
-        ),
-      });
-    }
-
-    return buildCountChart(
-      `${count}d`,
-      data,
-      [
-        { name: 'current', payload: aggregateForRange(start, count, false) },
-        { name: 'previous', payload: aggregateForRange(start, count, true) },
-      ],
-      makeTimeScale('day', count),
-    );
-  });
-}
-
 function isUndefinedTableError(error: unknown) {
   return (
     error != null &&
@@ -2024,7 +1964,7 @@ async function shouldUseLegacyHistoryFallback(
   context: string,
 ) {
   const today = nowSg().startOf('day');
-  if (end.startOf('day') > today) {
+  if (end.startOf('day') >= today) {
     return true;
   }
 
@@ -2942,9 +2882,7 @@ export async function getStatisticsData() {
   };
 
   const statistics: SystemAnalytics = {
-    timeScaleChartsIssueCount: hasIssueFactCoverage
-      ? buildIssueCountChartsFromIssueFacts(issueFactRows)
-      : buildIssueCountGraphs(issues),
+    timeScaleChartsIssueCount: buildIssueCountGraphs(issues),
     timeScaleChartsIssueDuration: hasIssueFactCoverage
       ? buildDurationChartsFromIssueFacts(issueFactRows)
       : buildIssueDurationGraphs(issues),

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -2023,10 +2023,13 @@ async function shouldUseLegacyHistoryFallback(
   end: DateTime,
   context: string,
 ) {
+  const today = nowSg().startOf('day');
+  if (end.startOf('day') > today) {
+    return true;
+  }
+
   const coverageEnd =
-    end.startOf('day') < nowSg().startOf('day')
-      ? end.startOf('day')
-      : nowSg().startOf('day');
+    end.startOf('day') < today ? end.startOf('day') : today;
   if (coverageEnd < start.startOf('day')) {
     return false;
   }
@@ -2858,10 +2861,14 @@ export async function getStatisticsData() {
     rollingYearStart,
     rollingYearEnd,
   );
-  await assertOperationalFactCoverage(
+  const factCoverageRows = await getOperationalFactCoverageDatesInRange(
     rollingYearStart,
     rollingYearEnd,
-    'statistics rolling year',
+  );
+  const hasIssueFactCoverage = hasFullDateCoverage(
+    factCoverageRows,
+    rollingYearStart,
+    rollingYearEnd,
   );
   const issuesByLineId = buildIssuesByLineId(issues);
   const issueFactRowsByDate = groupIssueFactRowsByDate(
@@ -2909,23 +2916,38 @@ export async function getStatisticsData() {
     title: 'Rolling Year Heatmap',
     data: Array.from({ length: 365 }, (_, index) => {
       const date = rollingYearStart.plus({ days: index }).toISODate()!;
+      if (hasIssueFactCoverage) {
+        return {
+          name: date,
+          payload: summarizeIssueFactRows(
+            issueFactRowsByDate.get(date) ?? [],
+            'count',
+          ),
+        };
+      }
+      const dayDate = DateTime.fromISO(date, { zone: SG_TIMEZONE });
+      const dayIssues = issues.filter((issue) =>
+        issueTouchesDate(issue, dayDate),
+      );
+      const counts = pickIssueTypes(dayIssues);
       return {
         name: date,
-        payload: summarizeIssueFactRows(
-          issueFactRowsByDate.get(date) ?? [],
-          'count',
-        ),
+        payload: {
+          disruption: counts.disruption ?? 0,
+          maintenance: counts.maintenance ?? 0,
+          infra: counts.infra ?? 0,
+        },
       };
     }),
   };
 
   const statistics: SystemAnalytics = {
-    timeScaleChartsIssueCount: buildIssueCountChartsFromIssueFacts(
-      issueFactRows,
-    ),
-    timeScaleChartsIssueDuration: buildDurationChartsFromIssueFacts(
-      issueFactRows,
-    ),
+    timeScaleChartsIssueCount: hasIssueFactCoverage
+      ? buildIssueCountChartsFromIssueFacts(issueFactRows)
+      : buildIssueCountGraphs(issues),
+    timeScaleChartsIssueDuration: hasIssueFactCoverage
+      ? buildDurationChartsFromIssueFacts(issueFactRows)
+      : buildIssueDurationGraphs(issues),
     chartTotalIssueCountByLine,
     chartTotalIssueCountByStation,
     chartRollingYearHeatmap,

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -1986,6 +1986,23 @@ async function getOperationalFactCoverageDatesInRange(
   }
 }
 
+async function getOperationalFactCoverageStartDate() {
+  const db = await getDefaultDb();
+  try {
+    const [row] = await db
+      .select({
+        startDate: sql<string | null>`min(${lineDayFactsTable.date})`,
+      })
+      .from(lineDayFactsTable);
+    return row?.startDate ?? null;
+  } catch (error) {
+    if (isUndefinedTableError(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
 function hasFullDateCoverage(
   rows: Array<{ date: string }>,
   start: DateTime,
@@ -1999,6 +2016,29 @@ function hasFullDateCoverage(
 
   const dates = new Set(rows.map((row) => row.date));
   return dates.size === expectedDays;
+}
+
+async function shouldUseLegacyHistoryFallback(
+  start: DateTime,
+  end: DateTime,
+  context: string,
+) {
+  const coverageRows = await getOperationalFactCoverageDatesInRange(start, end);
+  if (hasFullDateCoverage(coverageRows, start, end)) {
+    return false;
+  }
+
+  const coverageStart = await getOperationalFactCoverageStartDate();
+  if (
+    coverageStart != null &&
+    start.startOf('day') < DateTime.fromISO(coverageStart, { zone: SG_TIMEZONE })
+  ) {
+    return true;
+  }
+
+  throw new Error(
+    `Missing operational fact coverage for ${context}: ${start.toISODate()} to ${end.toISODate()}`,
+  );
 }
 
 async function assertOperationalFactCoverage(
@@ -2572,11 +2612,47 @@ export async function getHistoryYearSummaryData(year: number) {
     yearStart,
     yearEnd.minus({ days: 1 }),
   );
-  await assertOperationalFactCoverage(
-    yearStart,
-    yearEnd.minus({ days: 1 }),
-    `history year ${year}`,
-  );
+  if (
+    await shouldUseLegacyHistoryFallback(
+      yearStart,
+      yearEnd.minus({ days: 1 }),
+      `history year ${year}`,
+    )
+  ) {
+    const dataset = await getBaseDataset();
+    const issues = Object.values(dataset.allIssues).filter((issue) =>
+      issueOverlapsRange(issue, yearStart, yearEnd),
+    );
+
+    const summaryByMonth = Array.from({ length: 12 }, (_, index) => {
+      const monthStart = DateTime.fromObject(
+        { year, month: index + 1, day: 1 },
+        { zone: SG_TIMEZONE },
+      ).startOf('day');
+      const monthEnd = monthStart.plus({ months: 1 });
+      const monthIssues = issues.filter((issue) =>
+        issueOverlapsRange(issue, monthStart, monthEnd),
+      );
+      return {
+        month: monthStart.toISODate()!,
+        issueCountsByType: pickIssueTypes(monthIssues),
+        totalCount: monthIssues.length,
+      };
+    }).reverse();
+
+    return {
+      data: {
+        startAt: yearStart.toISODate()!,
+        endAt: yearEnd.minus({ day: 1 }).toISODate()!,
+        summaryByMonth,
+      },
+      included: withIssues(
+        dataset.included,
+        dataset.allIssues,
+        issues.map((issue) => issue.id),
+      ),
+    };
+  }
   const issueIds = [...new Set(factRows.map((row) => row.issue_id))];
   const included = await getIncludedForIssueIds(issueIds);
   const uniqueIssuesByMonth = Array.from(
@@ -2632,11 +2708,59 @@ export async function getHistoryYearMonthData(year: number, month: number) {
     monthStart,
     monthEnd.minus({ days: 1 }),
   );
-  await assertOperationalFactCoverage(
-    monthStart,
-    monthEnd.minus({ days: 1 }),
-    `history month ${year}-${month.toString().padStart(2, '0')}`,
-  );
+  if (
+    await shouldUseLegacyHistoryFallback(
+      monthStart,
+      monthEnd.minus({ days: 1 }),
+      `history month ${year}-${month.toString().padStart(2, '0')}`,
+    )
+  ) {
+    const dataset = await getBaseDataset();
+
+    const issues = Object.values(dataset.allIssues).filter((issue) =>
+      issueOverlapsRange(issue, monthStart, monthEnd),
+    );
+
+    const weeks = new Map<string, string[]>();
+    for (
+      let date = monthStart.startOf('week');
+      date < monthEnd.endOf('week');
+      date = date.plus({ week: 1 })
+    ) {
+      const key = `${date.weekYear}-W${date.weekNumber.toString().padStart(2, '0')}`;
+      const issueIds = issues
+        .filter((issue) =>
+          issueOverlapsRange(
+            issue,
+            date.startOf('week'),
+            date.startOf('week').plus({ week: 1 }),
+          ),
+        )
+        .map((issue) => issue.id)
+        .sort((a, b) => b.localeCompare(a));
+      if (issueIds.length > 0 || !weeks.has(key)) {
+        weeks.set(key, issueIds);
+      }
+    }
+
+    return {
+      data: {
+        startAt: monthStart.toISODate()!,
+        endAt: monthEnd.minus({ day: 1 }).toISODate()!,
+        issuesByWeek: [...weeks.entries()]
+          .sort(([a], [b]) => b.localeCompare(a))
+          .map(([week, issueIds]) => ({
+            week,
+            issueIds,
+          })),
+      },
+      included: withIssues(
+        dataset.included,
+        dataset.allIssues,
+        issues.map((issue) => issue.id),
+      ),
+    };
+  }
   const issueIds = [...new Set(factRows.map((row) => row.issue_id))];
   const included = await getIncludedForIssueIds(issueIds);
   const weeks = new Map<string, Set<string>>();
@@ -2681,7 +2805,24 @@ export async function getHistoryDayData(
 ) {
   const date = DateTime.fromObject({ year, month, day }, { zone: SG_TIMEZONE });
   const factRows = await getIssueDayFactsInRange(date, date);
-  await assertOperationalFactCoverage(date, date, `history day ${date}`);
+  if (await shouldUseLegacyHistoryFallback(date, date, `history day ${date}`)) {
+    const dataset = await getBaseDataset();
+    const issues = Object.values(dataset.allIssues).filter((issue) =>
+      issueTouchesDate(issue, date),
+    );
+    const issueIds = issues
+      .map((issue) => issue.id)
+      .sort((a, b) => b.localeCompare(a));
+
+    return {
+      data: {
+        startAt: date.toISODate()!,
+        endAt: date.toISODate()!,
+        issueIds,
+      },
+      included: withIssues(dataset.included, dataset.allIssues, issueIds),
+    };
+  }
   const issueIds = [...new Set(factRows.map((row) => row.issue_id))].sort(
     (a, b) => b.localeCompare(a),
   );

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -1310,7 +1310,7 @@ async function getIncludedForIssueIds(issueIds: readonly string[]) {
 function withIssues(
   baseIncluded: BaseIncludedEntities,
   allIssues: Record<string, Issue>,
-  issueIds?: string[],
+  issueIds?: readonly string[],
 ): IncludedEntities {
   const selectedIssues =
     issueIds == null

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -2023,8 +2023,19 @@ async function shouldUseLegacyHistoryFallback(
   end: DateTime,
   context: string,
 ) {
-  const coverageRows = await getOperationalFactCoverageDatesInRange(start, end);
-  if (hasFullDateCoverage(coverageRows, start, end)) {
+  const coverageEnd =
+    end.startOf('day') < nowSg().startOf('day')
+      ? end.startOf('day')
+      : nowSg().startOf('day');
+  if (coverageEnd < start.startOf('day')) {
+    return false;
+  }
+
+  const coverageRows = await getOperationalFactCoverageDatesInRange(
+    start,
+    coverageEnd,
+  );
+  if (hasFullDateCoverage(coverageRows, start, coverageEnd)) {
     return false;
   }
 
@@ -2037,7 +2048,7 @@ async function shouldUseLegacyHistoryFallback(
   }
 
   throw new Error(
-    `Missing operational fact coverage for ${context}: ${start.toISODate()} to ${end.toISODate()}`,
+    `Missing operational fact coverage for ${context}: ${start.toISODate()} to ${coverageEnd.toISODate()}`,
   );
 }
 

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -572,11 +572,14 @@ function buildCountChart(
   };
 }
 
-async function buildBaseDataset(
+async function buildDataset(
   referenceNow = nowSg(),
   db?: AppDb,
+  issueIds?: readonly string[],
 ): Promise<BaseDataset> {
   const database = db ?? (await getDefaultDb());
+  const selectedIssueIds =
+    issueIds == null ? undefined : [...new Set(issueIds)];
 
   const [
     metadataRows,
@@ -615,15 +618,40 @@ async function buildBaseDataset(
     database.select().from(servicesTable),
     database.select().from(serviceRevisionsTable),
     database.select().from(publicHolidaysTable),
-    database.select().from(issuesTable),
-    database
-      .select({
-        issue_id: evidencesTable.issue_id,
-        latest_ts: sql<string>`max(${evidencesTable.ts})`,
-      })
-      .from(evidencesTable)
-      .groupBy(evidencesTable.issue_id),
-    database.select().from(impactEventsTable),
+    selectedIssueIds == null
+      ? database.select().from(issuesTable)
+      : selectedIssueIds.length > 0
+        ? database
+            .select()
+            .from(issuesTable)
+            .where(inArray(issuesTable.id, selectedIssueIds))
+        : [],
+    selectedIssueIds == null
+      ? database
+          .select({
+            issue_id: evidencesTable.issue_id,
+            latest_ts: sql<string>`max(${evidencesTable.ts})`,
+          })
+          .from(evidencesTable)
+          .groupBy(evidencesTable.issue_id)
+      : selectedIssueIds.length > 0
+        ? database
+            .select({
+              issue_id: evidencesTable.issue_id,
+              latest_ts: sql<string>`max(${evidencesTable.ts})`,
+            })
+            .from(evidencesTable)
+            .where(inArray(evidencesTable.issue_id, selectedIssueIds))
+            .groupBy(evidencesTable.issue_id)
+        : [],
+    selectedIssueIds == null
+      ? database.select().from(impactEventsTable)
+      : selectedIssueIds.length > 0
+        ? database
+            .select()
+            .from(impactEventsTable)
+            .where(inArray(impactEventsTable.issue_id, selectedIssueIds))
+        : [],
   ]);
 
   const latestEventByTypeByIssueId = impactEventRows.reduce<
@@ -1253,6 +1281,13 @@ async function buildBaseDataset(
   };
 }
 
+async function buildBaseDataset(
+  referenceNow = nowSg(),
+  db?: AppDb,
+): Promise<BaseDataset> {
+  return buildDataset(referenceNow, db);
+}
+
 async function getBaseDataset() {
   const now = Date.now();
   if (cachedBaseDataset != null && cachedBaseDataset.expiresAt > now) {
@@ -1265,6 +1300,11 @@ async function getBaseDataset() {
     value: dataset,
   };
   return dataset;
+}
+
+async function getIncludedForIssueIds(issueIds: readonly string[]) {
+  const dataset = await buildDataset(nowSg(), undefined, issueIds);
+  return withIssues(dataset.included, dataset.allIssues, issueIds);
 }
 
 function withIssues(
@@ -1831,6 +1871,66 @@ function buildDurationChartsFromIssueFacts(
   });
 }
 
+function buildIssueCountChartsFromIssueFacts(
+  rows: Array<{
+    date: string;
+    issue_id: string;
+    issue_type: IssueType;
+    active_anytime: boolean;
+  }>,
+) {
+  const end = nowSg().startOf('day');
+  const activeRowsByDate = groupIssueFactRowsByDate(
+    rows.filter((row) => row.active_anytime),
+  );
+  const aggregateForRange = (
+    start: DateTime,
+    count: number,
+    previous = false,
+  ): Record<string, number> => {
+    const rangeStart = previous ? start.minus({ days: count }) : start;
+    const issueTypesById = new Map<string, IssueType>();
+    for (let offset = 0; offset < count; offset++) {
+      const date = rangeStart.plus({ days: offset }).toFormat('yyyy-MM-dd');
+      for (const row of activeRowsByDate.get(date) ?? []) {
+        issueTypesById.set(row.issue_id, row.issue_type);
+      }
+    }
+    return [...issueTypesById.values()].reduce<Record<IssueType, number>>(
+      (payload, issueType) => {
+        payload[issueType] += 1;
+        return payload;
+      },
+      emptyIssueTypePayload(),
+    );
+  };
+
+  return [7, 30, 90].map((count) => {
+    const start = end.minus({ days: count - 1 });
+    const data: ChartEntry[] = [];
+    for (let offset = 0; offset < count; offset++) {
+      const date = start.plus({ days: offset }).toFormat('yyyy-MM-dd');
+      data.push({
+        name: date,
+        payload: summarizeIssueFactRows(
+          activeRowsByDate.get(date) ?? [],
+          'count',
+        ),
+      });
+    }
+
+    return buildCountChart(
+      `${count}d`,
+      data,
+      [
+        { name: 'current', payload: aggregateForRange(start, count, false) },
+        { name: 'previous', payload: aggregateForRange(start, count, true) },
+      ],
+      makeTimeScale('day', count),
+    );
+  });
+}
+
 function isUndefinedTableError(error: unknown) {
   return (
     error != null &&
@@ -1860,6 +1960,32 @@ async function getIssueDayFactsInRange(start: DateTime, end: DateTime) {
   }
 }
 
+async function getOperationalFactCoverageDatesInRange(
+  start: DateTime,
+  end: DateTime,
+) {
+  const db = await getDefaultDb();
+  try {
+    return await db
+      .select({
+        date: lineDayFactsTable.date,
+      })
+      .from(lineDayFactsTable)
+      .where(
+        and(
+          gte(lineDayFactsTable.date, start.toISODate()!),
+          lte(lineDayFactsTable.date, end.toISODate()!),
+        ),
+      )
+      .groupBy(lineDayFactsTable.date);
+  } catch (error) {
+    if (isUndefinedTableError(error)) {
+      return [];
+    }
+    throw error;
+  }
+}
+
 function hasFullDateCoverage(
   rows: Array<{ date: string }>,
   start: DateTime,
@@ -1873,6 +1999,19 @@ function hasFullDateCoverage(
 
   const dates = new Set(rows.map((row) => row.date));
   return dates.size === expectedDays;
+}
+
+async function assertOperationalFactCoverage(
+  start: DateTime,
+  end: DateTime,
+  context: string,
+) {
+  const coverageRows = await getOperationalFactCoverageDatesInRange(start, end);
+  if (!hasFullDateCoverage(coverageRows, start, end)) {
+    throw new Error(
+      `Missing operational fact coverage for ${context}: ${start.toISODate()} to ${end.toISODate()}`,
+    );
+  }
 }
 
 async function rebuildOperationalFactsForDateFromDataset(
@@ -2433,70 +2572,43 @@ export async function getHistoryYearSummaryData(year: number) {
     yearStart,
     yearEnd.minus({ days: 1 }),
   );
-  if (hasFullDateCoverage(factRows, yearStart, yearEnd.minus({ days: 1 }))) {
-    const dataset = await getBaseDataset();
-    const issueIds = [...new Set(factRows.map((row) => row.issue_id))];
-    const uniqueIssuesByMonth = Array.from(
-      { length: 12 },
-      () => new Map<string, IssueType>(),
-    );
-
-    for (const row of factRows) {
-      const date = parseDateTime(row.date);
-      uniqueIssuesByMonth[date.month - 1]?.set(
-        row.issue_id,
-        row.issue_type as IssueType,
-      );
-    }
-
-    const summaryByMonth = Array.from({ length: 12 }, (_, index) => {
-      const monthStart = DateTime.fromObject(
-        { year, month: index + 1, day: 1 },
-        { zone: SG_TIMEZONE },
-      ).startOf('day');
-      const uniqueIssues =
-        uniqueIssuesByMonth[index] ?? new Map<string, IssueType>();
-      const issueCountsByType = [...uniqueIssues.values()].reduce<
-        Partial<Record<IssueType, number>>
-      >((acc, type) => {
-        acc[type] = (acc[type] ?? 0) + 1;
-        return acc;
-      }, {});
-      return {
-        month: monthStart.toISODate()!,
-        issueCountsByType,
-        totalCount: uniqueIssues.size,
-      };
-    }).reverse();
-
-    return {
-      data: {
-        startAt: yearStart.toISODate()!,
-        endAt: yearEnd.minus({ day: 1 }).toISODate()!,
-        summaryByMonth,
-      },
-      included: withIssues(dataset.included, dataset.allIssues, issueIds),
-    };
-  }
-
-  const dataset = await getBaseDataset();
-  const issues = Object.values(dataset.allIssues).filter((issue) =>
-    issueOverlapsRange(issue, yearStart, yearEnd),
+  await assertOperationalFactCoverage(
+    yearStart,
+    yearEnd.minus({ days: 1 }),
+    `history year ${year}`,
   );
+  const issueIds = [...new Set(factRows.map((row) => row.issue_id))];
+  const included = await getIncludedForIssueIds(issueIds);
+  const uniqueIssuesByMonth = Array.from(
+    { length: 12 },
+    () => new Map<string, IssueType>(),
+  );
+
+  for (const row of factRows) {
+    const date = parseDateTime(row.date);
+    uniqueIssuesByMonth[date.month - 1]?.set(
+      row.issue_id,
+      row.issue_type as IssueType,
+    );
+  }
 
   const summaryByMonth = Array.from({ length: 12 }, (_, index) => {
     const monthStart = DateTime.fromObject(
       { year, month: index + 1, day: 1 },
       { zone: SG_TIMEZONE },
     ).startOf('day');
-    const monthEnd = monthStart.plus({ months: 1 });
-    const monthIssues = issues.filter((issue) =>
-      issueOverlapsRange(issue, monthStart, monthEnd),
-    );
+    const uniqueIssues =
+      uniqueIssuesByMonth[index] ?? new Map<string, IssueType>();
+    const issueCountsByType = [...uniqueIssues.values()].reduce<
+      Partial<Record<IssueType, number>>
+    >((acc, type) => {
+      acc[type] = (acc[type] ?? 0) + 1;
+      return acc;
+    }, {});
     return {
       month: monthStart.toISODate()!,
-      issueCountsByType: pickIssueTypes(monthIssues),
-      totalCount: monthIssues.length,
+      issueCountsByType,
+      totalCount: uniqueIssues.size,
     };
   }).reverse();
 
@@ -2506,11 +2618,7 @@ export async function getHistoryYearSummaryData(year: number) {
       endAt: yearEnd.minus({ day: 1 }).toISODate()!,
       summaryByMonth,
     },
-    included: withIssues(
-      dataset.included,
-      dataset.allIssues,
-      issues.map((issue) => issue.id),
-    ),
+    included,
   };
 }
 
@@ -2524,68 +2632,30 @@ export async function getHistoryYearMonthData(year: number, month: number) {
     monthStart,
     monthEnd.minus({ days: 1 }),
   );
-  if (hasFullDateCoverage(factRows, monthStart, monthEnd.minus({ days: 1 }))) {
-    const dataset = await getBaseDataset();
-    const issueIds = [...new Set(factRows.map((row) => row.issue_id))];
-    const weeks = new Map<string, Set<string>>();
-    for (
-      let date = monthStart.startOf('week');
-      date < monthEnd.endOf('week');
-      date = date.plus({ week: 1 })
-    ) {
-      const key = `${date.weekYear}-W${date.weekNumber.toString().padStart(2, '0')}`;
-      weeks.set(key, new Set());
-    }
-
-    for (const row of factRows) {
-      const date = parseDateTime(row.date);
-      const key = `${date.weekYear}-W${date.weekNumber.toString().padStart(2, '0')}`;
-      const issueIdsForWeek = weeks.get(key);
-      if (issueIdsForWeek != null) {
-        issueIdsForWeek.add(row.issue_id);
-      }
-    }
-
-    return {
-      data: {
-        startAt: monthStart.toISODate()!,
-        endAt: monthEnd.minus({ day: 1 }).toISODate()!,
-        issuesByWeek: [...weeks.entries()]
-          .sort(([a], [b]) => b.localeCompare(a))
-          .map(([week, ids]) => ({
-            week,
-            issueIds: [...ids].sort((a, b) => b.localeCompare(a)),
-          })),
-      },
-      included: withIssues(dataset.included, dataset.allIssues, issueIds),
-    };
-  }
-
-  const dataset = await getBaseDataset();
-
-  const issues = Object.values(dataset.allIssues).filter((issue) =>
-    issueOverlapsRange(issue, monthStart, monthEnd),
+  await assertOperationalFactCoverage(
+    monthStart,
+    monthEnd.minus({ days: 1 }),
+    `history month ${year}-${month.toString().padStart(2, '0')}`,
   );
+  const issueIds = [...new Set(factRows.map((row) => row.issue_id))];
+  const included = await getIncludedForIssueIds(issueIds);
+  const weeks = new Map<string, Set<string>>();
 
-  const weeks = new Map<string, string[]>();
   for (
     let date = monthStart.startOf('week');
     date < monthEnd.endOf('week');
     date = date.plus({ week: 1 })
   ) {
     const key = `${date.weekYear}-W${date.weekNumber.toString().padStart(2, '0')}`;
-    const issueIds = issues
-      .filter((issue) =>
-        issueOverlapsRange(
-          issue,
-          date.startOf('week'),
-          date.startOf('week').plus({ week: 1 }),
-        ),
-      )
-      .map((issue) => issue.id)
-      .sort((a, b) => b.localeCompare(a));
-    if (issueIds.length > 0 || !weeks.has(key)) {
-      weeks.set(key, issueIds);
+    weeks.set(key, new Set());
+  }
+
+  for (const row of factRows) {
+    const date = parseDateTime(row.date);
+    const key = `${date.weekYear}-W${date.weekNumber.toString().padStart(2, '0')}`;
+    const issueIdsForWeek = weeks.get(key);
+    if (issueIdsForWeek != null) {
+      issueIdsForWeek.add(row.issue_id);
     }
   }
 
@@ -2595,16 +2665,12 @@ export async function getHistoryYearMonthData(year: number, month: number) {
       endAt: monthEnd.minus({ day: 1 }).toISODate()!,
       issuesByWeek: [...weeks.entries()]
         .sort(([a], [b]) => b.localeCompare(a))
-        .map(([week, issueIds]) => ({
+        .map(([week, ids]) => ({
           week,
-          issueIds,
+          issueIds: [...ids].sort((a, b) => b.localeCompare(a)),
         })),
     },
-    included: withIssues(
-      dataset.included,
-      dataset.allIssues,
-      issues.map((issue) => issue.id),
-    ),
+    included,
   };
 }
 
@@ -2615,28 +2681,11 @@ export async function getHistoryDayData(
 ) {
   const date = DateTime.fromObject({ year, month, day }, { zone: SG_TIMEZONE });
   const factRows = await getIssueDayFactsInRange(date, date);
-  if (factRows.length > 0) {
-    const dataset = await getBaseDataset();
-    const issueIds = [...new Set(factRows.map((row) => row.issue_id))].sort(
-      (a, b) => b.localeCompare(a),
-    );
-    return {
-      data: {
-        startAt: date.toISODate()!,
-        endAt: date.toISODate()!,
-        issueIds,
-      },
-      included: withIssues(dataset.included, dataset.allIssues, issueIds),
-    };
-  }
-
-  const dataset = await getBaseDataset();
-  const issues = Object.values(dataset.allIssues).filter((issue) =>
-    issueTouchesDate(issue, date),
+  await assertOperationalFactCoverage(date, date, `history day ${date}`);
+  const issueIds = [...new Set(factRows.map((row) => row.issue_id))].sort(
+    (a, b) => b.localeCompare(a),
   );
-  const issueIds = issues
-    .map((issue) => issue.id)
-    .sort((a, b) => b.localeCompare(a));
+  const included = await getIncludedForIssueIds(issueIds);
 
   return {
     data: {
@@ -2644,7 +2693,7 @@ export async function getHistoryDayData(
       endAt: date.toISODate()!,
       issueIds,
     },
-    included: withIssues(dataset.included, dataset.allIssues, issueIds),
+    included,
   };
 }
 
@@ -2657,10 +2706,10 @@ export async function getStatisticsData() {
     rollingYearStart,
     rollingYearEnd,
   );
-  const hasIssueFactCoverage = hasFullDateCoverage(
-    issueFactRows,
+  await assertOperationalFactCoverage(
     rollingYearStart,
     rollingYearEnd,
+    'statistics rolling year',
   );
   const issuesByLineId = buildIssuesByLineId(issues);
   const issueFactRowsByDate = groupIssueFactRowsByDate(
@@ -2708,36 +2757,23 @@ export async function getStatisticsData() {
     title: 'Rolling Year Heatmap',
     data: Array.from({ length: 365 }, (_, index) => {
       const date = rollingYearStart.plus({ days: index }).toISODate()!;
-      if (hasIssueFactCoverage) {
-        return {
-          name: date,
-          payload: summarizeIssueFactRows(
-            issueFactRowsByDate.get(date) ?? [],
-            'count',
-          ),
-        };
-      }
-      const dayDate = DateTime.fromISO(date, { zone: SG_TIMEZONE });
-      const dayIssues = issues.filter((issue) =>
-        issueTouchesDate(issue, dayDate),
-      );
-      const counts = pickIssueTypes(dayIssues);
       return {
         name: date,
-        payload: {
-          disruption: counts.disruption ?? 0,
-          maintenance: counts.maintenance ?? 0,
-          infra: counts.infra ?? 0,
-        },
+        payload: summarizeIssueFactRows(
+          issueFactRowsByDate.get(date) ?? [],
+          'count',
+        ),
       };
     }),
   };
 
   const statistics: SystemAnalytics = {
-    timeScaleChartsIssueCount: buildIssueCountGraphs(issues),
-    timeScaleChartsIssueDuration: hasIssueFactCoverage
-      ? buildDurationChartsFromIssueFacts(issueFactRows)
-      : buildIssueDurationGraphs(issues),
+    timeScaleChartsIssueCount: buildIssueCountChartsFromIssueFacts(
+      issueFactRows,
+    ),
+    timeScaleChartsIssueDuration: buildDurationChartsFromIssueFacts(
+      issueFactRows,
+    ),
     chartTotalIssueCountByLine,
     chartTotalIssueCountByStation,
     chartRollingYearHeatmap,


### PR DESCRIPTION
## Summary

- Require explicit operational fact coverage for History and Statistics hot paths instead of falling back to broad issue scans.
- Use `line_day_facts` date coverage to distinguish missing facts from valid zero-issue days.
- Hydrate History issue cards through a targeted issue-ID dataset path, while leaving detail/profile compatibility paths on the existing full base dataset.
- Build Statistics rolling issue count, duration, and heatmap charts directly from `issue_day_facts`.

## Impact

History and rolling Statistics requests now fail explicitly when operational facts are missing, rather than silently rebuilding expensive aggregate data from `buildBaseDataset()`. Remaining all-time Statistics cards still use the broad dataset and can be moved to compact aggregate queries in a follow-up.

## Validation

- `npm run build` passed.
- Build still emits the existing Wrangler sandbox log-file `EPERM` warning locally, but exits 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Contributions" section with guidance and examples for Conventional Commits in pull request titles.

* **Refactor**
  * Revised data-query and history logic to support issue-scoped inclusion, improve historical reconstruction choices, and make coverage checks more reliable for charts and statistics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-site/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->