### PR TITLE
fix: service advisories operational badge count

### DIFF
--- a/app/components/CurrentAdvisoriesSection/helpers.test.ts
+++ b/app/components/CurrentAdvisoriesSection/helpers.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { countOperationalLinesOutsideCurrentAdvisories } from './helpers';
+
+describe('countOperationalLinesOutsideCurrentAdvisories', () => {
+  it('excludes normal lines that already appear in service advisories', () => {
+    expect(
+      countOperationalLinesOutsideCurrentAdvisories({
+        issuesActiveNow: [{ lineIds: ['NSL'] }],
+        issuesActiveToday: [{ lineIds: ['EWL'] }],
+        lineSummaries: [
+          { lineId: 'NSL', status: 'ongoing_disruption' },
+          { lineId: 'EWL', status: 'normal' },
+          { lineId: 'CCL', status: 'normal' },
+          { lineId: 'DTL', status: 'closed_for_day' },
+        ],
+      }),
+    ).toBe(1);
+  });
+
+  it('deduplicates advisories that touch the same line', () => {
+    expect(
+      countOperationalLinesOutsideCurrentAdvisories({
+        issuesActiveNow: [{ lineIds: ['NSL'] }],
+        issuesActiveToday: [{ lineIds: ['NSL', 'EWL'] }],
+        lineSummaries: [
+          { lineId: 'NSL', status: 'normal' },
+          { lineId: 'EWL', status: 'normal' },
+          { lineId: 'CCL', status: 'normal' },
+        ],
+      }),
+    ).toBe(1);
+  });
+});

--- a/app/components/CurrentAdvisoriesSection/helpers.ts
+++ b/app/components/CurrentAdvisoriesSection/helpers.ts
@@ -1,0 +1,26 @@
+import type { Issue, LineSummary } from '~/types';
+
+type AdvisoryIssue = Pick<Issue, 'lineIds'>;
+type AdvisoryLineSummary = Pick<LineSummary, 'lineId' | 'status'>;
+
+export function countOperationalLinesOutsideCurrentAdvisories({
+  issuesActiveNow,
+  issuesActiveToday,
+  lineSummaries,
+}: {
+  issuesActiveNow: AdvisoryIssue[];
+  issuesActiveToday: AdvisoryIssue[];
+  lineSummaries: AdvisoryLineSummary[];
+}) {
+  const advisoryLineIds = new Set(
+    [...issuesActiveNow, ...issuesActiveToday].flatMap(
+      (issue) => issue.lineIds,
+    ),
+  );
+
+  return lineSummaries.filter(
+    (lineSummary) =>
+      lineSummary.status === 'normal' &&
+      !advisoryLineIds.has(lineSummary.lineId),
+  ).length;
+}

--- a/app/routes/{-$lang}/index.tsx
+++ b/app/routes/{-$lang}/index.tsx
@@ -10,6 +10,7 @@ import { getDateCountForViewport } from '~/helpers/getDateCountForViewport';
 import { useViewport, ViewportSchema } from '~/hooks/useViewport';
 import { getOverviewFn } from '~/util/overview.functions';
 import { CurrentAdvisoriesSection } from '../../components/CurrentAdvisoriesSection';
+import { countOperationalLinesOutsideCurrentAdvisories } from '../../components/CurrentAdvisoriesSection/helpers';
 import { assert } from '../../util/assert';
 
 const SearchParamsSchema = z.object({
@@ -155,9 +156,12 @@ function HomePage() {
   }, [overview.issueIdsActiveToday, issues]);
 
   const lineOperationalCount = useMemo(() => {
-    return overview.lineSummaries.filter((line) => line.status === 'normal')
-      .length;
-  }, [overview.lineSummaries]);
+    return countOperationalLinesOutsideCurrentAdvisories({
+      issuesActiveNow,
+      issuesActiveToday,
+      lineSummaries: overview.lineSummaries,
+    });
+  }, [issuesActiveNow, issuesActiveToday, overview.lineSummaries]);
 
   return (
     <IncludedEntitiesContext.Provider value={included}>

--- a/app/routes/{-$lang}/system-map.tsx
+++ b/app/routes/{-$lang}/system-map.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import { createIntl, FormattedMessage, useIntl } from 'react-intl';
 import type { IssueAffectedBranch } from '~/types';
 import { CurrentAdvisoriesSection } from '~/components/CurrentAdvisoriesSection';
+import { countOperationalLinesOutsideCurrentAdvisories } from '~/components/CurrentAdvisoriesSection/helpers';
 import { StationMap } from '~/components/StationMap';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
 import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
@@ -79,9 +80,12 @@ function SystemMapPage() {
   }, [overview.issueIdsActiveToday, included.issues]);
 
   const lineOperationalCount = useMemo(() => {
-    return overview.lineSummaries.filter((line) => line.status === 'normal')
-      .length;
-  }, [overview.lineSummaries]);
+    return countOperationalLinesOutsideCurrentAdvisories({
+      issuesActiveNow,
+      issuesActiveToday,
+      lineSummaries: overview.lineSummaries,
+    });
+  }, [issuesActiveNow, issuesActiveToday, overview.lineSummaries]);
 
   const lines = useMemo(() => {
     return Object.values(included.lines);


### PR DESCRIPTION
## Summary
- Correct the Service Advisories operational badge so it only counts lines that are truly operational and not already covered by active or same-day advisories.
- Factor the count into a shared helper and use it on both the home page and system map.
- Add unit coverage for the double-count and deduplication cases.

## Testing
- `npm run verify` passed.
- Added Vitest coverage for the new operational-line count helper.