### PR TITLE
ci: add workflow to sync production into main

### DIFF
--- a/.github/workflows/sync-production-to-main.yml
+++ b/.github/workflows/sync-production-to-main.yml
@@ -1,0 +1,27 @@
+name: Sync production to main
+
+on:
+  push:
+    branches:
+      - production
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  open-sync-pr:
+    name: Open production → main sync PR
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/production'
+    steps:
+      - name: Create pull request from production to main
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: production
+          destination_branch: main
+          pr_title: "chore: sync production into main"
+          pr_body: |
+            Automated sync PR to bring `main` (staging) up to date with `production`.
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation
- Keep `main` (staging) aligned with `production` by creating an automated sync PR when production is updated.

### Description
- Add a GitHub Actions workflow at `.github/workflows/sync-production-to-main.yml` that triggers on pushes to `production` and manual dispatch and uses `repo-sync/pull-request@v2` to open a PR from `production` → `main` with `pull-requests: write` permissions.

### Testing
- Ran `npm run verify` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fbda0e7108320b365920f754995c6)