### PR TITLE
perf: reduce SSR data payload and issue scans

### DIFF
--- a/app/routes/{-$lang}.tsx
+++ b/app/routes/{-$lang}.tsx
@@ -50,14 +50,7 @@ function RouteComponent() {
   const { lang = 'en-SG' } = Route.useParams();
   const loaderData = Route.useLoaderData();
 
-  const {
-    messages,
-    lineIds,
-    included,
-    metadata,
-    operatorIds,
-    operatorsIncluded,
-  } = loaderData;
+  const { messages, lineNavItems, metadata, operatorNavItems } = loaderData;
 
   const isHydrated = useHydrated();
 
@@ -271,14 +264,12 @@ function RouteComponent() {
                   />
                 </h3>
                 <ul className="space-y-3">
-                  {lineIds.map((lineId) => {
-                    const line = included.lines[lineId];
-
+                  {lineNavItems.map((line) => {
                     return (
-                      <li key={lineId}>
+                      <li key={line.id}>
                         <Link
                           to="/{-$lang}/lines/$lineId"
-                          params={{ lineId }}
+                          params={{ lineId: line.id }}
                           className="flex items-center gap-x-1.5 text-sm transition-colors hover:text-accent-light"
                         >
                           <span
@@ -340,19 +331,15 @@ function RouteComponent() {
                     />
                   </h3>
                   <ul className="space-y-3">
-                    {operatorIds.map((operatorId) => {
-                      const operator = operatorsIncluded[operatorId];
-
+                    {operatorNavItems.map((operator) => {
                       return (
-                        <li key={operatorId}>
+                        <li key={operator.id}>
                           <Link
                             to="/{-$lang}/operators/$operatorId"
-                            params={{ operatorId }}
+                            params={{ operatorId: operator.id }}
                             className="flex text-sm transition-colors hover:text-accent-light"
                           >
-                            {operator != null
-                              ? getLocalizedTranslation(operator.name, lang)
-                              : operatorId}
+                            {getLocalizedTranslation(operator.name, lang)}
                           </Link>
                         </li>
                       );

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -3042,10 +3042,7 @@ export async function getOperatorProfileData(operatorId: string, days: number) {
   ) as Record<string, LineSummary>;
   const operatorLines = lineIds.map((lineId) => dataset.included.lines[lineId]);
   const operatorIssuesByLineId = Object.fromEntries(
-    lineIds.map((lineId) => [
-      lineId,
-      dataset.issuesByLineId[lineId] ?? [],
-    ]),
+    lineIds.map((lineId) => [lineId, dataset.issuesByLineId[lineId] ?? []]),
   ) as Record<string, IssueWithOperationalEffects[]>;
 
   const operatorIssues = Object.values(dataset.allIssues).filter((issue) =>

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -5,7 +5,7 @@ import {
   type Service as CoreService,
   type ServiceEffectKind,
 } from '@mrtdown/core';
-import { and, desc, eq, gte, inArray, lte, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, inArray, lte, sql } from 'drizzle-orm';
 import { DateTime } from 'luxon';
 import type {
   ChartEntry,
@@ -99,9 +99,10 @@ type BaseDataset = {
   metadata: Record<string, string>;
   publicHolidaySet: Set<string>;
   allIssues: Record<string, IssueWithOperationalEffects>;
+  issuesByLineId: Record<string, IssueWithOperationalEffects[]>;
 };
 
-const BASE_DATASET_CACHE_TTL_MS = 60_000;
+const BASE_DATASET_CACHE_TTL_MS = 5 * 60_000;
 const OPERATIONAL_FACTS_REBUILD_DAY_BATCH = 30;
 let cachedBaseDataset:
   | {
@@ -109,6 +110,7 @@ let cachedBaseDataset:
       value: BaseDataset;
     }
   | undefined;
+let pendingBaseDataset: Promise<BaseDataset> | undefined;
 const dateTimeCache = new Map<string, DateTime>();
 const issueBoundsCache = new WeakMap<Issue, IssueIntervalBounds[]>();
 
@@ -1470,6 +1472,8 @@ async function buildDataset(
     };
   }
 
+  const issuesByLineId = buildIssuesByLineId(Object.values(allIssues));
+
   return {
     included: {
       lines: linesById,
@@ -1483,6 +1487,7 @@ async function buildDataset(
     metadata,
     publicHolidaySet,
     allIssues,
+    issuesByLineId,
   };
 }
 
@@ -1499,12 +1504,19 @@ async function getBaseDataset() {
     return cachedBaseDataset.value;
   }
 
-  const dataset = await buildBaseDataset();
-  cachedBaseDataset = {
-    expiresAt: Date.now() + BASE_DATASET_CACHE_TTL_MS,
-    value: dataset,
-  };
-  return dataset;
+  pendingBaseDataset ??= buildBaseDataset()
+    .then((dataset) => {
+      cachedBaseDataset = {
+        expiresAt: Date.now() + BASE_DATASET_CACHE_TTL_MS,
+        value: dataset,
+      };
+      return dataset;
+    })
+    .finally(() => {
+      pendingBaseDataset = undefined;
+    });
+
+  return pendingBaseDataset;
 }
 
 async function getIncludedForIssueIds(issueIds: readonly string[]) {
@@ -2268,24 +2280,29 @@ function chunk<T>(items: T[], size: number) {
   return chunks;
 }
 
-function buildOperationalFactsRebuildContext(
-  dataset: BaseDataset,
-): OperationalFactsRebuildContext {
-  const issues = Object.values(dataset.allIssues);
+function buildIssuesByLineId(issues: Iterable<IssueWithOperationalEffects>) {
   const issuesByLineId: Record<string, IssueWithOperationalEffects[]> = {};
 
   for (const issue of issues) {
-    for (const lineId of issue.lineIds) {
+    for (const lineId of new Set(issue.lineIds)) {
       const lineIssues = issuesByLineId[lineId] ?? [];
       lineIssues.push(issue);
       issuesByLineId[lineId] = lineIssues;
     }
   }
 
+  return issuesByLineId;
+}
+
+function buildOperationalFactsRebuildContext(
+  dataset: BaseDataset,
+): OperationalFactsRebuildContext {
+  const issues = Object.values(dataset.allIssues);
+
   return {
     issues,
     lines: Object.values(dataset.included.lines),
-    issuesByLineId,
+    issuesByLineId: dataset.issuesByLineId,
   };
 }
 
@@ -2738,16 +2755,30 @@ export async function rebuildOperationalFactsRange(
 }
 
 export async function getRootData() {
-  const dataset = await getBaseDataset();
+  const db = await getDefaultDb();
+  const [lineRows, metadataRows, operatorRows] = await Promise.all([
+    db
+      .select({
+        id: linesTable.id,
+        name: linesTable.name,
+        color: linesTable.color,
+      })
+      .from(linesTable)
+      .orderBy(asc(linesTable.id)),
+    db.select().from(metadataTable).orderBy(asc(metadataTable.key)),
+    db
+      .select({
+        id: operatorsTable.id,
+        name: operatorsTable.name,
+      })
+      .from(operatorsTable)
+      .orderBy(asc(operatorsTable.id)),
+  ]);
+
   return {
-    lineIds: Object.keys(dataset.included.lines).sort(),
-    included: withIssues(dataset.included, dataset.allIssues, []),
-    metadata: Object.entries(dataset.metadata).map(([key, value]) => ({
-      key,
-      value,
-    })),
-    operatorIds: Object.keys(dataset.included.operators).sort(),
-    operatorsIncluded: dataset.included.operators,
+    lineNavItems: lineRows,
+    metadata: metadataRows,
+    operatorNavItems: operatorRows,
   };
 }
 
@@ -2756,9 +2787,7 @@ export async function getOverviewData(days: number) {
   const issues = Object.values(dataset.allIssues);
   const lineSummaries = rankLineSummaries(
     Object.values(dataset.included.lines).map((line) => {
-      const lineIssues = issues.filter((issue) =>
-        issue.lineIds.includes(line.id),
-      );
+      const lineIssues = dataset.issuesByLineId[line.id] ?? [];
       return buildLineSummary(line, lineIssues, days, dataset.publicHolidaySet);
     }),
   );
@@ -2809,9 +2838,7 @@ export async function getLineProfileData(lineId: string, days: number) {
 
   const allLineSummaries = rankLineSummaries(
     Object.values(dataset.included.lines).map((candidateLine) => {
-      const candidateIssues = Object.values(dataset.allIssues).filter((issue) =>
-        issue.lineIds.includes(candidateLine.id),
-      );
+      const candidateIssues = dataset.issuesByLineId[candidateLine.id] ?? [];
       return buildLineSummary(
         candidateLine,
         candidateIssues,
@@ -2821,9 +2848,7 @@ export async function getLineProfileData(lineId: string, days: number) {
     }),
   );
 
-  const lineIssues = Object.values(dataset.allIssues).filter((issue) =>
-    issue.lineIds.includes(lineId),
-  );
+  const lineIssues = dataset.issuesByLineId[lineId] ?? [];
   const rankedSummary = allLineSummaries.find(
     (summary) => summary.lineId === lineId,
   );
@@ -3003,13 +3028,12 @@ export async function getOperatorProfileData(operatorId: string, days: number) {
       line.operators.some((entry) => entry.operatorId === operatorId),
     )
     .map((line) => line.id);
+  const lineIdSet = new Set(lineIds);
 
   const lineSummaries = Object.fromEntries(
     lineIds.map((lineId) => {
       const line = dataset.included.lines[lineId];
-      const lineIssues = Object.values(dataset.allIssues).filter((issue) =>
-        issue.lineIds.includes(lineId),
-      );
+      const lineIssues = dataset.issuesByLineId[lineId] ?? [];
       return [
         lineId,
         buildLineSummary(line, lineIssues, days, dataset.publicHolidaySet),
@@ -3020,14 +3044,12 @@ export async function getOperatorProfileData(operatorId: string, days: number) {
   const operatorIssuesByLineId = Object.fromEntries(
     lineIds.map((lineId) => [
       lineId,
-      Object.values(dataset.allIssues).filter((issue) =>
-        issue.lineIds.includes(lineId),
-      ),
+      dataset.issuesByLineId[lineId] ?? [],
     ]),
   ) as Record<string, IssueWithOperationalEffects[]>;
 
   const operatorIssues = Object.values(dataset.allIssues).filter((issue) =>
-    issue.lineIds.some((lineId) => lineIds.includes(lineId)),
+    issue.lineIds.some((lineId) => lineIdSet.has(lineId)),
   );
 
   const totalStationsOperated = new Set(
@@ -3043,9 +3065,7 @@ export async function getOperatorProfileData(operatorId: string, days: number) {
       lineId,
       status: lineSummaries[lineId].status,
       uptimeRatio: lineSummaries[lineId].uptimeRatio,
-      issueCount: operatorIssues.filter((issue) =>
-        issue.lineIds.includes(lineId),
-      ).length,
+      issueCount: (operatorIssuesByLineId[lineId] ?? []).length,
     }),
   );
 

--- a/app/util/root.functions.ts
+++ b/app/util/root.functions.ts
@@ -10,17 +10,14 @@ export const getRootFn = createServerFn({ method: 'GET' })
   .inputValidator((val) => InputSchema.parse(val))
   .handler(async (val) => {
     const { lang } = val.data;
-    const { lineIds, included, metadata, operatorIds, operatorsIncluded } =
-      await getRootData();
+    const { lineNavItems, metadata, operatorNavItems } = await getRootData();
 
     const { default: messages } = await import(`../../lang/${lang}.json`);
 
     return {
-      lineIds,
-      included,
+      lineNavItems,
       metadata,
-      operatorIds,
-      operatorsIncluded,
+      operatorNavItems,
       messages,
     };
   });

--- a/docs/SLOWNESS_INVESTIGATION.md
+++ b/docs/SLOWNESS_INVESTIGATION.md
@@ -1,0 +1,118 @@
+# Site Slowness Investigation (2026-05-21)
+
+## Scope
+
+Investigated likely causes of runtime slowness by reviewing route loaders and server data assembly paths, then confirmed the production behavior with live checks from Singapore on 2026-05-21.
+
+## Key Findings
+
+### 1) Root layout loader fetches large shared data on every page load/navigation
+
+`/{-$lang}` route loader always calls `getRootFn`, which in turn always calls `getRootData`. This happens for the root layout that wraps all child pages.
+
+`getRootData` returns:
+- all line IDs,
+- full `included` entity payload,
+- metadata,
+- all operator IDs,
+- full operators payload.
+
+Even though it excludes issues (`withIssues(..., [])`), the included payload still carries full lines/stations/towns/landmarks dictionaries and is likely large.
+
+Potential impact:
+- higher TTFB for cold/expired cache requests,
+- larger serialized SSR/dehydration payload to send to clients,
+- extra parse/hydration cost on the client.
+
+### 2) Base dataset construction is expensive and cache TTL is short (60s)
+
+`getBaseDataset` builds the complete dataset via `buildBaseDataset/buildDataset` when cache is empty/expired. Cache TTL is only 60 seconds and process-local.
+
+Potential impact:
+- frequent dataset rebuilds under moderate traffic,
+- repeated expensive in-memory processing for many pages,
+- worse behavior on multi-instance/serverless deployments where caches are not shared.
+
+### 3) Overview computation repeatedly scans issues per line (O(lines × issues))
+
+In `getOverviewData`, line summaries are built by iterating all lines and filtering all issues per line (`issues.filter(...)`).
+
+Potential impact:
+- CPU-heavy request path, especially when issue history grows,
+- increased latency for the home page and endpoints using overview data.
+
+### 4) The repository itself flags large generated artifacts
+
+`AGENTS.md` explicitly calls out large generated station map snapshots under `app/components/StationMap/components/Map*.tsx`.
+
+Potential impact:
+- route-specific bundle bloat (especially system map route),
+- slower first load and parse/execute time when those modules are pulled.
+
+## Production reachability check from this environment
+
+Initial attempts to benchmark production endpoints from the earlier execution environment were blocked:
+
+- `curl -L -w ... https://mrtdown.org/` -> HTTP code `000` / curl exit `56`
+- `curl -Iv https://mrtdown.org/` -> proxy tunnel `403 Forbidden`
+
+Running locally later on 2026-05-21, direct production checks succeeded. The bare domain redirects to `https://www.mrtdown.org/`.
+
+## Live production timing check
+
+Measured with `curl -L --compressed` from Singapore.
+
+| Route | TTFB samples | Downloaded size |
+| --- | ---: | ---: |
+| `/` | 2.39s, 2.89s, 4.91s | ~134 KB compressed |
+| `/statistics` | 8.26s, 10.31s, 11.86s; later 14.13s | ~135 KB compressed |
+| `/lines/BPLRT` | 2.14s, 3.00s, 3.83s; later 5.50s | ~75-129 KB compressed |
+| `/history` | 0.56s, 1.40s, 1.87s | ~75 KB compressed |
+| `/system-map` | 0.56s, 0.65s, 2.55s | ~98-153 KB compressed |
+| `/about` | usually 0.13s-0.19s; one capture at 1.54s | ~64 KB compressed |
+| JS/CSS assets | 0.05s-0.20s | Cloudflare HIT |
+
+Key observations:
+
+- HTML responses have no `cf-cache-status` header and no useful `cache-control` header in the sampled responses. They appear to be rendered at origin on every request.
+- Static JS/CSS assets are fast and served from Cloudflare cache, so CDN/static asset delivery is not the main bottleneck.
+- TTFB accounts for almost the whole request time, which points to server render/data work before first byte rather than slow response transfer.
+- The root page HTML decodes to ~833 KB, including ~590 KB of inline TanStack router hydration data.
+- `/statistics` decodes to ~756 KB, including ~573 KB of inline hydration data.
+- `/lines/BPLRT` decodes to ~617 KB, including ~570 KB of inline hydration data.
+
+Conclusion: the live check confirms the code-level hypothesis. The production app is serializing a large shared data payload into SSR pages, and route loaders, especially `/statistics`, are doing expensive work per request.
+
+## Recommended next actions
+
+1. **Split root loader payload by actual UI need**
+   - Keep root data minimal (only nav and metadata needed globally).
+   - Move heavy data fetching to route-level loaders where needed.
+   - Consider returning denormalized lightweight nav models instead of full entity dictionaries.
+
+2. **Increase or redesign base dataset caching**
+   - Raise TTL above 60s for read-mostly data, or
+   - introduce stale-while-revalidate strategy, or
+   - precompute and persist a read model snapshot.
+
+3. **Pre-index issues by line once per request/cached dataset**
+   - Build `issuesByLineId` once and reuse across summary builders.
+   - Avoid per-line filtering over full issue list.
+
+4. **Confirm client bundle hotspots with build analysis**
+   - Run bundle analyzer to quantify map chunk sizes.
+   - Ensure map-heavy code is route-split and lazy-loaded.
+
+5. **Collect real-user and server metrics in production**
+   - Add server timing around `getBaseDataset`, `getRootData`, and `getOverviewData`.
+   - Track payload size of root loader response.
+   - Capture Web Vitals (LCP/INP/CLS) segmented by route.
+
+6. **Add CDN/origin caching for public SSR HTML**
+   - Add short `s-maxage` plus `stale-while-revalidate` for cacheable public pages.
+   - Keep static assets on long-lived hashed URLs.
+   - Verify that pages with request-specific behavior are either excluded or vary correctly.
+
+7. **Precompute expensive route data**
+   - Precompute `/statistics` data or serve it from a static artifact/cache instead of recomputing on request.
+   - Split line-page data so each line route serializes only the selected line plus required related entities.


### PR DESCRIPTION
## Summary

- shrink the root layout loader to direct DB reads for footer nav and metadata instead of serializing the full dataset
- cache an issues-by-line index in the base dataset and reuse it in overview, line, operator, and operational fact summary paths
- extend and dedupe base dataset cache rebuilds to reduce repeated cold-request work
- add the site slowness investigation notes that motivated the changes

## Validation

- `npm run verify`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized navigation data loading to use pre-computed indexes, reducing redundant operations.
  * Extended cache duration for improved performance during repeated requests.

* **Documentation**
  * Added investigation report documenting production performance findings and recommended optimizations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-site/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->