### PR TITLE
fix: Choose latest service revision that has path entries and fallback endedAt from newer revisions

### DIFF
--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -1108,9 +1108,11 @@ async function buildDataset(
           return null;
         }
 
-        return new Date(latestOverallRevision.updated_at)
-          .toISOString()
-          .slice(0, 10);
+        return isoDate(
+          DateTime.fromJSDate(latestOverallRevision.updated_at).setZone(
+            SG_TIMEZONE,
+          ),
+        );
       })(),
       stationIds: [...new Set(entries.map((entry) => entry.station_id))],
       entries: entries.map((entry) => ({

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -1003,7 +1003,6 @@ async function buildDataset(
     return acc;
   }, {});
 
-
   const latestRevisionByServiceId = Object.fromEntries(
     serviceRows
       .map((service) => {
@@ -1100,14 +1099,18 @@ async function buildDataset(
           return endedAtByStationCode;
         }
 
-        const latestOverallRevision = latestOverallRevisionByServiceId[service.id];
+        const latestOverallRevision =
+          latestOverallRevisionByServiceId[service.id];
         const hasNewerRevisionWithoutPath =
-          latestOverallRevision != null && latestOverallRevision.id !== latestRevision.id;
+          latestOverallRevision != null &&
+          latestOverallRevision.id !== latestRevision.id;
         if (!hasNewerRevisionWithoutPath) {
           return null;
         }
 
-        return new Date(latestOverallRevision.updated_at).toISOString().slice(0, 10);
+        return new Date(latestOverallRevision.updated_at)
+          .toISOString()
+          .slice(0, 10);
       })(),
       stationIds: [...new Set(entries.map((entry) => entry.station_id))],
       entries: entries.map((entry) => ({

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -945,24 +945,28 @@ async function buildDataset(
     return acc;
   }, {});
 
-  const latestRevisionByServiceId = Object.fromEntries(
-    serviceRows
-      .map((service) => {
-        const revisions = revisionsByServiceId[service.id] ?? [];
-        if (revisions.length === 0) {
+  const revisionsSortedByServiceId = Object.fromEntries(
+    Object.entries(revisionsByServiceId).map(([serviceId, revisions]) => [
+      serviceId,
+      [...revisions].sort((a, b) => {
+        const aTs = new Date(a.updated_at).getTime();
+        const bTs = new Date(b.updated_at).getTime();
+        if (aTs !== bTs) {
+          return bTs - aTs;
+        }
+        return b.id.localeCompare(a.id);
+      }),
+    ]),
+  ) as Record<string, typeof serviceRevisionRows>;
+
+  const latestOverallRevisionByServiceId = Object.fromEntries(
+    Object.entries(revisionsSortedByServiceId)
+      .map(([serviceId, revisions]) => {
+        const latestRevision = revisions[0];
+        if (latestRevision == null) {
           return null;
         }
-
-        const latestRevision = [...revisions].sort((a, b) => {
-          const aTs = new Date(a.updated_at).getTime();
-          const bTs = new Date(b.updated_at).getTime();
-          if (aTs !== bTs) {
-            return bTs - aTs;
-          }
-          return b.id.localeCompare(a.id);
-        })[0];
-
-        return [service.id, latestRevision] as const;
+        return [serviceId, latestRevision] as const;
       })
       .filter(
         (
@@ -972,20 +976,18 @@ async function buildDataset(
       ),
   );
 
-  const latestRevisionIds = [
-    ...new Set(
-      Object.values(latestRevisionByServiceId).map((revision) => revision.id),
-    ),
+  const allRevisionIds = [
+    ...new Set(serviceRevisionRows.map((revision) => revision.id)),
   ];
   const servicePathRows =
-    latestRevisionIds.length > 0
+    allRevisionIds.length > 0
       ? await database
           .select()
           .from(serviceRevisionPathStationEntriesTable)
           .where(
             inArray(
               serviceRevisionPathStationEntriesTable.service_revision_id,
-              latestRevisionIds,
+              allRevisionIds,
             ),
           )
       : [];
@@ -1000,6 +1002,30 @@ async function buildDataset(
     acc[key].push(row);
     return acc;
   }, {});
+
+
+  const latestRevisionByServiceId = Object.fromEntries(
+    serviceRows
+      .map((service) => {
+        const revisions = revisionsSortedByServiceId[service.id] ?? [];
+        const latestRevisionWithPath = revisions.find((revision) => {
+          const revisionKey = `${revision.id}::${service.id}`;
+          const entries = pathEntriesByRevisionKey[revisionKey] ?? [];
+          return entries.length > 0;
+        });
+        if (latestRevisionWithPath == null) {
+          return null;
+        }
+
+        return [service.id, latestRevisionWithPath] as const;
+      })
+      .filter(
+        (
+          entry,
+        ): entry is readonly [string, (typeof serviceRevisionRows)[number]] =>
+          entry != null,
+      ),
+  );
 
   const stationCodeLookup = new Map<
     string,
@@ -1063,12 +1089,26 @@ async function buildDataset(
       titleTranslations: translations,
       startedAt:
         minStart != null && !allStartsInFuture ? minStart.toISODate() : null,
-      endedAt:
-        endedDates.length === entries.length
-          ? (endedDates
-              .sort((a, b) => b.toMillis() - a.toMillis())[0]
-              ?.toISODate() ?? null)
-          : null,
+      endedAt: (() => {
+        const endedAtByStationCode =
+          endedDates.length === entries.length
+            ? (endedDates
+                .sort((a, b) => b.toMillis() - a.toMillis())[0]
+                ?.toISODate() ?? null)
+            : null;
+        if (endedAtByStationCode != null) {
+          return endedAtByStationCode;
+        }
+
+        const latestOverallRevision = latestOverallRevisionByServiceId[service.id];
+        const hasNewerRevisionWithoutPath =
+          latestOverallRevision != null && latestOverallRevision.id !== latestRevision.id;
+        if (!hasNewerRevisionWithoutPath) {
+          return null;
+        }
+
+        return new Date(latestOverallRevision.updated_at).toISOString().slice(0, 10);
+      })(),
       stationIds: [...new Set(entries.map((entry) => entry.station_id))],
       entries: entries.map((entry) => ({
         stationId: entry.station_id,


### PR DESCRIPTION
### Motivation

- Ensure the dataset picks the most recent service revision that actually contains path entries rather than blindly using the newest revision id. 
- Provide a fallback for a branch `endedAt` when station codes don't indicate an end but a newer overall revision exists without a path.

### Description

- Introduce `revisionsSortedByServiceId` and `latestOverallRevisionByServiceId` to sort revisions per service by `updated_at` and `id` and expose the overall latest revision per service. 
- Query path entries for all revisions (`allRevisionIds`) and build `pathEntriesByRevisionKey` before selecting the latest revision that has path entries. 
- Compute `latestRevisionByServiceId` by finding the most recent revision (from sorted list) that has associated path entries. 
- Update branch `endedAt` logic to fall back to the `updated_at` date of a newer overall revision when station code ended dates are not available and a newer revision without a path exists.

### Testing

- Ran the TypeScript build with `yarn build`, which completed successfully. 
- Ran the test suite with `yarn test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e992ddb688320aa1f71ef8f8bdf53)