### PR TITLE
fix: align operational line count

### DIFF
--- a/app/components/CurrentAdvisoriesSection/helpers.test.ts
+++ b/app/components/CurrentAdvisoriesSection/helpers.test.ts
@@ -1,12 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { countOperationalLinesOutsideCurrentAdvisories } from './helpers';
+import { countOperationalLineSummaries } from './helpers';
 
-describe('countOperationalLinesOutsideCurrentAdvisories', () => {
-  it('excludes normal lines that already appear in service advisories', () => {
+describe('countOperationalLineSummaries', () => {
+  it('counts normal line summaries as operational', () => {
     expect(
-      countOperationalLinesOutsideCurrentAdvisories({
-        issuesActiveNow: [{ lineIds: ['NSL'] }],
-        issuesActiveToday: [{ lineIds: ['EWL'] }],
+      countOperationalLineSummaries({
         lineSummaries: [
           { lineId: 'NSL', status: 'ongoing_disruption' },
           { lineId: 'EWL', status: 'normal' },
@@ -14,18 +12,17 @@ describe('countOperationalLinesOutsideCurrentAdvisories', () => {
           { lineId: 'DTL', status: 'closed_for_day' },
         ],
       }),
-    ).toBe(1);
+    ).toBe(2);
   });
 
-  it('deduplicates advisories that touch the same line', () => {
+  it('does not count closed or future lines as operational', () => {
     expect(
-      countOperationalLinesOutsideCurrentAdvisories({
-        issuesActiveNow: [{ lineIds: ['NSL'] }],
-        issuesActiveToday: [{ lineIds: ['NSL', 'EWL'] }],
+      countOperationalLineSummaries({
         lineSummaries: [
           { lineId: 'NSL', status: 'normal' },
-          { lineId: 'EWL', status: 'normal' },
-          { lineId: 'CCL', status: 'normal' },
+          { lineId: 'EWL', status: 'closed_for_day' },
+          { lineId: 'CCL', status: 'future_service' },
+          { lineId: 'DTL', status: 'ongoing_maintenance' },
         ],
       }),
     ).toBe(1);

--- a/app/components/CurrentAdvisoriesSection/helpers.ts
+++ b/app/components/CurrentAdvisoriesSection/helpers.ts
@@ -1,26 +1,12 @@
-import type { Issue, LineSummary } from '~/types';
+import type { LineSummary } from '~/types';
 
-type AdvisoryIssue = Pick<Issue, 'lineIds'>;
 type AdvisoryLineSummary = Pick<LineSummary, 'lineId' | 'status'>;
 
-export function countOperationalLinesOutsideCurrentAdvisories({
-  issuesActiveNow,
-  issuesActiveToday,
+export function countOperationalLineSummaries({
   lineSummaries,
 }: {
-  issuesActiveNow: AdvisoryIssue[];
-  issuesActiveToday: AdvisoryIssue[];
   lineSummaries: AdvisoryLineSummary[];
 }) {
-  const advisoryLineIds = new Set(
-    [...issuesActiveNow, ...issuesActiveToday].flatMap(
-      (issue) => issue.lineIds,
-    ),
-  );
-
-  return lineSummaries.filter(
-    (lineSummary) =>
-      lineSummary.status === 'normal' &&
-      !advisoryLineIds.has(lineSummary.lineId),
-  ).length;
+  return lineSummaries.filter((lineSummary) => lineSummary.status === 'normal')
+    .length;
 }

--- a/app/routes/{-$lang}/index.tsx
+++ b/app/routes/{-$lang}/index.tsx
@@ -12,7 +12,7 @@ import { useViewport, ViewportSchema } from '~/hooks/useViewport';
 import { getOverviewFn } from '~/util/overview.functions';
 import { sortLineSummariesWithFutureServiceLast } from './helpers/sortLineSummaries';
 import { CurrentAdvisoriesSection } from '../../components/CurrentAdvisoriesSection';
-import { countOperationalLinesOutsideCurrentAdvisories } from '../../components/CurrentAdvisoriesSection/helpers';
+import { countOperationalLineSummaries } from '../../components/CurrentAdvisoriesSection/helpers';
 import { assert } from '../../util/assert';
 
 const SearchParamsSchema = z.object({
@@ -178,12 +178,10 @@ function HomePage() {
   }, [overview.issueIdsActiveToday, issues]);
 
   const lineOperationalCount = useMemo(() => {
-    return countOperationalLinesOutsideCurrentAdvisories({
-      issuesActiveNow,
-      issuesActiveToday,
+    return countOperationalLineSummaries({
       lineSummaries: overview.lineSummaries,
     });
-  }, [issuesActiveNow, issuesActiveToday, overview.lineSummaries]);
+  }, [overview.lineSummaries]);
 
   const sortedLineSummaries = useMemo(() => {
     return sortLineSummariesWithFutureServiceLast(overview.lineSummaries);

--- a/app/routes/{-$lang}/system-map.tsx
+++ b/app/routes/{-$lang}/system-map.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import { createIntl, FormattedMessage, useIntl } from 'react-intl';
 import type { IssueAffectedBranch } from '~/types';
 import { CurrentAdvisoriesSection } from '~/components/CurrentAdvisoriesSection';
-import { countOperationalLinesOutsideCurrentAdvisories } from '~/components/CurrentAdvisoriesSection/helpers';
+import { countOperationalLineSummaries } from '~/components/CurrentAdvisoriesSection/helpers';
 import { StationMap } from '~/components/StationMap';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
 import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
@@ -81,12 +81,10 @@ function SystemMapPage() {
   }, [overview.issueIdsActiveToday, included.issues]);
 
   const lineOperationalCount = useMemo(() => {
-    return countOperationalLinesOutsideCurrentAdvisories({
-      issuesActiveNow,
-      issuesActiveToday,
+    return countOperationalLineSummaries({
       lineSummaries: overview.lineSummaries,
     });
-  }, [issuesActiveNow, issuesActiveToday, overview.lineSummaries]);
+  }, [overview.lineSummaries]);
 
   const lines = useMemo(() => {
     return Object.values(included.lines);


### PR DESCRIPTION
## Summary

- Count operational lines directly from line summaries with `status === "normal"`.
- Update the home page and system map advisory summaries to use that same source of truth.
- Refresh helper tests around operational, closed, future, and maintenance statuses.

## Why

The "N Lines Operational" summary was subtracting lines that appeared in current or same-day advisories, while the line list below labels every `normal` line as Operational. This made the summary disagree with the visible line statuses.

## Validation

- `npm run test:run -- app/components/CurrentAdvisoriesSection/helpers.test.ts`
- `npm run verify` passed after rerunning with sandbox escalation for the `tsx` IPC pipe restriction under `/var/folders/...`.