### PR TITLE
fix(home): restore daily status bars

### DIFF
--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -1585,17 +1585,15 @@ function buildLineSummary(
         dailyDowntimeIntervals.push(...contributingBounds);
       }
 
-      if (issueContributesToLineDowntime(issue)) {
-        const current = dayBreakdown.breakdownByIssueTypes[issue.type] ?? {
-          totalDurationSeconds: 0,
-          issueIds: [],
-        };
-        current.totalDurationSeconds += dayOverlap;
-        if (!current.issueIds.includes(issue.id)) {
-          current.issueIds.push(issue.id);
-        }
-        dayBreakdown.breakdownByIssueTypes[issue.type] = current;
+      const current = dayBreakdown.breakdownByIssueTypes[issue.type] ?? {
+        totalDurationSeconds: 0,
+        issueIds: [],
+      };
+      current.totalDurationSeconds += dayOverlap;
+      if (!current.issueIds.includes(issue.id)) {
+        current.issueIds.push(issue.id);
       }
+      dayBreakdown.breakdownByIssueTypes[issue.type] = current;
     }
 
     totalDowntimeSeconds += sumIntervalSeconds(
@@ -1677,6 +1675,16 @@ function rankLineSummaries(lineSummaries: LineSummary[]) {
       totalLines: ranked.length > 0 ? ranked.length : null,
     };
   });
+}
+
+function getLineSummaryDowntimeSeconds(
+  summary: LineSummary,
+  issueType: IssueType,
+) {
+  return (
+    summary.downtimeBreakdown?.find((breakdown) => breakdown.type === issueType)
+      ?.downtimeSeconds ?? 0
+  );
 }
 
 function buildWindowCountEntries(
@@ -2550,7 +2558,6 @@ async function rebuildOperationalFactsForDateFromDataset(
       dataset.publicHolidaySet,
       asOf,
     );
-    const dayBreakdown = summary.breakdownByDates[dateKey];
     const counts = lineIssues.reduce<Record<IssueType, number>>(
       (acc, issue) => {
         if (issueTouchesDate(issue, normalizedDate)) {
@@ -2572,15 +2579,13 @@ async function rebuildOperationalFactsForDateFromDataset(
               .seconds,
       ),
       downtime_disruption_seconds: Math.round(
-        dayBreakdown?.breakdownByIssueTypes.disruption?.totalDurationSeconds ??
-          0,
+        getLineSummaryDowntimeSeconds(summary, 'disruption'),
       ),
       downtime_maintenance_seconds: Math.round(
-        dayBreakdown?.breakdownByIssueTypes.maintenance?.totalDurationSeconds ??
-          0,
+        getLineSummaryDowntimeSeconds(summary, 'maintenance'),
       ),
       downtime_infra_seconds: Math.round(
-        dayBreakdown?.breakdownByIssueTypes.infra?.totalDurationSeconds ?? 0,
+        getLineSummaryDowntimeSeconds(summary, 'infra'),
       ),
       issue_count_disruption: counts.disruption,
       issue_count_maintenance: counts.maintenance,


### PR DESCRIPTION
## Summary

Restores the homepage daily line bars so they show all active issue types for each day: disruptions, maintenance, and infrastructure issues.

## Details

The regression came from commit `dc449e8e3b4195140c8e41e2e0de81409357617f`, which tightened `breakdownByDates` to only include issues that contribute to downtime. The homepage bars and their popovers are driven by that breakdown, so non-downtime maintenance and infra entries disappeared.

This PR separates display breakdown semantics from uptime semantics:

- daily status bar breakdowns include all active issue types
- uptime and operational fact `downtime_*` values remain disruption-only
- tests cover the new line summary breakdown behavior

## Validation

- `npm run test:run -- issueOperationalEffects`
- `npm run typecheck`
- `npm run verify`

`npm run verify` passed with existing Biome warnings elsewhere in the repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization of downtime calculation logic for improved performance.

---

**Note:** This release contains internal code improvements with no visible changes to user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-site/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->