### PR TITLE
fix: Render future_service line summaries last in overview

### DIFF
--- a/app/routes/{-$lang}/helpers/sortLineSummaries.test.ts
+++ b/app/routes/{-$lang}/helpers/sortLineSummaries.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import type { LineSummary } from '~/types';
+import { sortLineSummariesWithFutureServiceLast } from './sortLineSummaries';
+
+const lineSummary = (
+  lineId: string,
+  status: LineSummary['status'],
+): LineSummary => {
+  return {
+    lineId,
+    status,
+    durationSecondsByIssueType: {},
+    durationSecondsTotalForIssues: 0,
+    breakdownByDates: {},
+    uptimeRatio: 1,
+    totalServiceSeconds: 0,
+    totalDowntimeSeconds: 0,
+    downtimeBreakdown: [],
+    uptimeRank: null,
+    totalLines: null,
+  };
+};
+
+describe('sortLineSummariesWithFutureServiceLast', () => {
+  it('moves future service entries to the end', () => {
+    const input: LineSummary[] = [
+      lineSummary('A', 'future_service'),
+      lineSummary('B', 'normal'),
+      lineSummary('C', 'ongoing_maintenance'),
+      lineSummary('D', 'future_service'),
+      lineSummary('E', 'ongoing_disruption'),
+    ];
+
+    const sorted = sortLineSummariesWithFutureServiceLast(input);
+
+    expect(sorted.map((summary) => summary.lineId)).toEqual([
+      'B',
+      'C',
+      'E',
+      'A',
+      'D',
+    ]);
+  });
+
+  it('does not mutate the input array', () => {
+    const input: LineSummary[] = [
+      lineSummary('A', 'future_service'),
+      lineSummary('B', 'normal'),
+    ];
+
+    sortLineSummariesWithFutureServiceLast(input);
+
+    expect(input.map((summary) => summary.lineId)).toEqual(['A', 'B']);
+  });
+});

--- a/app/routes/{-$lang}/helpers/sortLineSummaries.ts
+++ b/app/routes/{-$lang}/helpers/sortLineSummaries.ts
@@ -1,0 +1,18 @@
+import type { LineSummary } from '~/types';
+
+export function sortLineSummariesWithFutureServiceLast(
+  lineSummaries: LineSummary[],
+): LineSummary[] {
+  return [...lineSummaries].sort((first, second) => {
+    if (first.status === second.status) {
+      return 0;
+    }
+    if (first.status === 'future_service') {
+      return 1;
+    }
+    if (second.status === 'future_service') {
+      return -1;
+    }
+    return 0;
+  });
+}

--- a/app/routes/{-$lang}/index.tsx
+++ b/app/routes/{-$lang}/index.tsx
@@ -10,6 +10,7 @@ import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
 import { getDateCountForViewport } from '~/helpers/getDateCountForViewport';
 import { useViewport, ViewportSchema } from '~/hooks/useViewport';
 import { getOverviewFn } from '~/util/overview.functions';
+import { sortLineSummariesWithFutureServiceLast } from './helpers/sortLineSummaries';
 import { CurrentAdvisoriesSection } from '../../components/CurrentAdvisoriesSection';
 import { countOperationalLinesOutsideCurrentAdvisories } from '../../components/CurrentAdvisoriesSection/helpers';
 import { assert } from '../../util/assert';
@@ -184,6 +185,10 @@ function HomePage() {
     });
   }, [issuesActiveNow, issuesActiveToday, overview.lineSummaries]);
 
+  const sortedLineSummaries = useMemo(() => {
+    return sortLineSummariesWithFutureServiceLast(overview.lineSummaries);
+  }, [overview.lineSummaries]);
+
   return (
     <IncludedEntitiesContext.Provider value={included}>
       <div className="flex flex-col space-y-6 sm:space-y-8">
@@ -211,14 +216,14 @@ function HomePage() {
         {isLineSummaryViewportPending ? (
           <HomeLineSummariesSkeleton
             dateKeys={measuredDateKeys}
-            lineIds={overview.lineSummaries.map((lineSummary) => {
+            lineIds={sortedLineSummaries.map((lineSummary) => {
               return lineSummary.lineId;
             })}
           />
         ) : (
           <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
             <div className="flex flex-col gap-y-4 px-2 py-2 sm:gap-y-6 sm:px-3 sm:py-4">
-              {overview.lineSummaries.map((lineSummary) => (
+              {sortedLineSummaries.map((lineSummary) => (
                 <LineSummaryBlock
                   key={lineSummary.lineId}
                   data={lineSummary}


### PR DESCRIPTION
### Motivation
- Ensure lines with `status: 'future_service'` are rendered at the end of the line summaries list so upcoming services don't interrupt active/operational ordering.
- Avoid mutating the original `overview.lineSummaries` array when reordering for presentation.

### Description
- Add `sortLineSummariesWithFutureServiceLast` in `app/routes/{-$lang}/helpers/sortLineSummaries.ts` which returns a new array with `'future_service'` entries moved to the end.
- Add unit tests in `app/routes/{-$lang}/helpers/sortLineSummaries.test.ts` that verify ordering and non-mutation of the input array.
- Update the home route `app/routes/{-$lang}/index.tsx` to import `sortLineSummariesWithFutureServiceLast` and use `sortedLineSummaries` for the skeleton `lineIds` and the rendered `LineSummaryBlock` list.

### Testing
- Run unit tests for the sorter with `vitest`, covering `moves future service entries to the end`, which passed.
- Run unit tests for the sorter with `vitest`, covering `does not mutate the input array`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f92cababc8320841cc78a602f1151)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Line summaries are now sorted with future service items displayed last.

* **Tests**
  * Added test coverage for line summary sorting functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-site/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->