### PR TITLE
fix: repair impact event cascade constraints

### DIFF
--- a/drizzle/0006_repair_impact_event_cascades.sql
+++ b/drizzle/0006_repair_impact_event_cascades.sql
@@ -1,0 +1,114 @@
+DELETE FROM "impact_event_basis_evidences" AS child
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "impact_events" AS parent
+  WHERE parent."id" = child."impact_event_id"
+)
+OR NOT EXISTS (
+  SELECT 1
+  FROM "evidences" AS parent
+  WHERE parent."id" = child."evidence_id"
+);
+--> statement-breakpoint
+DELETE FROM "impact_event_causes" AS child
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "impact_events" AS parent
+  WHERE parent."id" = child."impact_event_id"
+);
+--> statement-breakpoint
+DELETE FROM "impact_event_entity_facilities" AS child
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "impact_events" AS parent
+  WHERE parent."id" = child."impact_event_id"
+);
+--> statement-breakpoint
+DELETE FROM "impact_event_entity_services" AS child
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "impact_events" AS parent
+  WHERE parent."id" = child."impact_event_id"
+);
+--> statement-breakpoint
+DELETE FROM "impact_event_facility_effects" AS child
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "impact_events" AS parent
+  WHERE parent."id" = child."impact_event_id"
+);
+--> statement-breakpoint
+DELETE FROM "impact_event_periods" AS child
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "impact_events" AS parent
+  WHERE parent."id" = child."impact_event_id"
+);
+--> statement-breakpoint
+DELETE FROM "impact_event_service_effects" AS child
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "impact_events" AS parent
+  WHERE parent."id" = child."impact_event_id"
+);
+--> statement-breakpoint
+DELETE FROM "impact_event_service_scopes" AS child
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "impact_events" AS parent
+  WHERE parent."id" = child."impact_event_id"
+);
+--> statement-breakpoint
+ALTER TABLE "impact_event_basis_evidences" DROP CONSTRAINT IF EXISTS "impact_event_basis_evidences_impact_event_id_impact_events_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_basis_evidences" DROP CONSTRAINT IF EXISTS "impact_event_basis_evidences_evidence_id_evidences_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_causes" DROP CONSTRAINT IF EXISTS "impact_event_causes_impact_event_id_impact_events_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_entity_facilities" DROP CONSTRAINT IF EXISTS "impact_event_entity_facilities_impact_event_id_impact_events_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_entity_services" DROP CONSTRAINT IF EXISTS "impact_event_entity_services_impact_event_id_impact_events_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_facility_effects" DROP CONSTRAINT IF EXISTS "impact_event_facility_effects_impact_event_id_impact_events_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_periods" DROP CONSTRAINT IF EXISTS "impact_event_periods_impact_event_id_impact_events_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_service_effects" DROP CONSTRAINT IF EXISTS "impact_event_service_effects_impact_event_id_impact_events_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_service_scopes" DROP CONSTRAINT IF EXISTS "impact_event_service_scopes_impact_event_id_impact_events_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_basis_evidences" ADD CONSTRAINT "impact_event_basis_evidences_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade NOT VALID;
+--> statement-breakpoint
+ALTER TABLE "impact_event_basis_evidences" ADD CONSTRAINT "impact_event_basis_evidences_evidence_id_evidences_id_fk" FOREIGN KEY ("evidence_id") REFERENCES "public"."evidences"("id") ON DELETE cascade ON UPDATE cascade NOT VALID;
+--> statement-breakpoint
+ALTER TABLE "impact_event_causes" ADD CONSTRAINT "impact_event_causes_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade NOT VALID;
+--> statement-breakpoint
+ALTER TABLE "impact_event_entity_facilities" ADD CONSTRAINT "impact_event_entity_facilities_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade NOT VALID;
+--> statement-breakpoint
+ALTER TABLE "impact_event_entity_services" ADD CONSTRAINT "impact_event_entity_services_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade NOT VALID;
+--> statement-breakpoint
+ALTER TABLE "impact_event_facility_effects" ADD CONSTRAINT "impact_event_facility_effects_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade NOT VALID;
+--> statement-breakpoint
+ALTER TABLE "impact_event_periods" ADD CONSTRAINT "impact_event_periods_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade NOT VALID;
+--> statement-breakpoint
+ALTER TABLE "impact_event_service_effects" ADD CONSTRAINT "impact_event_service_effects_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade NOT VALID;
+--> statement-breakpoint
+ALTER TABLE "impact_event_service_scopes" ADD CONSTRAINT "impact_event_service_scopes_impact_event_id_impact_events_id_fk" FOREIGN KEY ("impact_event_id") REFERENCES "public"."impact_events"("id") ON DELETE cascade ON UPDATE cascade NOT VALID;
+--> statement-breakpoint
+ALTER TABLE "impact_event_basis_evidences" VALIDATE CONSTRAINT "impact_event_basis_evidences_impact_event_id_impact_events_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_basis_evidences" VALIDATE CONSTRAINT "impact_event_basis_evidences_evidence_id_evidences_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_causes" VALIDATE CONSTRAINT "impact_event_causes_impact_event_id_impact_events_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_entity_facilities" VALIDATE CONSTRAINT "impact_event_entity_facilities_impact_event_id_impact_events_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_entity_services" VALIDATE CONSTRAINT "impact_event_entity_services_impact_event_id_impact_events_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_facility_effects" VALIDATE CONSTRAINT "impact_event_facility_effects_impact_event_id_impact_events_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_periods" VALIDATE CONSTRAINT "impact_event_periods_impact_event_id_impact_events_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_service_effects" VALIDATE CONSTRAINT "impact_event_service_effects_impact_event_id_impact_events_id_fk";
+--> statement-breakpoint
+ALTER TABLE "impact_event_service_scopes" VALIDATE CONSTRAINT "impact_event_service_scopes_impact_event_id_impact_events_id_fk";

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,2906 @@
+{
+  "id": "09f4a60f-3f0d-4e0c-9d65-9925e6f955fa",
+  "prevId": "2001e840-9473-40b9-97d1-b6f42a859060",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.evidences": {
+      "name": "evidences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "evidence_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "render": {
+          "name": "render",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "evidences_issue_id_idx": {
+          "name": "evidences_issue_id_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "evidences_ts_idx": {
+          "name": "evidences_ts_idx",
+          "columns": [
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "evidences_issue_id_issues_id_fk": {
+          "name": "evidences_issue_id_issues_id_fk",
+          "tableFrom": "evidences",
+          "columnsFrom": ["issue_id"],
+          "tableTo": "issues",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_basis_evidences": {
+      "name": "impact_event_basis_evidences",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_id": {
+          "name": "evidence_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_basis_evidences_impact_event_id_idx": {
+          "name": "impact_event_basis_evidences_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "impact_event_basis_evidences_evidence_id_idx": {
+          "name": "impact_event_basis_evidences_evidence_id_idx",
+          "columns": [
+            {
+              "expression": "evidence_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "impact_event_basis_evidences_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_basis_evidences_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_basis_evidences",
+          "columnsFrom": ["impact_event_id"],
+          "tableTo": "impact_events",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "impact_event_basis_evidences_evidence_id_evidences_id_fk": {
+          "name": "impact_event_basis_evidences_evidence_id_evidences_id_fk",
+          "tableFrom": "impact_event_basis_evidences",
+          "columnsFrom": ["evidence_id"],
+          "tableTo": "evidences",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_basis_evidences_impact_event_id_evidence_id_pk": {
+          "name": "impact_event_basis_evidences_impact_event_id_evidence_id_pk",
+          "columns": ["impact_event_id", "evidence_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_causes": {
+      "name": "impact_event_causes",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "impact_event_cause_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_causes_impact_event_id_idx": {
+          "name": "impact_event_causes_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "impact_event_causes_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_causes_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_causes",
+          "columnsFrom": ["impact_event_id"],
+          "tableTo": "impact_events",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_causes_impact_event_id_type_pk": {
+          "name": "impact_event_causes_impact_event_id_type_pk",
+          "columns": ["impact_event_id", "type"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_entity_facilities": {
+      "name": "impact_event_entity_facilities",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "affected_entity_facility_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_entity_facilities_impact_event_id_idx": {
+          "name": "impact_event_entity_facilities_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "impact_event_entity_facilities_station_id_idx": {
+          "name": "impact_event_entity_facilities_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "impact_event_entity_facilities_line_id_idx": {
+          "name": "impact_event_entity_facilities_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "impact_event_entity_facilities_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_entity_facilities_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_entity_facilities",
+          "columnsFrom": ["impact_event_id"],
+          "tableTo": "impact_events",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "impact_event_entity_facilities_station_id_stations_id_fk": {
+          "name": "impact_event_entity_facilities_station_id_stations_id_fk",
+          "tableFrom": "impact_event_entity_facilities",
+          "columnsFrom": ["station_id"],
+          "tableTo": "stations",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "impact_event_entity_facilities_line_id_lines_id_fk": {
+          "name": "impact_event_entity_facilities_line_id_lines_id_fk",
+          "tableFrom": "impact_event_entity_facilities",
+          "columnsFrom": ["line_id"],
+          "tableTo": "lines",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_entity_facilities_impact_event_id_station_id_kind_pk": {
+          "name": "impact_event_entity_facilities_impact_event_id_station_id_kind_pk",
+          "columns": ["impact_event_id", "station_id", "kind"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_entity_services": {
+      "name": "impact_event_entity_services",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_entity_services_impact_event_id_idx": {
+          "name": "impact_event_entity_services_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "impact_event_entity_services_service_id_idx": {
+          "name": "impact_event_entity_services_service_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "impact_event_entity_services_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_entity_services_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_entity_services",
+          "columnsFrom": ["impact_event_id"],
+          "tableTo": "impact_events",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "impact_event_entity_services_service_id_services_id_fk": {
+          "name": "impact_event_entity_services_service_id_services_id_fk",
+          "tableFrom": "impact_event_entity_services",
+          "columnsFrom": ["service_id"],
+          "tableTo": "services",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_entity_services_impact_event_id_service_id_pk": {
+          "name": "impact_event_entity_services_impact_event_id_service_id_pk",
+          "columns": ["impact_event_id", "service_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_facility_effects": {
+      "name": "impact_event_facility_effects",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "facility_effect_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_facility_effects_impact_event_id_idx": {
+          "name": "impact_event_facility_effects_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "impact_event_facility_effects_kind_idx": {
+          "name": "impact_event_facility_effects_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "impact_event_facility_effects_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_facility_effects_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_facility_effects",
+          "columnsFrom": ["impact_event_id"],
+          "tableTo": "impact_events",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_facility_effects_impact_event_id_kind_pk": {
+          "name": "impact_event_facility_effects_impact_event_id_kind_pk",
+          "columns": ["impact_event_id", "kind"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_periods": {
+      "name": "impact_event_periods",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_ts": {
+          "name": "start_ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_ts": {
+          "name": "end_ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_periods_start_at_idx": {
+          "name": "impact_event_periods_start_at_idx",
+          "columns": [
+            {
+              "expression": "start_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "impact_event_periods_end_at_idx": {
+          "name": "impact_event_periods_end_at_idx",
+          "columns": [
+            {
+              "expression": "end_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "impact_event_periods_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_periods_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_periods",
+          "columnsFrom": ["impact_event_id"],
+          "tableTo": "impact_events",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_periods_impact_event_id_index_pk": {
+          "name": "impact_event_periods_impact_event_id_index_pk",
+          "columns": ["impact_event_id", "index"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_service_effects": {
+      "name": "impact_event_service_effects",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "service_effect_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "interval",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_service_effects_impact_event_id_idx": {
+          "name": "impact_event_service_effects_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "impact_event_service_effects_kind_idx": {
+          "name": "impact_event_service_effects_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "impact_event_service_effects_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_service_effects_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_service_effects",
+          "columnsFrom": ["impact_event_id"],
+          "tableTo": "impact_events",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_service_effects_impact_event_id_kind_pk": {
+          "name": "impact_event_service_effects_impact_event_id_kind_pk",
+          "columns": ["impact_event_id", "kind"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_service_scopes": {
+      "name": "impact_event_service_scopes",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "impact_event_service_scope_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_station_id": {
+          "name": "from_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_station_id": {
+          "name": "to_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_service_scopes_impact_event_id_idx": {
+          "name": "impact_event_service_scopes_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "impact_event_service_scopes_type_idx": {
+          "name": "impact_event_service_scopes_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "impact_event_service_scopes_station_id_idx": {
+          "name": "impact_event_service_scopes_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "impact_event_service_scopes_from_station_id_idx": {
+          "name": "impact_event_service_scopes_from_station_id_idx",
+          "columns": [
+            {
+              "expression": "from_station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "impact_event_service_scopes_to_station_id_idx": {
+          "name": "impact_event_service_scopes_to_station_id_idx",
+          "columns": [
+            {
+              "expression": "to_station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "impact_event_service_scopes_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_service_scopes_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_service_scopes",
+          "columnsFrom": ["impact_event_id"],
+          "tableTo": "impact_events",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "impact_event_service_scopes_station_id_stations_id_fk": {
+          "name": "impact_event_service_scopes_station_id_stations_id_fk",
+          "tableFrom": "impact_event_service_scopes",
+          "columnsFrom": ["station_id"],
+          "tableTo": "stations",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "impact_event_service_scopes_from_station_id_stations_id_fk": {
+          "name": "impact_event_service_scopes_from_station_id_stations_id_fk",
+          "tableFrom": "impact_event_service_scopes",
+          "columnsFrom": ["from_station_id"],
+          "tableTo": "stations",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "impact_event_service_scopes_to_station_id_stations_id_fk": {
+          "name": "impact_event_service_scopes_to_station_id_stations_id_fk",
+          "tableFrom": "impact_event_service_scopes",
+          "columnsFrom": ["to_station_id"],
+          "tableTo": "stations",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_service_scopes_impact_event_id_index_pk": {
+          "name": "impact_event_service_scopes_impact_event_id_index_pk",
+          "columns": ["impact_event_id", "index"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "impact_event_service_scopes_type_station_shape_check": {
+          "name": "impact_event_service_scopes_type_station_shape_check",
+          "value": "\n          (\n            \"impact_event_service_scopes\".\"type\" = 'service.whole'\n            and \"impact_event_service_scopes\".\"station_id\" is null\n            and \"impact_event_service_scopes\".\"from_station_id\" is null\n            and \"impact_event_service_scopes\".\"to_station_id\" is null\n          )\n          or (\n            \"impact_event_service_scopes\".\"type\" = 'service.point'\n            and \"impact_event_service_scopes\".\"station_id\" is not null\n            and \"impact_event_service_scopes\".\"from_station_id\" is null\n            and \"impact_event_service_scopes\".\"to_station_id\" is null\n          )\n          or (\n            \"impact_event_service_scopes\".\"type\" = 'service.segment'\n            and \"impact_event_service_scopes\".\"station_id\" is null\n            and \"impact_event_service_scopes\".\"from_station_id\" is not null\n            and \"impact_event_service_scopes\".\"to_station_id\" is not null\n          )\n        "
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.impact_events": {
+      "name": "impact_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_events_issue_id_idx": {
+          "name": "impact_events_issue_id_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "impact_events_issue_id_issues_id_fk": {
+          "name": "impact_events_issue_id_issues_id_fk",
+          "tableFrom": "impact_events",
+          "columnsFrom": ["issue_id"],
+          "tableTo": "issues",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_day_facts": {
+      "name": "issue_day_facts",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "issue_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_anytime": {
+          "name": "active_anytime",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_end_of_day": {
+          "name": "active_end_of_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inferred_interval_count": {
+          "name": "inferred_interval_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_day_facts_issue_id_idx": {
+          "name": "issue_day_facts_issue_id_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "issue_day_facts_date_issue_type_idx": {
+          "name": "issue_day_facts_date_issue_type_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "issue_day_facts_as_of_idx": {
+          "name": "issue_day_facts_as_of_idx",
+          "columns": [
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "issue_day_facts_issue_id_issues_id_fk": {
+          "name": "issue_day_facts_issue_id_issues_id_fk",
+          "tableFrom": "issue_day_facts",
+          "columnsFrom": ["issue_id"],
+          "tableTo": "issues",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_day_facts_date_issue_id_pk": {
+          "name": "issue_day_facts_date_issue_id_pk",
+          "columns": ["date", "issue_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues_next": {
+      "name": "issues_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "issue_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_meta": {
+          "name": "title_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidences": {
+          "name": "evidences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impact_events": {
+          "name": "impact_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "issue_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_meta": {
+          "name": "title_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.landmarks_next": {
+      "name": "landmarks_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.landmarks": {
+      "name": "landmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.line_day_facts": {
+      "name": "line_day_facts",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_seconds": {
+          "name": "service_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downtime_disruption_seconds": {
+          "name": "downtime_disruption_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downtime_maintenance_seconds": {
+          "name": "downtime_maintenance_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downtime_infra_seconds": {
+          "name": "downtime_infra_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_count_disruption": {
+          "name": "issue_count_disruption",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_count_maintenance": {
+          "name": "issue_count_maintenance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_count_infra": {
+          "name": "issue_count_infra",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "line_day_facts_line_id_idx": {
+          "name": "line_day_facts_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "line_day_facts_date_idx": {
+          "name": "line_day_facts_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "line_day_facts_as_of_idx": {
+          "name": "line_day_facts_as_of_idx",
+          "columns": [
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "line_day_facts_line_id_lines_id_fk": {
+          "name": "line_day_facts_line_id_lines_id_fk",
+          "tableFrom": "line_day_facts",
+          "columnsFrom": ["line_id"],
+          "tableTo": "lines",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "line_day_facts_date_line_id_pk": {
+          "name": "line_day_facts_date_line_id_pk",
+          "columns": ["date", "line_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.line_operators": {
+      "name": "line_operators",
+      "schema": "",
+      "columns": {
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator_id": {
+          "name": "operator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "line_operators_line_id_idx": {
+          "name": "line_operators_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "line_operators_operator_id_idx": {
+          "name": "line_operators_operator_id_idx",
+          "columns": [
+            {
+              "expression": "operator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "line_operators_line_id_lines_id_fk": {
+          "name": "line_operators_line_id_lines_id_fk",
+          "tableFrom": "line_operators",
+          "columnsFrom": ["line_id"],
+          "tableTo": "lines",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "line_operators_operator_id_operators_id_fk": {
+          "name": "line_operators_operator_id_operators_id_fk",
+          "tableFrom": "line_operators",
+          "columnsFrom": ["operator_id"],
+          "tableTo": "operators",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "line_operators_line_id_operator_id_pk": {
+          "name": "line_operators_line_id_operator_id_pk",
+          "columns": ["line_id", "operator_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.line_services": {
+      "name": "line_services",
+      "schema": "",
+      "columns": {
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "line_services_line_id_idx": {
+          "name": "line_services_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "line_services_service_id_idx": {
+          "name": "line_services_service_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "line_services_line_id_lines_id_fk": {
+          "name": "line_services_line_id_lines_id_fk",
+          "tableFrom": "line_services",
+          "columnsFrom": ["line_id"],
+          "tableTo": "lines",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "line_services_service_id_services_id_fk": {
+          "name": "line_services_service_id_services_id_fk",
+          "tableFrom": "line_services",
+          "columnsFrom": ["service_id"],
+          "tableTo": "services",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "line_services_line_id_service_id_pk": {
+          "name": "line_services_line_id_service_id_pk",
+          "columns": ["line_id", "service_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lines_next": {
+      "name": "lines_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "line_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operating_hours": {
+          "name": "operating_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operators": {
+          "name": "operators",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lines": {
+      "name": "lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "line_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operating_hours": {
+          "name": "operating_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metadata": {
+      "name": "metadata",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operators_next": {
+      "name": "operators_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "founded_at": {
+          "name": "founded_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operators": {
+      "name": "operators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "founded_at": {
+          "name": "founded_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.public_holidays": {
+      "name": "public_holidays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "holiday_name": {
+          "name": "holiday_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_revision_path_station_entries": {
+      "name": "service_revision_path_station_entries",
+      "schema": "",
+      "columns": {
+        "service_revision_id": {
+          "name": "service_revision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_code": {
+          "name": "display_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_index": {
+          "name": "path_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "service_revision_path_entries_service_revision_id_idx": {
+          "name": "service_revision_path_entries_service_revision_id_idx",
+          "columns": [
+            {
+              "expression": "service_revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "service_revision_path_entries_service_id_idx": {
+          "name": "service_revision_path_entries_service_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "service_revision_path_entries_station_id_idx": {
+          "name": "service_revision_path_entries_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "service_revision_path_entries_path_index_idx": {
+          "name": "service_revision_path_entries_path_index_idx",
+          "columns": [
+            {
+              "expression": "path_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "sr_path_entries_revision_fk": {
+          "name": "sr_path_entries_revision_fk",
+          "tableFrom": "service_revision_path_station_entries",
+          "columnsFrom": ["service_revision_id", "service_id"],
+          "tableTo": "service_revisions",
+          "columnsTo": ["id", "service_id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "sr_path_entries_station_fk": {
+          "name": "sr_path_entries_station_fk",
+          "tableFrom": "service_revision_path_station_entries",
+          "columnsFrom": ["station_id"],
+          "tableTo": "stations",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "sr_path_entries_pk": {
+          "name": "sr_path_entries_pk",
+          "columns": [
+            "service_revision_id",
+            "service_id",
+            "station_id",
+            "path_index"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_revisions": {
+      "name": "service_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operating_hours": {
+          "name": "operating_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "service_revisions_service_id_idx": {
+          "name": "service_revisions_service_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "service_revisions_service_id_services_id_fk": {
+          "name": "service_revisions_service_id_services_id_fk",
+          "tableFrom": "service_revisions",
+          "columnsFrom": ["service_id"],
+          "tableTo": "services",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "service_revisions_id_service_id_pk": {
+          "name": "service_revisions_id_service_id_pk",
+          "columns": ["id", "service_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services_next": {
+      "name": "services_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revisions": {
+          "name": "revisions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "services_line_id_idx": {
+          "name": "services_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "services_line_id_lines_id_fk": {
+          "name": "services_line_id_lines_id_fk",
+          "tableFrom": "services",
+          "columnsFrom": ["line_id"],
+          "tableTo": "lines",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_codes": {
+      "name": "station_codes",
+      "schema": "",
+      "columns": {
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structure_type": {
+          "name": "structure_type",
+          "type": "station_structure_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_codes_line_id_idx": {
+          "name": "station_codes_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "station_codes_station_id_idx": {
+          "name": "station_codes_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "station_codes_line_id_lines_id_fk": {
+          "name": "station_codes_line_id_lines_id_fk",
+          "tableFrom": "station_codes",
+          "columnsFrom": ["line_id"],
+          "tableTo": "lines",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "station_codes_station_id_stations_id_fk": {
+          "name": "station_codes_station_id_stations_id_fk",
+          "tableFrom": "station_codes",
+          "columnsFrom": ["station_id"],
+          "tableTo": "stations",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "station_codes_line_id_station_id_code_pk": {
+          "name": "station_codes_line_id_station_id_code_pk",
+          "columns": ["line_id", "station_id", "code"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_landmarks": {
+      "name": "station_landmarks",
+      "schema": "",
+      "columns": {
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "landmark_id": {
+          "name": "landmark_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_landmarks_station_id_idx": {
+          "name": "station_landmarks_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "station_landmarks_landmark_id_idx": {
+          "name": "station_landmarks_landmark_id_idx",
+          "columns": [
+            {
+              "expression": "landmark_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "station_landmarks_station_id_stations_id_fk": {
+          "name": "station_landmarks_station_id_stations_id_fk",
+          "tableFrom": "station_landmarks",
+          "columnsFrom": ["station_id"],
+          "tableTo": "stations",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "station_landmarks_landmark_id_landmarks_id_fk": {
+          "name": "station_landmarks_landmark_id_landmarks_id_fk",
+          "tableFrom": "station_landmarks",
+          "columnsFrom": ["landmark_id"],
+          "tableTo": "landmarks",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "station_landmarks_station_id_landmark_id_pk": {
+          "name": "station_landmarks_station_id_landmark_id_pk",
+          "columns": ["station_id", "landmark_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations_next": {
+      "name": "stations_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geo": {
+          "name": "geo",
+          "type": "geometry(point)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "town_id": {
+          "name": "town_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_codes": {
+          "name": "station_codes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "landmark_ids": {
+          "name": "landmark_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "stations_next_geo_idx": {
+          "name": "stations_next_geo_idx",
+          "columns": [
+            {
+              "expression": "geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gist",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geo": {
+          "name": "geo",
+          "type": "geometry(point)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "town_id": {
+          "name": "town_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stations_geo_idx": {
+          "name": "stations_geo_idx",
+          "columns": [
+            {
+              "expression": "geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gist",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "stations_town_id_towns_id_fk": {
+          "name": "stations_town_id_towns_id_fk",
+          "tableFrom": "stations",
+          "columnsFrom": ["town_id"],
+          "tableTo": "towns",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towns_next": {
+      "name": "towns_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towns": {
+      "name": "towns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.affected_entity_facility_kind": {
+      "name": "affected_entity_facility_kind",
+      "schema": "public",
+      "values": ["lift", "escalator", "screen-door"]
+    },
+    "public.evidence_type": {
+      "name": "evidence_type",
+      "schema": "public",
+      "values": ["statement.official", "report.public", "report.media"]
+    },
+    "public.facility_effect_kind": {
+      "name": "facility_effect_kind",
+      "schema": "public",
+      "values": ["out-of-service", "degraded"]
+    },
+    "public.impact_event_cause_type": {
+      "name": "impact_event_cause_type",
+      "schema": "public",
+      "values": [
+        "signal.fault",
+        "track.fault",
+        "train.fault",
+        "power.fault",
+        "station.fault",
+        "security",
+        "weather",
+        "passenger.incident",
+        "platform_door.fault",
+        "delay",
+        "track.work",
+        "system.upgrade",
+        "elevator.outage",
+        "escalator.outage",
+        "air_conditioning.issue",
+        "station.renovation"
+      ]
+    },
+    "public.impact_event_service_scope_type": {
+      "name": "impact_event_service_scope_type",
+      "schema": "public",
+      "values": ["service.whole", "service.segment", "service.point"]
+    },
+    "public.issue_type": {
+      "name": "issue_type",
+      "schema": "public",
+      "values": ["disruption", "maintenance", "infra"]
+    },
+    "public.line_type": {
+      "name": "line_type",
+      "schema": "public",
+      "values": ["mrt.high", "mrt.medium", "lrt"]
+    },
+    "public.service_effect_kind": {
+      "name": "service_effect_kind",
+      "schema": "public",
+      "values": [
+        "delay",
+        "no-service",
+        "reduced-service",
+        "service-hours-adjustment"
+      ]
+    },
+    "public.station_structure_type": {
+      "name": "station_structure_type",
+      "schema": "public",
+      "values": ["elevated", "underground", "at_grade", "in_building"]
+    }
+  },
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1776355200000,
       "tag": "0005_canonical_issue_periods",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1779349162790,
+      "tag": "0006_repair_impact_event_cascades",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add a custom Drizzle migration to remove orphan impact-event child rows.
- Recreate and validate impact-event child foreign keys with `ON DELETE cascade ON UPDATE cascade`.
- Repair the concrete DB state needed by the merged cascade-based issue sync from #92.

## Root Cause
After #92 deployed, staging still failed inserting `impact_event_periods` for the TEL/DTL service adjustment issue. The deploy log confirms staging deployed commit `22dba36` and ran `drizzle-kit migrate`, so the Worker was not stale.

That means deleting incoming parent `impact_events` by ID did not remove existing `impact_event_periods` rows in the actual staging DB. The most likely live-state explanation is missing/drifted impact-event child FK enforcement or orphan child rows from earlier runs. This migration repairs that contract explicitly.

## Validation
- `npm run db:generate:check`
- `npm run verify`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repaired database referential integrity to ensure proper data consistency across related records.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-site/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->