### PR TITLE
fix: add home viewport skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ populated from data archives.
 - `npm run deploy`: build and deploy with Wrangler.
 - `npm run typecheck`: run TypeScript without emitting files.
 - `npm run lint`: run Biome linting.
-- `npm run format:check`: check formatting for files changed since
-  `origin/main`.
+- `npm run format:check`: check formatting across the repository.
 - `npm run test:run`: run Vitest once.
 - `npm run verify`: run typecheck, lint, formatting check, migration drift
   check, and tests.

--- a/app/routes/{-$lang}/index.tsx
+++ b/app/routes/{-$lang}/index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, notFound } from '@tanstack/react-router';
+import classNames from 'classnames';
 import { DateTime } from 'luxon';
 import { useEffect, useMemo } from 'react';
 import { createIntl, FormattedMessage } from 'react-intl';
@@ -19,6 +20,9 @@ const SearchParamsSchema = z.object({
 
 export const Route = createFileRoute('/{-$lang}/')({
   component: HomePage,
+  pendingComponent: HomePagePending,
+  pendingMs: 0,
+  pendingMinMs: 0,
 
   validateSearch: SearchParamsSchema,
   loaderDeps({ search }) {
@@ -123,6 +127,23 @@ function HomePage() {
   const navigate = Route.useNavigate();
 
   const measuredViewport = useViewport();
+  const measuredDateCount = useMemo(
+    () => getDateCountForViewport(measuredViewport),
+    [measuredViewport],
+  );
+  const measuredDateKeys = useMemo(() => {
+    const dateRangeEnd = DateTime.now()
+      .startOf('hour')
+      .setZone('Asia/Singapore');
+    return Array.from({ length: measuredDateCount }, (_, daysAgo) => {
+      return (
+        dateRangeEnd
+          .minus({ days: measuredDateCount - daysAgo - 1 })
+          .toISODate() ?? `date-${daysAgo}`
+      );
+    });
+  }, [measuredDateCount]);
+  const isLineSummaryViewportPending = dateCount !== measuredDateCount;
 
   useEffect(() => {
     if (viewport === measuredViewport) {
@@ -187,17 +208,26 @@ function HomePage() {
           lineOperationalCount={lineOperationalCount}
         />
 
-        <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
-          <div className="flex flex-col gap-y-4 px-2 py-2 sm:gap-y-6 sm:px-3 sm:py-4">
-            {overview.lineSummaries.map((lineSummary) => (
-              <LineSummaryBlock
-                key={lineSummary.lineId}
-                data={lineSummary}
-                dateTimes={dateTimes}
-              />
-            ))}
+        {isLineSummaryViewportPending ? (
+          <HomeLineSummariesSkeleton
+            dateKeys={measuredDateKeys}
+            lineIds={overview.lineSummaries.map((lineSummary) => {
+              return lineSummary.lineId;
+            })}
+          />
+        ) : (
+          <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
+            <div className="flex flex-col gap-y-4 px-2 py-2 sm:gap-y-6 sm:px-3 sm:py-4">
+              {overview.lineSummaries.map((lineSummary) => (
+                <LineSummaryBlock
+                  key={lineSummary.lineId}
+                  data={lineSummary}
+                  dateTimes={dateTimes}
+                />
+              ))}
+            </div>
           </div>
-        </div>
+        )}
 
         <div className="rounded-2xl border border-gray-200 bg-gray-50 p-6 dark:border-gray-700 dark:bg-gray-800/50">
           <h3 className="mb-4 text-center font-semibold text-gray-700 text-sm dark:text-gray-300">
@@ -260,3 +290,123 @@ function HomePage() {
     </IncludedEntitiesContext.Provider>
   );
 }
+
+function HomePagePending() {
+  return (
+    <div className="flex flex-col space-y-6 sm:space-y-8">
+      <header className="flex flex-col items-center space-y-2 text-center">
+        <div className="h-9 w-72 max-w-full animate-pulse rounded-md bg-gray-200 dark:bg-gray-800" />
+        <div className="h-6 w-80 max-w-full animate-pulse rounded-md bg-gray-200 dark:bg-gray-800" />
+      </header>
+
+      <div className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <div className="mb-4 h-6 w-44 animate-pulse rounded-md bg-gray-200 dark:bg-gray-700" />
+        <div className="flex flex-col gap-4 md:flex-row md:items-center">
+          <div className="h-12 grow animate-pulse rounded-lg bg-gray-100 dark:bg-gray-700" />
+          <div className="h-10 w-36 animate-pulse rounded-xl bg-gray-200 dark:bg-gray-700" />
+        </div>
+      </div>
+
+      <HomeLineSummariesSkeleton lineIds={PENDING_LINE_IDS} />
+
+      <div className="rounded-2xl border border-gray-200 bg-gray-50 p-6 dark:border-gray-700 dark:bg-gray-800/50">
+        <div className="mx-auto mb-4 h-5 w-36 animate-pulse rounded-md bg-gray-200 dark:bg-gray-700" />
+        <div className="flex flex-wrap justify-center gap-x-6 gap-y-3">
+          {PENDING_LEGEND_IDS.map((legendId) => (
+            <div className="inline-flex items-center gap-x-2" key={legendId}>
+              <div className="size-3 animate-pulse rounded-full bg-gray-300 dark:bg-gray-700" />
+              <div className="h-4 w-24 animate-pulse rounded-sm bg-gray-200 dark:bg-gray-700" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface HomeLineSummariesSkeletonProps {
+  dateKeys?: string[];
+  lineIds: string[];
+}
+
+function HomeLineSummariesSkeleton(props: HomeLineSummariesSkeletonProps) {
+  const { dateKeys, lineIds } = props;
+  const skeletonLineIds =
+    lineIds.length > 0 ? lineIds : ['line-summary-skeleton'];
+
+  return (
+    <div
+      aria-busy="true"
+      className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800"
+    >
+      <span className="sr-only">Loading service status</span>
+      <div className="flex flex-col gap-y-4 px-2 py-2 sm:gap-y-6 sm:px-3 sm:py-4">
+        {skeletonLineIds.map((lineId) => (
+          <div
+            className="flex animate-pulse flex-col rounded-lg bg-gray-100 px-4 py-2 dark:bg-gray-800"
+            key={lineId}
+          >
+            <div className="mb-1.5 flex items-center">
+              <div className="h-5 w-12 rounded-sm bg-gray-300 dark:bg-gray-700" />
+              <div className="ms-1.5 h-4 w-36 rounded-sm bg-gray-300 dark:bg-gray-700" />
+              <div className="ms-auto h-4 w-20 rounded-sm bg-gray-300 dark:bg-gray-700" />
+            </div>
+
+            <div className="flex items-center justify-between gap-x-1">
+              <HomeSkeletonDateBars dateKeys={dateKeys} />
+            </div>
+
+            <div className="mt-1.5 flex items-center justify-between gap-x-1">
+              <div className="h-3 w-20 rounded-sm bg-gray-300 dark:bg-gray-700" />
+              <div className="h-3 w-24 rounded-sm bg-gray-300 dark:bg-gray-700" />
+              <div className="h-3 w-14 rounded-sm bg-gray-300 dark:bg-gray-700" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface HomeSkeletonDateBarsProps {
+  dateKeys?: string[];
+}
+
+function HomeSkeletonDateBars(props: HomeSkeletonDateBarsProps) {
+  const { dateKeys } = props;
+
+  if (dateKeys != null) {
+    return dateKeys.map((dateKey) => (
+      <div
+        className="h-7 w-1.5 shrink-0 rounded-xs bg-gray-300 dark:bg-gray-700"
+        key={dateKey}
+      />
+    ));
+  }
+
+  return PENDING_DATE_BAR_IDS.map((barId, index) => (
+    <div
+      className={classNames(
+        'h-7 w-1.5 shrink-0 rounded-xs bg-gray-300 dark:bg-gray-700',
+        {
+          'hidden sm:block': index >= 30 && index < 60,
+          'hidden lg:block': index >= 60,
+        },
+      )}
+      key={barId}
+    />
+  ));
+}
+
+const PENDING_LINE_IDS = ['skeleton-line-1', 'skeleton-line-2'];
+const PENDING_LEGEND_IDS = [
+  'operational',
+  'disruption',
+  'maintenance',
+  'infrastructure',
+  'closed',
+];
+const PENDING_DATE_BAR_IDS = Array.from(
+  { length: 90 },
+  (_, index) => `date-bar-${index}`,
+);

--- a/app/routes/{-$lang}/operators/$operatorId/components/OperatorUptimeCard.tsx
+++ b/app/routes/{-$lang}/operators/$operatorId/components/OperatorUptimeCard.tsx
@@ -46,4 +46,3 @@ export const OperatorUptimeCard: React.FC<Props> = (props) => {
     </div>
   );
 };
-

--- a/app/util/sitemap.functions.ts
+++ b/app/util/sitemap.functions.ts
@@ -54,8 +54,14 @@ function buildEntries(path: string, rootUrl: string): Element {
 
 export const getSitemapFn = createServerFn({ method: 'GET' }).handler(
   async () => {
-    const { lineIds, stationIds, operatorIds, issueIds, monthEarliest, monthLatest } =
-      await getSitemapData();
+    const {
+      lineIds,
+      stationIds,
+      operatorIds,
+      issueIds,
+      monthEarliest,
+      monthLatest,
+    } = await getSitemapData();
     const paths: string[] = [
       '/',
       '/history',

--- a/app/util/statistics.functions.ts
+++ b/app/util/statistics.functions.ts
@@ -1,6 +1,6 @@
 import { createServerFn } from '@tanstack/react-start';
 import { getStatisticsData } from './db.queries';
 
-export const getStatisticsFn = createServerFn({ method: 'GET' }).handler(
-  () => getStatisticsData(),
+export const getStatisticsFn = createServerFn({ method: 'GET' }).handler(() =>
+  getStatisticsData(),
 );

--- a/biome.json
+++ b/biome.json
@@ -14,6 +14,8 @@
       "!app/components/StationMap/components/Map*.tsx",
       "!app/index.css",
       "!dist/**",
+      "!drizzle/**",
+      "!lang/en-SG.json",
       "!node_modules/**",
       "!worker-configuration.d.ts",
       "!.wrangler/**",

--- a/docs/GENERATED_FILES.md
+++ b/docs/GENERATED_FILES.md
@@ -15,6 +15,12 @@ Several large files are generated or mechanically produced and should not be han
 - Script: `npm run db:generate`
 - Check: `npm run db:generate:check`
 
+## Extracted Message Catalog
+
+- Path: `lang/en-SG.json`
+- Source: FormatJS extraction
+- Script: `npm run i18n:extract`
+
 ## Station Map Snapshots
 
 - Path: `app/components/StationMap/components/Map*.tsx`

--- a/docs/QUALITY.md
+++ b/docs/QUALITY.md
@@ -10,7 +10,9 @@ The default verification script currently runs:
 - `npm run db:generate:check`
 - `npm run test:run`
 
-`npm run format:check` uses Biome's non-writing check mode over files changed since `origin/main`, avoiding unrelated formatting churn while the overhaul stack is still being cleaned up. Empty changed-file sets are accepted so GitHub's pull request merge checkout does not fail spuriously.
+`npm run format:check` uses Biome's non-writing check mode across the repository. This keeps local verification aligned with CI and catches uncommitted formatting issues before a branch is pushed.
+
+Generated files listed in `docs/GENERATED_FILES.md` are excluded from normal Biome checks in `biome.json`.
 
 `npm run verify:strict` currently mirrors the default verification script so existing references continue to work during the overhaul.
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:run": "vitest --run",
     "typecheck": "tsc --noEmit",
     "lint": "biome lint .",
-    "format:check": "biome format --changed --since=origin/main --no-errors-on-unmatched .",
+    "format:check": "biome format .",
     "verify": "npm run typecheck && npm run lint && npm run format:check && npm run db:generate:check && npm run test:run",
     "verify:strict": "npm run typecheck && npm run lint && npm run format:check && npm run db:generate:check && npm run test:run",
     "dev:pull": "curl -i -X POST http://localhost:3000/internal/api/tasks/pull",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,9 +11,9 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2024",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2024" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    "jsx": "react-jsx",                                /* Specify what JSX code is generated. */
+    "jsx": "react-jsx" /* Specify what JSX code is generated. */,
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
     // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
@@ -25,16 +25,18 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "es2022",                                /* Specify what module code is generated. */
+    "module": "es2022" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "bundler",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "bundler" /* Specify how TypeScript looks up a file from a given module specifier. */,
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     "paths": {
       "~/*": ["./app/*"]
-    },                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    } /* Specify a set of entries that re-map imports to additional lookup locations. */,
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    "types": ["node"],                                      /* Specify type package names to be included without being referenced in a source file. */
+    "types": [
+      "node"
+    ] /* Specify type package names to be included without being referenced in a source file. */,
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
@@ -56,11 +58,11 @@
     // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    "sourceMap": true /* Create source map files for emitted JavaScript files. */,
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
     // "removeComments": true,                           /* Disable emitting comments. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
@@ -80,12 +82,12 @@
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
     // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
 
     /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
+    "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
@@ -108,6 +110,6 @@
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
   }
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,130 +1,124 @@
 {
-    "$schema": "node_modules/wrangler/config-schema.json",
-    "name": "mrtdown-site",
-    "main": "app/server.ts",
-    "compatibility_date": "2026-04-08",
-    "compatibility_flags": [
-        "nodejs_compat"
-    ],
-    "observability": {
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "mrtdown-site",
+  "main": "app/server.ts",
+  "compatibility_date": "2026-04-08",
+  "compatibility_flags": ["nodejs_compat"],
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1,
+    "traces": {
+      "enabled": true,
+      "head_sampling_rate": 1
+    }
+  },
+  "limits": {
+    "cpu_ms": 300000
+  },
+  "hyperdrive": [
+    {
+      "binding": "HYPERDRIVE",
+      "id": "e9034596011b46179c4c7f65c2ebc773",
+      "localConnectionString": "postgresql://postgres:postgres@localhost:5432/mrtdown-db"
+    }
+  ],
+  "workflows": [
+    {
+      "binding": "PULL_WORKFLOW",
+      "name": "mrtdown-pull-preview",
+      "class_name": "PullWorkflow"
+    }
+  ],
+  "version_metadata": {
+    "binding": "CF_VERSION_METADATA"
+  },
+  "env": {
+    "preview": {
+      "workflows": [
+        {
+          "binding": "PULL_WORKFLOW",
+          "name": "mrtdown-pull-preview",
+          "class_name": "PullWorkflow"
+        }
+      ],
+      "hyperdrive": [
+        {
+          "binding": "HYPERDRIVE",
+          "id": "e9034596011b46179c4c7f65c2ebc773"
+        }
+      ],
+      "observability": {
         "enabled": true,
         "head_sampling_rate": 1,
         "traces": {
-            "enabled": true,
-            "head_sampling_rate": 1
+          "enabled": true,
+          "head_sampling_rate": 1
         }
+      },
+      "version_metadata": {
+        "binding": "CF_VERSION_METADATA"
+      }
     },
-    "limits": {
+    "staging": {
+      "triggers": {
+        "crons": ["0 * * * *"]
+      },
+      "workflows": [
+        {
+          "binding": "PULL_WORKFLOW",
+          "name": "mrtdown-pull-staging",
+          "class_name": "PullWorkflow"
+        }
+      ],
+      "hyperdrive": [
+        {
+          "binding": "HYPERDRIVE",
+          "id": "1413ff84b6ef40a19973b1bc8a662736"
+        }
+      ],
+      "observability": {
+        "enabled": true,
+        "head_sampling_rate": 1,
+        "traces": {
+          "enabled": true,
+          "head_sampling_rate": 1
+        }
+      },
+      "version_metadata": {
+        "binding": "CF_VERSION_METADATA"
+      }
+    },
+    "production": {
+      "triggers": {
+        "crons": ["*/30 * * * *"]
+      },
+      "observability": {
+        "enabled": true,
+        "head_sampling_rate": 0.1,
+        "traces": {
+          "enabled": true,
+          "head_sampling_rate": 0.1
+        }
+      },
+      "limits": {
         "cpu_ms": 300000
-    },
-    "hyperdrive": [
+      },
+      "hyperdrive": [
         {
-            "binding": "HYPERDRIVE",
-            "id": "e9034596011b46179c4c7f65c2ebc773",
-            "localConnectionString": "postgresql://postgres:postgres@localhost:5432/mrtdown-db"
+          "binding": "HYPERDRIVE",
+          "id": "1d9561e9411649a6afe8612881ff926d"
         }
-    ],
-    "workflows": [
+      ],
+      "workflows": [
         {
-            "binding": "PULL_WORKFLOW",
-            "name": "mrtdown-pull-preview",
-            "class_name": "PullWorkflow"
+          "binding": "PULL_WORKFLOW",
+          "name": "mrtdown-pull-production",
+          "class_name": "PullWorkflow"
         }
-    ],
-    "version_metadata": {
-      "binding": "CF_VERSION_METADATA"
-    },
-    "env": {
-        "preview": {
-            "workflows": [
-                {
-                    "binding": "PULL_WORKFLOW",
-                    "name": "mrtdown-pull-preview",
-                    "class_name": "PullWorkflow"
-                }
-            ],
-            "hyperdrive": [
-                {
-                    "binding": "HYPERDRIVE",
-                    "id": "e9034596011b46179c4c7f65c2ebc773"
-                }
-            ],
-            "observability": {
-                "enabled": true,
-                "head_sampling_rate": 1,
-                "traces": {
-                    "enabled": true,
-                    "head_sampling_rate": 1
-                }
-            },
-            "version_metadata": {
-              "binding": "CF_VERSION_METADATA"
-            },
-        },
-        "staging": {
-            "triggers": {
-                "crons": [
-                    "0 * * * *"
-                ]
-            },
-            "workflows": [
-                {
-                    "binding": "PULL_WORKFLOW",
-                    "name": "mrtdown-pull-staging",
-                    "class_name": "PullWorkflow"
-                }
-            ],
-            "hyperdrive": [
-                {
-                    "binding": "HYPERDRIVE",
-                    "id": "1413ff84b6ef40a19973b1bc8a662736"
-                }
-            ],
-            "observability": {
-                "enabled": true,
-                "head_sampling_rate": 1,
-                "traces": {
-                    "enabled": true,
-                    "head_sampling_rate": 1
-                }
-            },
-            "version_metadata": {
-              "binding": "CF_VERSION_METADATA"
-            },
-        },
-        "production": {
-            "triggers": {
-                "crons": [
-                    "*/30 * * * *"
-                ]
-            },
-            "observability": {
-                "enabled": true,
-                "head_sampling_rate": 0.1,
-                "traces": {
-                    "enabled": true,
-                    "head_sampling_rate": 0.1
-                }
-            },
-            "limits": {
-                "cpu_ms": 300000
-            },
-            "hyperdrive": [
-                {
-                    "binding": "HYPERDRIVE",
-                    "id": "1d9561e9411649a6afe8612881ff926d"
-                }
-            ],
-            "workflows": [
-                {
-                    "binding": "PULL_WORKFLOW",
-                    "name": "mrtdown-pull-production",
-                    "class_name": "PullWorkflow"
-                }
-            ],
-            "version_metadata": {
-              "binding": "CF_VERSION_METADATA"
-            },
-        }
+      ],
+      "version_metadata": {
+        "binding": "CF_VERSION_METADATA"
+      }
     }
+  }
 }


### PR DESCRIPTION
## Summary

Adds a home-page skeleton for the viewport detection reload path so large viewports do not briefly show an empty main area while the `viewport` search param changes from the server default to the measured client value.

## What Changed

- Added an immediate TanStack Router `pendingComponent` for the home route.
- Added route-level pending timing so the skeleton renders without the default pending delay.
- Added a line-summary skeleton for the already-mounted route case where loaded date counts do not yet match the measured viewport.
- Kept the skeleton responsive so it approximates the 30/60/90-day line summary widths.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run verify`

Note: full verification was run outside the sandbox because the Drizzle migration check uses `tsx` IPC, which the sandbox blocked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Home page now displays skeleton loading placeholders for line summaries while content is being fetched.

* **Documentation**
  * Updated project documentation covering code quality verification processes and generated file management.

* **Chores**
  * Updated code formatting verification scripts to check the entire repository and adjusted configuration files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-site/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->