### PR TITLE
ci: use pull workflow for preview ingestion

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -37,12 +37,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Reset, migrate, and seed preview database
+      - name: Reset and migrate preview database
         run: npm run db:preview:prepare
         env:
           ALLOW_DATABASE_RESET: "true"
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          FIXTURES_BASE_URL: https://foldaway.github.io/mrtdown-data/fixtures
 
       - name: Build
         run: npm run build
@@ -75,6 +74,34 @@ jobs:
           command: deploy --secrets-file preview.env
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Run preview pull workflow
+        timeout-minutes: 30
+        run: |-
+          set -euo pipefail
+
+          instance_id="$(uuidgen)"
+          npx wrangler workflows trigger mrtdown-pull-preview --id "$instance_id"
+
+          while true; do
+            output="$(npx wrangler workflows instances describe mrtdown-pull-preview "$instance_id" --step-output=false)"
+            echo "$output"
+
+            status="$(echo "$output" | sed -n 's/^Status:[[:space:]]*//p')"
+            case "$status" in
+              *Completed*)
+                exit 0
+                ;;
+              *Errored*|*Terminated*)
+                exit 1
+                ;;
+            esac
+
+            sleep 30
+          done
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Remove preview.env
         run: rm preview.env

--- a/app/scripts/seedFixtures.ts
+++ b/app/scripts/seedFixtures.ts
@@ -127,14 +127,12 @@ async function main(): Promise<void> {
     throw new Error('DATABASE_URL must be set');
   }
 
-  const fixturesBaseUrl =
-    process.env.FIXTURES_BASE_URL ?? DEFAULT_FIXTURES_BASE_URL;
   const pool = new Pool({ connectionString: DATABASE_URL });
   const db = drizzle(pool, { schema }) as Db;
 
   try {
-    console.log(`Seeding preview database from ${fixturesBaseUrl}`);
-    await stageFixtures(db, fixturesBaseUrl);
+    console.log(`Seeding preview database from ${DEFAULT_FIXTURES_BASE_URL}`);
+    await stageFixtures(db, DEFAULT_FIXTURES_BASE_URL);
     await syncSeededData(db);
     const facts = await rebuildOperationalFactsRange(
       OPERATIONAL_FACTS_REBUILD_DAYS,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "db:migrate": "drizzle-kit migrate",
     "db:migrate:debug": "tsx app/scripts/migrateDatabase.ts",
     "db:seed:fixtures": "tsx app/scripts/seedFixtures.ts",
-    "db:preview:prepare": "npm run db:reset && npm run db:migrate:debug && npm run db:seed:fixtures",
+    "db:preview:prepare": "npm run db:reset && npm run db:migrate:debug",
     "db:studio": "drizzle-kit studio",
     "cf-typegen": "wrangler types"
   },


### PR DESCRIPTION
## Summary

Reworks preview deploy ingestion so the GitHub Actions preview workflow deploys the Cloudflare Worker/Workflow first, then triggers `mrtdown-pull-preview` instead of seeding fixtures directly in CI.

Also removes the stale `FIXTURES_BASE_URL` override from the fixture seed script. The explicit `db:seed:fixtures` utility remains available and now always uses the built-in fixtures URL.

## Validation

- `npm run build`
- `rg "FIXTURES_BASE_URL|fixturesBaseUrl" .`
- YAML parse check for `.github/workflows/deploy-preview.yml`