### PR TITLE
chore: retire legacy translation types

### DIFF
--- a/app/components/IssueAffectedBranchPill/index.tsx
+++ b/app/components/IssueAffectedBranchPill/index.tsx
@@ -10,6 +10,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import type { IssueAffectedBranch } from '~/types';
 import { useAffectedStations } from '~/components/IssueAffectedBranchPill/hooks/useAffectedStations';
 import { useIncludedEntities } from '~/contexts/IncludedEntities';
+import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 
 interface Props {
   branch: IssueAffectedBranch;
@@ -29,13 +30,10 @@ export const IssueAffectedBranchPill: React.FC<Props> = (props) => {
   const renderStationRange = () => {
     if (source == null) return null;
 
-    const sourceName =
-      source.nameTranslations[intl.locale] ?? source.name ?? 'N/A';
+    const sourceName = getLocalizedTranslation(source.name, intl.locale);
     const destinationName =
       destination != null
-        ? (destination.nameTranslations[intl.locale] ??
-          destination.name ??
-          'N/A')
+        ? getLocalizedTranslation(destination.name, intl.locale)
         : null;
 
     if (destination) {
@@ -69,7 +67,7 @@ export const IssueAffectedBranchPill: React.FC<Props> = (props) => {
               params={{ stationId: source.id }}
               className="font-medium text-gray-700 text-xs transition-colors hover:underline dark:text-gray-200"
             >
-              {source.nameTranslations[intl.locale] ?? source.name ?? 'N/A'}
+              {getLocalizedTranslation(source.name, intl.locale)}
             </Link>
           )}
           {destination != null && (
@@ -80,7 +78,7 @@ export const IssueAffectedBranchPill: React.FC<Props> = (props) => {
                 params={{ stationId: destination.id }}
                 className="font-medium text-gray-700 text-xs transition-colors hover:underline dark:text-gray-200"
               >
-                {destination.nameTranslations[intl.locale] ?? destination.name}
+                {getLocalizedTranslation(destination.name, intl.locale)}
               </Link>
             </>
           )}
@@ -108,14 +106,15 @@ export const IssueAffectedBranchPill: React.FC<Props> = (props) => {
 
           <div className="flex items-center gap-x-1">
             <span className="font-medium text-gray-700 text-xs dark:text-gray-200">
-              {source?.nameTranslations[intl.locale] ?? source?.name ?? 'N/A'}
+              {source != null
+                ? getLocalizedTranslation(source.name, intl.locale)
+                : 'N/A'}
             </span>
             {destination != null && (
               <>
                 <ArrowsRightLeftIcon className="size-3 text-gray-400" />
                 <span className="font-medium text-gray-700 text-xs dark:text-gray-200">
-                  {destination.nameTranslations[intl.locale] ??
-                    destination.name}
+                  {getLocalizedTranslation(destination.name, intl.locale)}
                 </span>
               </>
             )}
@@ -206,8 +205,7 @@ export const IssueAffectedBranchPill: React.FC<Props> = (props) => {
                         className="group flex items-center gap-1"
                       >
                         <span className="text-gray-700 text-xs group-hover:underline dark:text-gray-300">
-                          {station.nameTranslations[intl.locale] ??
-                            station.name}
+                          {getLocalizedTranslation(station.name, intl.locale)}
                         </span>
                       </Link>
                     </div>

--- a/app/components/IssueCard/components/IssueContent.tsx
+++ b/app/components/IssueCard/components/IssueContent.tsx
@@ -2,6 +2,7 @@ import { Link } from '@tanstack/react-router';
 import { useIntl } from 'react-intl';
 import type { Issue, IssueInterval } from '~/types';
 import { IssueSubtypeBadge } from '~/components/IssueSubtypeBadge';
+import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 import { IssueAffectedBranchPill } from '../../IssueAffectedBranchPill';
 import { IssueTimestamp } from './IssueTimestamp';
 
@@ -22,7 +23,7 @@ export const IssueContent: React.FC<Props> = (props) => {
         params={{ issueId: issue.id }}
       >
         <h3 className="font-semibold text-gray-900 text-sm leading-tight dark:text-gray-100">
-          {issue.titleTranslations[intl.locale] ?? issue.title}
+          {getLocalizedTranslation(issue.title, intl.locale)}
         </h3>
       </Link>
 

--- a/app/components/LineSummaryBlock/components/DateCard.tsx
+++ b/app/components/LineSummaryBlock/components/DateCard.tsx
@@ -14,6 +14,7 @@ import type {
 } from '~/types';
 import { FormattedDuration } from '~/components/FormattedDuration';
 import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
+import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 import { useHydrated } from '../../../hooks/useHydrated';
 import { DAY_TYPE_MESSAGE_DESCRIPTORS } from '../constants';
 import { useOperatingHours } from '../hooks/useOperatingHours';
@@ -280,8 +281,7 @@ export const DateCard: React.FC<Props> = (props) => {
                         })}
                       />
                       <span className="leading-tight">
-                        {issueRef.titleTranslations[intl.locale] ??
-                          issueRef.title}
+                        {getLocalizedTranslation(issueRef.title, intl.locale)}
                       </span>
                     </Link>
                   );

--- a/app/components/LineSummaryBlock/index.tsx
+++ b/app/components/LineSummaryBlock/index.tsx
@@ -11,6 +11,7 @@ import {
 import type { LineSummary } from '~/types';
 import { LineSummaryStatusLabels } from '~/constants';
 import { useIncludedEntities } from '~/contexts/IncludedEntities';
+import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 import { useHydrated } from '../../hooks/useHydrated';
 import { DateCard } from './components/DateCard';
 import { NonOperationalDateCard } from './components/NonOperationalDateCard';
@@ -61,7 +62,7 @@ export const LineSummaryBlock: React.FC<Props> = (props) => {
             {line.id}
           </span>
           <span className="group-hover:underline">
-            {line.titleTranslations[intl.locale] ?? line.title}
+            {getLocalizedTranslation(line.name, intl.locale)}
           </span>
         </Link>
         <div className="flex grow justify-end truncate">

--- a/app/components/StationMap/index.tsx
+++ b/app/components/StationMap/index.tsx
@@ -8,6 +8,7 @@ import type { IssueAffectedBranch } from '~/types';
 import { ZoomControls } from '~/components/ZoomControls';
 import { useIncludedEntities } from '~/contexts/IncludedEntities';
 import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
+import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 import { assert } from '~/util/assert';
 import { MapApr2025 } from './components/MapApr2025';
 import { MapDec2019 } from './components/MapDec2019';
@@ -192,8 +193,7 @@ export const StationMap: React.FC<Props> = (props) => {
           continue;
         }
         const station = included.stations[stationId];
-        const stationName =
-          station.nameTranslations[intl.locale] ?? station.name;
+        const stationName = getLocalizedTranslation(station.name, intl.locale);
         const segments = segmentText(stationName, intl.locale);
         for (let i = 0; i < tspans.length; i++) {
           const tspan = tspans[i];
@@ -365,9 +365,7 @@ export const StationMap: React.FC<Props> = (props) => {
                     to="/{-$lang}/stations/$stationId"
                     params={{ stationId }}
                   >
-                    {station.nameTranslations[intl.locale] ??
-                      station.name ??
-                      stationId}
+                    {getLocalizedTranslation(station.name, intl.locale)}
                   </Link>
                 );
               })}

--- a/app/helpers/getLocalizedTranslation.ts
+++ b/app/helpers/getLocalizedTranslation.ts
@@ -1,0 +1,25 @@
+import type { Translations } from '@mrtdown/core';
+
+type TranslationLocale = keyof Translations;
+
+function normalizeTranslationLocale(
+  locale: string | null | undefined,
+): TranslationLocale {
+  switch (locale) {
+    case 'zh-Hans':
+    case 'ms':
+    case 'ta':
+      return locale;
+    default:
+      return 'en-SG';
+  }
+}
+
+export function getLocalizedTranslation(
+  translations: Translations,
+  locale: string | null | undefined,
+) {
+  return (
+    translations[normalizeTranslationLocale(locale)] ?? translations['en-SG']
+  );
+}

--- a/app/routes/{-$lang}.tsx
+++ b/app/routes/{-$lang}.tsx
@@ -18,6 +18,7 @@ import { FormattedDate, FormattedMessage, IntlProvider } from 'react-intl';
 import { LocaleSwitcher } from '~/components/LocaleSwitcher';
 import Spinner from '~/components/Spinner';
 import { LANGUAGES } from '~/constants';
+import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 import { getRootFn } from '~/util/root.functions';
 
 export const Route = createFileRoute('/{-$lang}')({
@@ -286,8 +287,7 @@ function RouteComponent() {
                           >
                             {line.id}
                           </span>
-                          {line.titleTranslations[lang ?? 'en-SG'] ??
-                            line.title}
+                          {getLocalizedTranslation(line.name, lang)}
                         </Link>
                       </li>
                     );
@@ -328,18 +328,6 @@ function RouteComponent() {
                         />
                       </Link>
                     </li>
-                    {/*{footerManifest.featuredStations.map((station) => (
-                      <li key={station.id}>
-                        <Link
-                          to="/{-$lang}/stations/$stationId"
-                          params={{ stationId: station.id }}
-                          className="flex text-sm transition-colors hover:text-blue-400"
-                        >
-                          {station.name_translations[lang ?? 'en-SG'] ??
-                            station.name}
-                        </Link>
-                      </li>
-                    ))}*/}
                   </ul>
                 </div>
 
@@ -362,9 +350,9 @@ function RouteComponent() {
                             params={{ operatorId }}
                             className="flex text-sm transition-colors hover:text-accent-light"
                           >
-                            {operator?.nameTranslations[lang ?? 'en-SG'] ??
-                              operator?.name ??
-                              operatorId}
+                            {operator != null
+                              ? getLocalizedTranslation(operator.name, lang)
+                              : operatorId}
                           </Link>
                         </li>
                       );

--- a/app/routes/{-$lang}/components/LineItem.tsx
+++ b/app/routes/{-$lang}/components/LineItem.tsx
@@ -6,6 +6,7 @@ import type { Line, LineSummaryStatus } from '~/types';
 import { LineSummaryStatusLabels } from '~/constants';
 import { useIncludedEntities } from '~/contexts/IncludedEntities';
 import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
+import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 
 interface Props {
   line: Line;
@@ -39,7 +40,7 @@ export const LineItem: React.FC<Props> = (props) => {
           className="group flex-1"
         >
           <h2 className="font-semibold text-gray-800 transition-colors group-hover:text-blue-600 dark:text-gray-200 dark:group-hover:text-blue-400">
-            {line.titleTranslations[intl.locale] ?? line.title}
+            {getLocalizedTranslation(line.name, intl.locale)}
           </h2>
         </Link>
 
@@ -86,7 +87,7 @@ export const LineItem: React.FC<Props> = (props) => {
             >
               <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 transition-all group-hover:border-blue-300 group-hover:bg-blue-50 dark:border-gray-600 dark:bg-gray-700/50 dark:group-hover:border-blue-500 dark:group-hover:bg-blue-900/20">
                 <p className="font-medium text-gray-700 text-sm group-hover:text-blue-700 dark:text-gray-300 dark:group-hover:text-blue-300">
-                  {issue.titleTranslations[intl.locale] ?? issue.title}
+                  {getLocalizedTranslation(issue.title, intl.locale)}
                 </p>
               </div>
             </Link>

--- a/app/routes/{-$lang}/issues/$issueId/index.tsx
+++ b/app/routes/{-$lang}/issues/$issueId/index.tsx
@@ -9,6 +9,7 @@ import { createIntl, FormattedMessage, useIntl } from 'react-intl';
 import { IssueTypeLabels } from '~/constants';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
 import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
+import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 import { assert } from '~/util/assert';
 import { getIssueFn } from '~/util/issue.functions';
 import { Attributes } from './components/Attributes';
@@ -26,7 +27,7 @@ export const Route = createFileRoute('/{-$lang}/issues/$issueId/')({
     assert(ctx.loaderData != null);
     const { data, included } = ctx.loaderData;
     const issue = included.issues[data.id];
-    const title = issue.titleTranslations[lang] ?? issue.title;
+    const title = getLocalizedTranslation(issue.title, lang);
 
     const rootUrl = import.meta.env.VITE_ROOT_URL;
     const ogUrl = new URL(
@@ -53,7 +54,7 @@ export const Route = createFileRoute('/{-$lang}/issues/$issueId/')({
     const stationCount = stationIds.size;
     const lineNames = issue.lineIds.map((lineId) => {
       const line = included.lines[lineId];
-      return line.titleTranslations[lang] ?? line.title;
+      return getLocalizedTranslation(line.name, lang);
     });
 
     const description = intl.formatMessage(
@@ -106,7 +107,7 @@ export const Route = createFileRoute('/{-$lang}/issues/$issueId/')({
             mainEntity: issue.intervals.map((interval) => {
               return {
                 '@type': 'Event',
-                name: issue.title,
+                name: title,
                 eventAttendanceMode:
                   'https://schema.org/OfflineEventAttendanceMode',
                 startDate: interval.startAt,
@@ -175,7 +176,7 @@ function IssuePage() {
           </div>
 
           <h1 className="mt-3 font-bold text-2xl text-gray-900 dark:text-gray-100">
-            {issue.titleTranslations[intl.locale] ?? issue.title}
+            {getLocalizedTranslation(issue.title, intl.locale)}
           </h1>
 
           <Attributes issue={issue} />

--- a/app/routes/{-$lang}/lines/$lineId/components/LineSchematicCard/components/BranchItem.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/components/LineSchematicCard/components/BranchItem.tsx
@@ -1,5 +1,6 @@
 import { FormattedDate, FormattedMessage, useIntl } from 'react-intl';
-import type { LineBranch } from '~/types';
+import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
+import type { LineBranch } from '~/util/db.queries';
 
 interface Props {
   branch: LineBranch;
@@ -13,7 +14,7 @@ export const BranchItem: React.FC<Props> = (props) => {
   return (
     <div className="flex flex-col">
       <span className="font-medium">
-        {branch.titleTranslations[intl.locale] ?? branch.title}
+        {getLocalizedTranslation(branch.name, intl.locale)}
       </span>
       {branch.startedAt == null ? (
         <span className="text-gray-500 text-xs dark:text-gray-400">

--- a/app/routes/{-$lang}/lines/$lineId/components/LineSchematicCard/index.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/components/LineSchematicCard/index.tsx
@@ -4,8 +4,10 @@ import classNames from 'classnames';
 import { DropdownMenu } from 'radix-ui';
 import { Fragment, useMemo, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import type { Line, LineBranch } from '~/types';
 import { useIncludedEntities } from '~/contexts/IncludedEntities';
+import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
+import type { LineBranch } from '~/util/db.queries';
+import type { Line } from '~/types';
 import { BranchItem } from './components/BranchItem';
 
 interface Props {
@@ -154,8 +156,10 @@ export const LineSchematicCard: React.FC<Props> = (props) => {
                         className="group flex"
                       >
                         <span className="text-gray-800 text-sm group-hover:underline dark:text-gray-200">
-                          {stations[stationId].nameTranslations[intl.locale] ??
-                            stations[stationId].name}
+                          {getLocalizedTranslation(
+                            stations[stationId].name,
+                            intl.locale,
+                          )}
                         </span>
                       </Link>
                     </div>

--- a/app/routes/{-$lang}/lines/$lineId/components/NextMaintenanceCard.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/components/NextMaintenanceCard.tsx
@@ -5,6 +5,7 @@ import { FormattedDateTimeRange, FormattedMessage, useIntl } from 'react-intl';
 import type { Issue } from '~/types';
 import { IssueAffectedBranchPill } from '~/components/IssueAffectedBranchPill';
 import { useIncludedEntities } from '~/contexts/IncludedEntities';
+import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 
 interface InternalContentProps {
   lineId: string;
@@ -45,7 +46,7 @@ const InternalContent: React.FC<InternalContentProps> = (props) => {
         params={{ issueId: issue.id }}
       >
         <span className="font-semibold text-base text-gray-800 leading-tight dark:text-gray-200">
-          {issue.titleTranslations[intl.locale] ?? issue.title}
+          {getLocalizedTranslation(issue.title, intl.locale)}
         </span>
       </Link>
 

--- a/app/routes/{-$lang}/lines/$lineId/components/QuickFactsCard.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/components/QuickFactsCard.tsx
@@ -9,8 +9,10 @@ import {
   FormattedNumber,
   useIntl,
 } from 'react-intl';
-import type { Line, LineBranch } from '~/types';
 import { useIncludedEntities } from '~/contexts/IncludedEntities';
+import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
+import type { LineBranch } from '~/util/db.queries';
+import type { Line } from '~/types';
 
 interface Props {
   line: Line;
@@ -51,7 +53,7 @@ export const QuickFactsCard: React.FC<Props> = (props) => {
         }
         return {
           id: operator.id,
-          name: operator.nameTranslations[intl.locale] ?? operator.name,
+          name: getLocalizedTranslation(operator.name, intl.locale),
         };
       })
       .filter((op): op is { id: string; name: string } => op != null);

--- a/app/routes/{-$lang}/lines/$lineId/components/StationInterchangesCard.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/components/StationInterchangesCard.tsx
@@ -2,6 +2,7 @@ import { Link } from '@tanstack/react-router';
 import { Fragment } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useIncludedEntities } from '~/contexts/IncludedEntities';
+import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 
 interface Props {
   lineId: string;
@@ -77,8 +78,10 @@ export const StationInterchangesCard: React.FC<Props> = (props) => {
                       className="group flex"
                     >
                       <span className="text-gray-800 text-sm group-hover:underline dark:text-gray-200">
-                        {stations[stationId].nameTranslations[intl.locale] ??
-                          stations[stationId].name}
+                        {getLocalizedTranslation(
+                          stations[stationId].name,
+                          intl.locale,
+                        )}
                       </span>
                     </Link>
                   </div>

--- a/app/routes/{-$lang}/lines/$lineId/index.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/index.tsx
@@ -11,6 +11,7 @@ import {
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
 import { buildIssueTypeCountString } from '~/helpers/buildIssueTypeCountString';
 import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
+import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 import { assert } from '~/util/assert';
 import { getLineProfileFn } from '~/util/lines.functions';
 import { CountTrendCards } from './components/CountTrendCards';
@@ -35,7 +36,7 @@ export const Route = createFileRoute('/{-$lang}/lines/$lineId/')({
     const { data: lineProfile, included } = ctx.loaderData;
     const { branches, issueCountByType } = lineProfile;
     const line = included.lines[lineId];
-    const componentName = line.titleTranslations[lang] ?? line.title;
+    const componentName = getLocalizedTranslation(line.name, lang);
 
     const rootUrl = import.meta.env.VITE_ROOT_URL;
 
@@ -156,8 +157,10 @@ export const Route = createFileRoute('/{-$lang}/lines/$lineId/')({
               containsPlace: branches.flatMap((branch) => {
                 return branch.stationIds.map((stationId) => {
                   const station = included.stations[stationId];
-                  const stationName =
-                    station.nameTranslations[lang] ?? station.name;
+                  const stationName = getLocalizedTranslation(
+                    station.name,
+                    lang,
+                  );
 
                   const alternateName = station.memberships
                     .map((membership) => membership.code)
@@ -186,7 +189,7 @@ function ComponentPage() {
   const line = included.lines[lineId];
 
   const intl = useIntl();
-  const componentName = line.titleTranslations[intl.locale] ?? line.title;
+  const componentName = getLocalizedTranslation(line.name, intl.locale);
 
   const stationCount = useMemo(() => {
     const stationIds = new Set<string>();
@@ -240,8 +243,7 @@ function ComponentPage() {
                     id="general.component_status.heading"
                     defaultMessage="{componentName} outages in the last {dateCount} days"
                     values={{
-                      componentName:
-                        line.titleTranslations[intl.locale] ?? line.title,
+                      componentName,
                       dateCount: DATE_COUNT,
                     }}
                   />

--- a/app/routes/{-$lang}/operators/$operatorId/components/OperatorCurrentStatusCard.tsx
+++ b/app/routes/{-$lang}/operators/$operatorId/components/OperatorCurrentStatusCard.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import { FormattedMessage } from 'react-intl';
-import type { OperatorProfile } from '~/types';
+import type { OperatorProfile } from '~/util/db.queries';
 
 interface Props {
   currentOperationalStatus: OperatorProfile['currentOperationalStatus'];

--- a/app/routes/{-$lang}/operators/$operatorId/components/OperatorLinePerformanceCard.tsx
+++ b/app/routes/{-$lang}/operators/$operatorId/components/OperatorLinePerformanceCard.tsx
@@ -1,9 +1,10 @@
 import { Link } from '@tanstack/react-router';
 import classNames from 'classnames';
 import { FormattedMessage, FormattedNumber, useIntl } from 'react-intl';
-import type { OperatorProfile } from '~/types';
 import { LineSummaryStatusLabels } from '~/constants';
 import { useIncludedEntities } from '~/contexts/IncludedEntities';
+import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
+import type { OperatorProfile } from '~/util/db.queries';
 
 interface Props {
   linePerformanceComparison: OperatorProfile['linePerformanceComparison'];
@@ -33,7 +34,7 @@ export const OperatorLinePerformanceCard: React.FC<Props> = (props) => {
           if (line == null) {
             return null;
           }
-          const lineName = line.titleTranslations[intl.locale] ?? line.title;
+          const lineName = getLocalizedTranslation(line.name, intl.locale);
 
           return (
             <Link

--- a/app/routes/{-$lang}/operators/$operatorId/components/OperatorQuickFactsCard.tsx
+++ b/app/routes/{-$lang}/operators/$operatorId/components/OperatorQuickFactsCard.tsx
@@ -1,7 +1,7 @@
 import { FormattedMessage, FormattedNumber } from 'react-intl';
 import { Duration } from 'luxon';
-import type { OperatorProfile } from '~/types';
 import { FormattedDuration } from '~/components/FormattedDuration';
+import type { OperatorProfile } from '~/util/db.queries';
 
 interface Props {
   operatorProfile: OperatorProfile;

--- a/app/routes/{-$lang}/operators/$operatorId/index.tsx
+++ b/app/routes/{-$lang}/operators/$operatorId/index.tsx
@@ -12,6 +12,7 @@ import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
 import { buildIssueTypeCountString } from '~/helpers/buildIssueTypeCountString';
 import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
 import { getDateCountForViewport } from '~/helpers/getDateCountForViewport';
+import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 import { useHydrated } from '~/hooks/useHydrated';
 import { useViewport, ViewportSchema } from '~/hooks/useViewport';
 import { getOperatorProfileFn } from '~/util/operator.functions';
@@ -46,7 +47,7 @@ export const Route = createFileRoute('/{-$lang}/operators/$operatorId/')({
     const { data: operatorProfile, included, dateCount } = ctx.loaderData;
 
     const operator = included.operators[operatorProfile.operatorId];
-    const operatorName = operator.nameTranslations[lang] ?? operator.name;
+    const operatorName = getLocalizedTranslation(operator.name, lang);
 
     const { default: messages } = await import(
       `../../../../../lang/${lang}.json`
@@ -186,7 +187,8 @@ function OperatorPage() {
   const { data: operatorProfile, included, dateCount } = loaderData;
   const operator = included.operators[operatorProfile.operatorId];
   const intl = useIntl();
-  const operatorName = operator.nameTranslations[intl.locale] ?? operator.name;
+  const operatorName = getLocalizedTranslation(operator.name, intl.locale);
+  const operatorDefaultName = getLocalizedTranslation(operator.name, 'en-SG');
 
   const isHydrated = useHydrated();
   const navigate = Route.useNavigate();
@@ -215,9 +217,9 @@ function OperatorPage() {
             <div className="relative">
               <h1 className="mb-2 font-black text-2xl text-white leading-tight md:text-3xl">
                 {operatorName}
-                {operator.name !== operatorName && (
+                {operatorDefaultName !== operatorName && (
                   <span className="ml-2 text-gray-300 text-xl">
-                    {operator.name}
+                    {operatorDefaultName}
                   </span>
                 )}
               </h1>

--- a/app/routes/{-$lang}/stations/$stationId.tsx
+++ b/app/routes/{-$lang}/stations/$stationId.tsx
@@ -18,6 +18,7 @@ import { LineTypeLabels, StationStructureTypeLabels } from '~/constants';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
 import { buildIssueTypeCountString } from '~/helpers/buildIssueTypeCountString';
 import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
+import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 import { useHydrated } from '~/hooks/useHydrated';
 import { getStationProfileFn } from '~/util/station.functions';
 import { assert } from '../../../util/assert';
@@ -29,10 +30,10 @@ function computeStationStrings(
   now = DateTime.now(),
 ) {
   const town = included.towns[station.townId];
-  const townName = town.nameTranslations[intl.locale] ?? town.name;
+  const townName = getLocalizedTranslation(town.name, intl.locale);
   const landmarkNames = station.landmarkIds.map((id) => {
     const landmark = included.landmarks[id];
-    return landmark.nameTranslations[intl.locale] ?? landmark.name;
+    return getLocalizedTranslation(landmark.name, intl.locale);
   });
 
   const operationalMemberSet = new Set<string>();
@@ -81,7 +82,7 @@ export const Route = createFileRoute('/{-$lang}/stations/$stationId')({
       messages,
     });
 
-    const stationName = station.nameTranslations[lang] ?? station.name;
+    const stationName = getLocalizedTranslation(station.name, lang);
 
     const title = intl.formatMessage(
       {
@@ -197,7 +198,8 @@ function StationPage() {
   const { data: stationProfile, included } = loaderData;
   const station = included.stations[stationProfile.stationId];
   const intl = useIntl();
-  const stationName = station.nameTranslations[intl.locale] ?? station.name;
+  const stationName = getLocalizedTranslation(station.name, intl.locale);
+  const stationDefaultName = getLocalizedTranslation(station.name, 'en-SG');
   const isHydrated = useHydrated();
 
   const { townName, landmarkNames, componentTypeStrings, isInterchange } =
@@ -258,9 +260,9 @@ function StationPage() {
 
                 <h1 className="mb-2 font-bold text-3xl text-gray-900 dark:text-white">
                   {stationName}
-                  {station.name !== stationName && (
+                  {stationDefaultName !== stationName && (
                     <span className="ml-2 text-gray-600 text-xl dark:text-gray-300">
-                      {station.name}
+                      {stationDefaultName}
                     </span>
                   )}
                 </h1>
@@ -378,9 +380,10 @@ function StationPage() {
                             {membership.lineId}
                           </span>
                           <span className="text-sm group-hover:underline">
-                            {included.lines[membership.lineId]
-                              .titleTranslations[intl.locale] ??
-                              included.lines[membership.lineId].title}
+                            {getLocalizedTranslation(
+                              included.lines[membership.lineId].name,
+                              intl.locale,
+                            )}
                           </span>
                         </Link>
                       </td>

--- a/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/DisruptionsHeatmap/index.tsx
+++ b/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/DisruptionsHeatmap/index.tsx
@@ -4,8 +4,8 @@ import { DateTime } from 'luxon';
 import type React from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import type { SystemAnalytics } from '~/types';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
+import type { SystemAnalytics } from '~/util/db.queries';
 import { DayIssuesList } from './components/DayIssuesList';
 import { useDayIssues } from './hooks/useDayIssues';
 

--- a/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/LinesIssueCountCard/components/TooltipContent.tsx
+++ b/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/LinesIssueCountCard/components/TooltipContent.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useIncludedEntities } from '~/contexts/IncludedEntities';
+import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 
 interface Props {
   active?: boolean;
@@ -31,7 +32,7 @@ export const TooltipContent: React.FC<Props> = ({ active, payload, label }) => {
       {isVisible && (
         <div className="z-50 flex w-52 flex-col rounded-lg border border-gray-200 bg-white px-4 py-3 shadow-lg outline-none ring-1 ring-black/5 backdrop-blur-sm dark:border-gray-700 dark:bg-gray-800 dark:ring-white/10">
           <span className="mb-2 font-semibold text-gray-900 text-sm dark:text-gray-100">
-            {line.titleTranslations[intl.locale] ?? line.title}
+            {getLocalizedTranslation(line.name, intl.locale)}
           </span>
           {payload.map((item) => (
             <div key={item.dataKey} className="flex items-center py-0.5">

--- a/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/LinesIssueCountCard/index.tsx
+++ b/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/LinesIssueCountCard/index.tsx
@@ -10,7 +10,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
-import type { SystemAnalytics } from '~/types';
+import type { SystemAnalytics } from '~/util/db.queries';
 
 import { Tick } from './components/Tick';
 import { TooltipContent } from './components/TooltipContent';

--- a/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/StationsIssueCountCard/components/Tick.tsx
+++ b/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/StationsIssueCountCard/components/Tick.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import { useIncludedEntities } from '~/contexts/IncludedEntities';
+import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 
 interface TickProps extends React.SVGProps<SVGElement> {
   x: number;
@@ -20,7 +21,9 @@ export const Tick: React.FC<TickProps> = (props) => {
     return stations[stationId];
   }, [stations, stationId]);
   const stationName =
-    station?.nameTranslations?.[intl.locale] ?? station?.name ?? stationId;
+    station != null
+      ? getLocalizedTranslation(station.name, intl.locale)
+      : stationId;
 
   return (
     <g transform={`translate(${x},${y})`}>

--- a/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/StationsIssueCountCard/components/TooltipContent.tsx
+++ b/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/StationsIssueCountCard/components/TooltipContent.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useIncludedEntities } from '~/contexts/IncludedEntities';
+import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 
 interface Props {
   active?: boolean;
@@ -23,7 +24,9 @@ export const TooltipContent: React.FC<Props> = ({ active, payload, label }) => {
 
   const station = stations[label];
   const stationName =
-    station?.nameTranslations?.[intl.locale] ?? station?.name ?? label;
+    station != null
+      ? getLocalizedTranslation(station.name, intl.locale)
+      : label;
 
   return (
     <div

--- a/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/StationsIssueCountCard/index.tsx
+++ b/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/StationsIssueCountCard/index.tsx
@@ -10,7 +10,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
-import type { SystemAnalytics } from '~/types';
+import type { SystemAnalytics } from '~/util/db.queries';
 import { Tick } from './components/Tick';
 import { TooltipContent } from './components/TooltipContent';
 

--- a/app/routes/{-$lang}/statistics/components/StatisticsGrid/index.tsx
+++ b/app/routes/{-$lang}/statistics/components/StatisticsGrid/index.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import type { SystemAnalytics } from '~/types';
+import type { SystemAnalytics } from '~/util/db.queries';
 import { CountTrendCards } from './components/CountTrendCards';
 import { DisruptionsHeatmap } from './components/DisruptionsHeatmap';
 import { DurationTrendCards } from './components/DurationTrendCards';

--- a/app/routes/{-$lang}/system-map.tsx
+++ b/app/routes/{-$lang}/system-map.tsx
@@ -7,6 +7,7 @@ import { CurrentAdvisoriesSection } from '~/components/CurrentAdvisoriesSection'
 import { StationMap } from '~/components/StationMap';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
 import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
+import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 import { getSystemMapFn } from '~/util/system-map.functions';
 
 export const Route = createFileRoute('/{-$lang}/system-map')({
@@ -153,7 +154,7 @@ function SystemMapPage() {
                   </div>
 
                   <span className="text-gray-800 text-sm group-hover:underline dark:text-gray-200">
-                    {line.titleTranslations[intl.locale] ?? line.title}
+                    {getLocalizedTranslation(line.name, intl.locale)}
                   </span>
                 </Link>
               ))}

--- a/app/types.ts
+++ b/app/types.ts
@@ -4,24 +4,15 @@ import type {
   IssueType,
   Landmark as CoreLandmark,
   Line as CoreLine,
-  OperatingHours,
   Operator as CoreOperator,
   Station as CoreStation,
   Town as CoreTown,
-  Translations,
 } from '@mrtdown/core';
-
-type AppTranslations = Translations & Record<string, string | null | undefined>;
 
 type StationCode = CoreStation['stationCodes'][number];
 
-export type Line = Pick<
-  CoreLine,
-  'id' | 'type' | 'color' | 'startedAt' | 'operators'
-> & {
-  title: string;
-  titleTranslations: AppTranslations;
-  operatingHours: OperatingHours;
+export type Line = Omit<CoreLine, 'serviceIds' | 'operatingHours'> & {
+  operatingHours: NonNullable<CoreLine['operatingHours']>;
 };
 
 type StationLineMembership = Pick<
@@ -33,12 +24,7 @@ type StationLineMembership = Pick<
   sequenceOrder: number;
 };
 
-export type Station = Pick<
-  CoreStation,
-  'id' | 'geo' | 'townId' | 'landmarkIds'
-> & {
-  name: string;
-  nameTranslations: AppTranslations;
+export type Station = Omit<CoreStation, 'stationCodes'> & {
   memberships: StationLineMembership[];
 };
 
@@ -54,9 +40,7 @@ export type IssueInterval = {
   status: 'ongoing' | 'ended' | 'future';
 };
 
-export type Issue = Pick<CoreIssue, 'id' | 'type'> & {
-  title: string;
-  titleTranslations: AppTranslations;
+export type Issue = Omit<CoreIssue, 'titleMeta'> & {
   subtypes: CauseSubtype[];
   durationSeconds: number;
   lineIds: string[];
@@ -64,28 +48,13 @@ export type Issue = Pick<CoreIssue, 'id' | 'type'> & {
   intervals: IssueInterval[];
 };
 
-type Landmark = Pick<CoreLandmark, 'id'> & {
-  name: string;
-  nameTranslations: AppTranslations;
-};
-
-type Town = Pick<CoreTown, 'id'> & {
-  name: string;
-  nameTranslations: AppTranslations;
-};
-
-type Operator = Pick<CoreOperator, 'id' | 'foundedAt' | 'url'> & {
-  name: string;
-  nameTranslations: AppTranslations;
-};
-
 export type IncludedEntities = {
   lines: Record<string, Line>;
   stations: Record<string, Station>;
   issues: Record<string, Issue>;
-  landmarks: Record<string, Landmark>;
-  towns: Record<string, Town>;
-  operators: Record<string, Operator>;
+  landmarks: Record<string, CoreLandmark>;
+  towns: Record<string, CoreTown>;
+  operators: Record<string, CoreOperator>;
 };
 
 export type LineSummaryStatus =
@@ -145,59 +114,4 @@ export type TimeScaleChart = {
   displayTimeScale?: TimeScale;
   dataTimeScale: TimeScale;
   dataCumulative: ChartEntry[];
-};
-
-type Chart = {
-  title: string;
-  data: ChartEntry[];
-};
-
-export type SystemAnalytics = {
-  timeScaleChartsIssueCount: TimeScaleChart[];
-  timeScaleChartsIssueDuration: TimeScaleChart[];
-  chartTotalIssueCountByLine: Chart;
-  chartTotalIssueCountByStation: Chart;
-  chartRollingYearHeatmap: Chart;
-  issueIdsDisruptionLongest: string[];
-};
-
-export type LineBranch = {
-  id: string;
-  title: string;
-  titleTranslations: AppTranslations;
-  startedAt: string | null;
-  endedAt: string | null;
-  stationIds: string[];
-};
-
-type OperatorLinePerformance = {
-  lineId: string;
-  status: LineSummaryStatus;
-  uptimeRatio: number | null;
-  issueCount: number;
-};
-
-export type OperatorProfile = {
-  operatorId: string;
-  lineIds: string[];
-  aggregateUptimeRatio: number | null;
-  currentOperationalStatus:
-    | 'all_operational'
-    | 'some_lines_disrupted'
-    | 'some_lines_under_maintenance'
-    | 'all_lines_closed_for_day';
-  linesAffected: string[];
-  totalIssuesByType: {
-    [key in IssueType]?: number;
-  };
-  totalStationsOperated: number;
-  issueIdsRecent: string[];
-  timeScaleGraphsIssueCount: TimeScaleChart[];
-  timeScaleGraphsUptimeRatios: TimeScaleChart[];
-  linePerformanceComparison: OperatorLinePerformance[];
-  totalDowntimeDurationSeconds: number;
-  downtimeDurationByIssueType: {
-    [key in IssueType]?: number;
-  };
-  yearsOfOperation: number | null;
 };

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -2,6 +2,7 @@ import {
   type IssueType,
   resolvePeriods,
   type FacilityEffectKind,
+  type Service as CoreService,
   type ServiceEffectKind,
 } from '@mrtdown/core';
 import { and, desc, eq, gte, inArray, lte, sql } from 'drizzle-orm';
@@ -14,13 +15,10 @@ import type {
   IssueAffectedBranch,
   IssueInterval,
   Line,
-  LineBranch,
   LineSummary,
   LineSummaryDayType,
   LineSummaryStatus,
-  OperatorProfile,
   Station,
-  SystemAnalytics,
   TimeScaleChart,
 } from '~/types';
 import {
@@ -58,12 +56,35 @@ const SG_TIMEZONE = 'Asia/Singapore';
 
 type BaseIncludedEntities = Omit<IncludedEntities, 'issues'>;
 
+type DatasetLineBranch = {
+  id: CoreService['id'];
+  name: CoreService['name'];
+  startedAt: CoreService['revisions'][number]['startAt'] | null;
+  endedAt: CoreService['revisions'][number]['endAt'];
+  stationIds: Array<
+    CoreService['revisions'][number]['path']['stations'][number]['stationId']
+  >;
+};
+
+type OperatorOperationalStatus =
+  | 'all_operational'
+  | 'some_lines_disrupted'
+  | 'some_lines_under_maintenance'
+  | 'all_lines_closed_for_day';
+
+type OperatorLinePerformance = {
+  lineId: string;
+  status: LineSummaryStatus;
+  uptimeRatio: number | null;
+  issueCount: number;
+};
+
 type IssueWithOperationalEffects = Issue & {
   serviceEffectKinds: ServiceEffectKind[];
   facilityEffectKinds: FacilityEffectKind[];
 };
 
-type BranchWithEntries = LineBranch & {
+type BranchWithEntries = DatasetLineBranch & {
   entries: Array<{
     stationId: string;
     displayCode: string;
@@ -98,7 +119,6 @@ type IssueIntervalBounds = {
   end: DateTime | null;
 };
 
-type AppTranslations = Line['titleTranslations'];
 type TimeScale = TimeScaleChart['dataTimeScale'];
 
 type StatisticsTimeWindow = {
@@ -199,10 +219,7 @@ function isoDateTime(value: DateTime) {
   return dateTime;
 }
 
-function parseTranslations(value: unknown): {
-  fallback: string;
-  translations: AppTranslations;
-} {
+function parseTranslations(value: unknown): Line['name'] {
   const isNonEmptyTranslation = (
     translation: string | null | undefined,
   ): translation is string =>
@@ -217,17 +234,11 @@ function parseTranslations(value: unknown): {
     ) ??
     Object.values(rawTranslations).find(isNonEmptyTranslation) ??
     '';
-  const translations: AppTranslations = {
-    ...rawTranslations,
+  return {
     'en-SG': fallback,
     'zh-Hans': rawTranslations['zh-Hans'] ?? null,
     ms: rawTranslations.ms ?? null,
     ta: rawTranslations.ta ?? null,
-  };
-
-  return {
-    fallback,
-    translations,
   };
 }
 
@@ -880,11 +891,10 @@ async function buildDataset(
 
   const operatorsById = Object.fromEntries(
     operatorsRows.map((row) => {
-      const { fallback, translations } = parseTranslations(row.name);
+      const name = parseTranslations(row.name);
       const operator: IncludedEntities['operators'][string] = {
         id: row.id,
-        name: fallback,
-        nameTranslations: translations,
+        name,
         foundedAt: row.founded_at,
         url: row.url,
       };
@@ -894,13 +904,12 @@ async function buildDataset(
 
   const townsById = Object.fromEntries(
     townsRows.map((row) => {
-      const { fallback, translations } = parseTranslations(row.name);
+      const name = parseTranslations(row.name);
       return [
         row.id,
         {
           id: row.id,
-          name: fallback,
-          nameTranslations: translations,
+          name,
         },
       ];
     }),
@@ -908,13 +917,12 @@ async function buildDataset(
 
   const landmarksById = Object.fromEntries(
     landmarksRows.map((row) => {
-      const { fallback, translations } = parseTranslations(row.name);
+      const name = parseTranslations(row.name);
       return [
         row.id,
         {
           id: row.id,
-          name: fallback,
-          nameTranslations: translations,
+          name,
         },
       ];
     }),
@@ -936,11 +944,10 @@ async function buildDataset(
 
   const linesById = Object.fromEntries(
     linesRows.map((row) => {
-      const { fallback, translations } = parseTranslations(row.name);
+      const name = parseTranslations(row.name);
       const line: Line = {
         id: row.id,
-        title: fallback,
-        titleTranslations: translations,
+        name,
         type: row.type,
         color: row.color,
         startedAt: row.started_at,
@@ -1092,7 +1099,7 @@ async function buildDataset(
       .filter((value): value is string => value != null)
       .map((value) => parseDateTime(value));
 
-    const { fallback, translations } = parseTranslations(service.name);
+    const name = parseTranslations(service.name);
     const minStart = startedDates.sort(
       (a, b) => a.toMillis() - b.toMillis(),
     )[0];
@@ -1100,8 +1107,7 @@ async function buildDataset(
       minStart != null && startedDates.every((date) => date > referenceNow);
     const branch: BranchWithEntries = {
       id: service.id,
-      title: fallback,
-      titleTranslations: translations,
+      name,
       startedAt:
         minStart != null && !allStartsInFuture ? minStart.toISODate() : null,
       endedAt: (() => {
@@ -1220,11 +1226,10 @@ async function buildDataset(
 
   const stationsById = Object.fromEntries(
     stationRows.map((row) => {
-      const { fallback, translations } = parseTranslations(row.name);
+      const name = parseTranslations(row.name);
       const station: Station = {
         id: row.id,
-        name: fallback,
-        nameTranslations: translations,
+        name,
         geo: {
           latitude: Number(row.latitude),
           longitude: Number(row.longitude),
@@ -1311,7 +1316,7 @@ async function buildDataset(
 
   const allIssues: Record<string, IssueWithOperationalEffects> = {};
   for (const row of issueRows) {
-    const { fallback, translations } = parseTranslations(row.title);
+    const title = parseTranslations(row.title);
     const latestEventByType = latestEventByTypeByIssueId[row.id] ?? {};
     const selectedStateEvents = [
       latestEventByType['periods.set'],
@@ -1454,8 +1459,7 @@ async function buildDataset(
 
     allIssues[row.id] = {
       id: row.id,
-      title: fallback,
-      titleTranslations: translations,
+      title,
       type: row.type,
       subtypes: [...causeSet],
       durationSeconds,
@@ -3035,15 +3039,16 @@ export async function getOperatorProfileData(operatorId: string, days: number) {
     ),
   ).size;
 
-  const linePerformanceComparison: OperatorProfile['linePerformanceComparison'] =
-    lineIds.map((lineId) => ({
+  const linePerformanceComparison: OperatorLinePerformance[] = lineIds.map(
+    (lineId) => ({
       lineId,
       status: lineSummaries[lineId].status,
       uptimeRatio: lineSummaries[lineId].uptimeRatio,
       issueCount: operatorIssues.filter((issue) =>
         issue.lineIds.includes(lineId),
       ).length,
-    }));
+    }),
+  );
 
   const activeSummaries = Object.values(lineSummaries);
   const linesAffected = activeSummaries
@@ -3054,8 +3059,7 @@ export async function getOperatorProfileData(operatorId: string, days: number) {
     )
     .map((summary) => summary.lineId);
 
-  let currentOperationalStatus: OperatorProfile['currentOperationalStatus'] =
-    'all_operational';
+  let currentOperationalStatus: OperatorOperationalStatus = 'all_operational';
   if (
     activeSummaries.length > 0 &&
     activeSummaries.every((summary) =>
@@ -3084,7 +3088,7 @@ export async function getOperatorProfileData(operatorId: string, days: number) {
     0,
   );
 
-  const profile: OperatorProfile = {
+  const profile = {
     operatorId,
     lineIds,
     aggregateUptimeRatio:
@@ -3431,22 +3435,21 @@ export async function getStatisticsData() {
     .slice(0, 10)
     .map((issue) => issue.id);
 
-  const chartTotalIssueCountByLine: SystemAnalytics['chartTotalIssueCountByLine'] =
-    {
-      title: 'Issue Count by Line',
-      data: Object.values(dataset.included.lines).map((line) => {
-        const counts = lineCountsById[line.id] ?? createIssueTypeBreakdown();
-        return {
-          name: line.id,
-          payload: {
-            disruption: counts.disruption,
-            maintenance: counts.maintenance,
-            infra: counts.infra,
-            totalIssues: counts.totalIssues,
-          },
-        };
-      }),
-    };
+  const chartTotalIssueCountByLine = {
+    title: 'Issue Count by Line',
+    data: Object.values(dataset.included.lines).map((line) => {
+      const counts = lineCountsById[line.id] ?? createIssueTypeBreakdown();
+      return {
+        name: line.id,
+        payload: {
+          disruption: counts.disruption,
+          maintenance: counts.maintenance,
+          infra: counts.infra,
+          totalIssues: counts.totalIssues,
+        },
+      };
+    }),
+  };
 
   const stationIssueCounts = Object.values(dataset.included.stations).map(
     (station) => {
@@ -3472,19 +3475,17 @@ export async function getStatisticsData() {
         rollingYearEnd,
       );
 
-  const chartTotalIssueCountByStation: SystemAnalytics['chartTotalIssueCountByStation'] =
-    {
-      title: 'Issue Count by Station',
-      data: stationIssueCounts
-        .sort(
-          (a, b) =>
-            (b.payload.totalIssues as number) -
-            (a.payload.totalIssues as number),
-        )
-        .slice(0, 15),
-    };
+  const chartTotalIssueCountByStation = {
+    title: 'Issue Count by Station',
+    data: stationIssueCounts
+      .sort(
+        (a, b) =>
+          (b.payload.totalIssues as number) - (a.payload.totalIssues as number),
+      )
+      .slice(0, 15),
+  };
 
-  const chartRollingYearHeatmap: SystemAnalytics['chartRollingYearHeatmap'] = {
+  const chartRollingYearHeatmap = {
     title: 'Rolling Year Heatmap',
     data: Array.from({ length: 365 }, (_, index) => {
       const date = isoDate(rollingYearStart.plus({ days: index }));
@@ -3497,7 +3498,7 @@ export async function getStatisticsData() {
     }),
   };
 
-  const statistics: SystemAnalytics = {
+  const statistics = {
     timeScaleChartsIssueCount: hasStatisticsIssueFactCoverage
       ? buildIssueCountChartsFromIssueFacts(issueFactRows)
       : buildStatisticsIssueCountGraphs(issues),
@@ -3542,3 +3543,15 @@ export async function getSitemapData() {
       latest != null ? isoDate(latest.startOf('month')) : isoDate(nowSg()),
   };
 }
+
+export type LineBranch = Awaited<
+  ReturnType<typeof getLineProfileData>
+>['data']['branches'][number];
+
+export type OperatorProfile = Awaited<
+  ReturnType<typeof getOperatorProfileData>
+>['data'];
+
+export type SystemAnalytics = Awaited<
+  ReturnType<typeof getStatisticsData>
+>['data'];


### PR DESCRIPTION
## Summary

- Retire legacy translation adapter types and remove `nameTranslations` / `titleTranslations` from the app read model.
- Keep canonical translated `name` and `title` fields on entities, resolving display strings at the UI edge with `getLocalizedTranslation`.
- Shrink `app/types.ts` by removing old generated-client-style exported shapes and inferring query-specific profile/statistics types from loader functions.

## Impact

Consumers now treat entity `name` and issue `title` as canonical translation objects instead of parallel legacy display/translation fields. UI components localize those fields explicitly when rendering.

## Validation

- `npm run verify`