### PR TITLE
ci: Deploy preview workflow from preview branch pushes

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,23 +1,15 @@
 name: Deploy Preview
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
+  push:
+    branches:
+      - preview
+  workflow_dispatch:
 
 jobs:
   deploy:
     name: Deploy preview
     runs-on: ubuntu-latest
-    # pull_request workflows from forks do not receive repository secrets
-    if: >-
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository && (
-      github.event.action == 'synchronize'
-      || github.event.action == 'opened'
-      || github.event.action == 'reopened')
     environment:
       name: preview
       url: ${{ steps.deploy.outputs.deployment-url }}
@@ -53,25 +45,11 @@ jobs:
           VITE_PUBLIC_POSTHOG_HOST: ${{ secrets.VITE_PUBLIC_POSTHOG_HOST }}
           VITE_ROOT_URL: "https://www.mrtdown.org"
 
-      - name: Create preview.env
-        run: |-
-          echo "VITE_ROOT_URL=https://www.mrtdown.org" >> preview.env
-
       - name: Deploy to Cloudflare Workers
         id: deploy
         uses: cloudflare/wrangler-action@v3
         with:
-          # Preview deployments intentionally use the top-level Wrangler config,
-          # not per-PR preview aliases. All open PRs deploy over the same preview
-          # Worker/Workflow resources, so newer preview deploys override older
-          # ones and share the same HYPERDRIVE and PULL_WORKFLOW config.
-          # `versions upload --preview-alias` does not deploy/update Workflows,
-          # so use `deploy` here to keep the Worker and Workflow in sync.
-          # Fully isolated previews would need per-PR Worker, Workflow,
-          # Hyperdrive, and Neon resources plus reliable teardown. That
-          # operational cost is not worth it while preview deploys are mostly
-          # for one active contributor.
-          command: deploy --secrets-file preview.env
+          command: deploy --env preview
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
@@ -103,5 +81,3 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
-      - name: Remove preview.env
-        run: rm preview.env

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   deploy:
+    if: github.ref == 'refs/heads/preview'
     name: Deploy preview
     runs-on: ubuntu-latest
     environment:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,3 +16,13 @@
 Canonical mrtdown archive data is fetched by the pull workflow, staged in `*_next` tables, promoted into normalized live tables, and read by server functions through `app/util/db.queries.ts`.
 
 The generated API client remains present for shared types and legacy boundaries during the overhaul. Treat new DB-backed query code as the direction of travel.
+
+## Deployment Branch Mapping
+
+Deploy workflows are branch-driven and map branches to environments as follows:
+
+- `production` branch -> `production` environment (`.github/workflows/deploy.yml`)
+- `main` branch -> `staging` environment (`.github/workflows/deploy.yml`)
+- `preview` branch -> `preview` environment (`.github/workflows/deploy-preview.yml`)
+
+This mapping is intentional so environment state is tied to a single long-lived branch rather than per-PR preview deploys.


### PR DESCRIPTION
### Motivation
- The previous preview pipeline deployed every pull request into a shared preview environment which caused PRs to overwrite one another. 
- The goal is to make preview follow a branch-to-environment model similar to `main -> staging` so a dedicated `preview` branch maps to the preview environment. 

### Description
- Changed `.github/workflows/deploy-preview.yml` trigger from pull request events to `push` on the `preview` branch and added `workflow_dispatch` for manual runs. 
- Removed the PR-specific `if` guard since the workflow is no longer PR-driven. 
- Switched the Cloudflare deploy invocation to use `deploy --env preview` instead of the prior `--secrets-file preview.env` flow. 
- Removed the temporary `preview.env` create/remove steps that were only necessary for the PR-based shared-deploy approach. 

### Testing
- Ran `npm run verify`, which executed typechecking, linting, formatting checks, migration generation checks, and tests, and the command completed successfully. 
- `vitest` test suite ran and all tests passed (`10` tests, `10` passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ebfefef88832083166c786132ce08)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment pipeline to trigger preview deployments from the dedicated preview branch instead of pull requests, with manual deployment support.

* **Documentation**
  * Added deployment branch mapping documentation describing how Git branches map to cloud deployment environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-site/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->