### PR TITLE
feat: refine home day popup interaction

### DIFF
--- a/app/components/LineSummaryBlock/components/DateCard.tsx
+++ b/app/components/LineSummaryBlock/components/DateCard.tsx
@@ -94,16 +94,24 @@ function useDateBreakdown(
 export const DateCard: React.FC<Props> = (props) => {
   const { line, dateTime, data } = props;
   const { segments } = useDateBreakdown(line, dateTime, data);
+  const intl = useIntl();
+  const isoDate = dateTime.toISODate();
+  const ariaLabel =
+    isoDate == null
+      ? undefined
+      : intl.formatMessage(
+          {
+            id: 'component.view_details_for_date',
+            defaultMessage: 'View details for {date}',
+          },
+          { date: isoDate },
+        );
 
   return (
     <button
       type="button"
       onClick={props.onActivate}
-      aria-label={
-        dateTime.toISODate() == null
-          ? undefined
-          : `View details for ${dateTime.toISODate()}`
-      }
+      aria-label={ariaLabel}
       aria-expanded={props.isActive}
       className={classNames(
         'group hover:-translate-y-0.5 flex h-9 min-w-0 cursor-pointer items-center justify-center rounded-sm transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-light focus-visible:ring-offset-1 active:translate-y-0 active:scale-95 dark:focus-visible:ring-accent-dark',

--- a/app/components/LineSummaryBlock/components/DateCard.tsx
+++ b/app/components/LineSummaryBlock/components/DateCard.tsx
@@ -2,17 +2,17 @@ import { CalendarDaysIcon, ClockIcon } from '@heroicons/react/24/outline';
 import { Link } from '@tanstack/react-router';
 import classNames from 'classnames';
 import { type DateTime, Duration } from 'luxon';
-import { Fragment, type PointerEvent, useMemo } from 'react';
+import { Fragment, useMemo } from 'react';
 import { FormattedDate, FormattedMessage, useIntl } from 'react-intl';
+import { FormattedDuration } from '~/components/FormattedDuration';
+import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
+import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 import type {
   Issue,
   Line,
   LineSummaryDateRecord,
   LineSummaryStatus,
 } from '~/types';
-import { FormattedDuration } from '~/components/FormattedDuration';
-import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
-import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 import { useHydrated } from '../../../hooks/useHydrated';
 import { DAY_TYPE_MESSAGE_DESCRIPTORS } from '../constants';
 import { useOperatingHours } from '../hooks/useOperatingHours';
@@ -95,34 +95,34 @@ export const DateCard: React.FC<Props> = (props) => {
   const { line, dateTime, data } = props;
   const { segments } = useDateBreakdown(line, dateTime, data);
 
-  const activateOnHoverPointer = (event: PointerEvent<HTMLButtonElement>) => {
-    if (event.pointerType === 'mouse' || event.pointerType === 'pen') {
-      props.onActivate();
-    }
-  };
-
   return (
     <button
       type="button"
       onClick={props.onActivate}
-      onFocus={props.onActivate}
-      onMouseEnter={props.onActivate}
-      onPointerEnter={activateOnHoverPointer}
-      aria-label={dateTime.toISODate() ?? undefined}
+      aria-label={
+        dateTime.toISODate() == null
+          ? undefined
+          : `View details for ${dateTime.toISODate()}`
+      }
       aria-expanded={props.isActive}
       className={classNames(
-        'group cursor-pointer rounded-sm transition-all duration-200 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-accent-light focus:ring-offset-1 dark:focus:ring-accent-dark dark:hover:bg-gray-800',
+        'group hover:-translate-y-0.5 flex h-9 min-w-0 cursor-pointer items-center justify-center rounded-sm transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-light focus-visible:ring-offset-1 active:translate-y-0 active:scale-95 dark:focus-visible:ring-accent-dark',
         {
-          'bg-gray-100 ring-2 ring-accent-light ring-offset-1 dark:bg-gray-800 dark:ring-accent-dark':
+          'bg-accent-light/10 shadow-inner dark:bg-accent-dark/15':
             props.isActive,
         },
       )}
     >
-      <div className="flex h-7 w-1.5 flex-col-reverse overflow-hidden rounded-xs bg-operational-light shadow-sm transition-all duration-200 group-hover:scale-125 group-hover:shadow-md group-focus:scale-125 dark:bg-operational-dark">
+      <div
+        className={classNames(
+          'flex w-full flex-col-reverse overflow-hidden rounded-xs bg-operational-light transition-all duration-150 group-hover:scale-105 group-hover:brightness-110 group-focus-visible:scale-105 dark:bg-operational-dark',
+          props.isActive ? 'h-9 brightness-110' : 'h-7',
+        )}
+      >
         {segments.map((segment) => (
           <div
             key={segment.type}
-            className={classNames('flex w-1.5', {
+            className={classNames('flex w-full', {
               'bg-disruption-light dark:bg-disruption-dark':
                 segment.type === 'ongoing_disruption',
               'bg-maintenance-light dark:bg-maintenance-dark':

--- a/app/components/LineSummaryBlock/components/NonOperationalDateCard.tsx
+++ b/app/components/LineSummaryBlock/components/NonOperationalDateCard.tsx
@@ -1,7 +1,7 @@
 import type React from 'react';
 
 export const NonOperationalDateCard: React.FC = () => (
-  <div className="group cursor-default rounded-sm">
-    <div className="h-7 w-1.5 shrink-0 rounded-xs bg-gray-400 shadow-sm transition-all duration-200 group-hover:scale-110 group-hover:shadow-md dark:bg-gray-600" />
+  <div className="flex h-9 min-w-0 cursor-default items-center justify-center rounded-sm">
+    <div className="h-7 w-full rounded-xs bg-gray-400 dark:bg-gray-600" />
   </div>
 );

--- a/app/components/LineSummaryBlock/components/ServiceEndedDateCard.tsx
+++ b/app/components/LineSummaryBlock/components/ServiceEndedDateCard.tsx
@@ -1,7 +1,7 @@
 import { CalendarDaysIcon, ClockIcon } from '@heroicons/react/24/outline';
 import classNames from 'classnames';
 import type { DateTime } from 'luxon';
-import { FormattedDate, FormattedMessage } from 'react-intl';
+import { FormattedDate, FormattedMessage, useIntl } from 'react-intl';
 import type { Line, LineSummaryDayType } from '~/types';
 import { useHydrated } from '../../../hooks/useHydrated';
 import { DAY_TYPE_MESSAGE_DESCRIPTORS } from '../constants';
@@ -16,17 +16,25 @@ interface Props {
 }
 
 export const ServiceEndedDateCard: React.FC<Props> = (props) => {
-  const { isActive, onActivate } = props;
+  const { isActive, onActivate, dateTime } = props;
+  const intl = useIntl();
+  const isoDate = dateTime.toISODate();
+  const ariaLabel =
+    isoDate == null
+      ? undefined
+      : intl.formatMessage(
+          {
+            id: 'component.view_details_for_date',
+            defaultMessage: 'View details for {date}',
+          },
+          { date: isoDate },
+        );
 
   return (
     <button
       type="button"
       onClick={onActivate}
-      aria-label={
-        props.dateTime.toISODate() == null
-          ? undefined
-          : `View details for ${props.dateTime.toISODate()}`
-      }
+      aria-label={ariaLabel}
       aria-expanded={isActive}
       className={classNames(
         'group hover:-translate-y-0.5 flex h-9 min-w-0 cursor-pointer items-center justify-center rounded-sm transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-light focus-visible:ring-offset-1 active:translate-y-0 active:scale-95 dark:focus-visible:ring-accent-dark',

--- a/app/components/LineSummaryBlock/components/ServiceEndedDateCard.tsx
+++ b/app/components/LineSummaryBlock/components/ServiceEndedDateCard.tsx
@@ -1,7 +1,6 @@
 import { CalendarDaysIcon, ClockIcon } from '@heroicons/react/24/outline';
 import classNames from 'classnames';
 import type { DateTime } from 'luxon';
-import type { PointerEvent } from 'react';
 import { FormattedDate, FormattedMessage } from 'react-intl';
 import type { Line, LineSummaryDayType } from '~/types';
 import { useHydrated } from '../../../hooks/useHydrated';
@@ -19,30 +18,29 @@ interface Props {
 export const ServiceEndedDateCard: React.FC<Props> = (props) => {
   const { isActive, onActivate } = props;
 
-  const activateOnHoverPointer = (event: PointerEvent<HTMLButtonElement>) => {
-    if (event.pointerType === 'mouse' || event.pointerType === 'pen') {
-      onActivate();
-    }
-  };
-
   return (
     <button
       type="button"
       onClick={onActivate}
-      onFocus={onActivate}
-      onMouseEnter={onActivate}
-      onPointerEnter={activateOnHoverPointer}
-      aria-label={props.dateTime.toISODate() ?? undefined}
+      aria-label={
+        props.dateTime.toISODate() == null
+          ? undefined
+          : `View details for ${props.dateTime.toISODate()}`
+      }
       aria-expanded={isActive}
       className={classNames(
-        'group cursor-pointer rounded-sm transition-all duration-200 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-accent-light focus:ring-offset-1 dark:focus:ring-accent-dark dark:hover:bg-gray-800',
+        'group hover:-translate-y-0.5 flex h-9 min-w-0 cursor-pointer items-center justify-center rounded-sm transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-light focus-visible:ring-offset-1 active:translate-y-0 active:scale-95 dark:focus-visible:ring-accent-dark',
         {
-          'bg-gray-100 ring-2 ring-accent-light ring-offset-1 dark:bg-gray-800 dark:ring-accent-dark':
-            isActive,
+          'bg-accent-light/10 shadow-inner dark:bg-accent-dark/15': isActive,
         },
       )}
     >
-      <div className="h-7 w-1.5 rounded-xs bg-gray-400 shadow-sm transition-all duration-200 group-hover:scale-125 group-hover:shadow-md group-focus:scale-125 dark:bg-gray-600" />
+      <div
+        className={classNames(
+          'w-full rounded-xs bg-gray-400 transition-all duration-150 group-hover:scale-105 group-hover:brightness-110 group-focus-visible:scale-105 dark:bg-gray-600',
+          isActive ? 'h-9 brightness-110' : 'h-7',
+        )}
+      />
     </button>
   );
 };

--- a/app/components/LineSummaryBlock/index.tsx
+++ b/app/components/LineSummaryBlock/index.tsx
@@ -9,10 +9,10 @@ import {
   FormattedRelativeTime,
   useIntl,
 } from 'react-intl';
-import type { LineSummary } from '~/types';
 import { LineSummaryStatusLabels } from '~/constants';
 import { useIncludedEntities } from '~/contexts/IncludedEntities';
 import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
+import type { LineSummary } from '~/types';
 import { useHydrated } from '../../hooks/useHydrated';
 import { DateCard, DateCardDetails } from './components/DateCard';
 import { NonOperationalDateCard } from './components/NonOperationalDateCard';
@@ -154,7 +154,12 @@ export const LineSummaryBlock: React.FC<Props> = (props) => {
           </div>
         </div>
 
-        <div className="flex items-center justify-between gap-x-1">
+        <div
+          className="grid items-center gap-x-1 sm:gap-x-0.5 lg:gap-x-px"
+          style={{
+            gridTemplateColumns: `repeat(${dateTimes.length}, minmax(0, 1fr))`,
+          }}
+        >
           {dateTimes.map((dateTime) => {
             const dateTimeIsoDate = dateTime.toISODate();
             if (

--- a/app/routes/{-$lang}/components/HomeLineSummariesSkeleton/components/HomeSkeletonDateBars.tsx
+++ b/app/routes/{-$lang}/components/HomeLineSummariesSkeleton/components/HomeSkeletonDateBars.tsx
@@ -1,0 +1,41 @@
+import classNames from 'classnames';
+
+interface HomeSkeletonDateBarsProps {
+  dateKeys?: string[];
+}
+
+export function HomeSkeletonDateBars(props: HomeSkeletonDateBarsProps) {
+  const { dateKeys } = props;
+
+  if (dateKeys != null) {
+    return dateKeys.map((dateKey) => <HomeSkeletonDateBar key={dateKey} />);
+  }
+
+  return PENDING_DATE_BAR_IDS.map((barId, index) => (
+    <HomeSkeletonDateBar
+      className={classNames({
+        'hidden sm:flex': index >= 30 && index < 60,
+        'hidden lg:flex': index >= 60,
+      })}
+      key={barId}
+    />
+  ));
+}
+
+function HomeSkeletonDateBar(props: { className?: string }) {
+  return (
+    <div
+      className={classNames(
+        'flex h-9 min-w-0 items-center justify-center rounded-sm',
+        props.className,
+      )}
+    >
+      <div className="h-7 w-full rounded-xs bg-gray-300 dark:bg-gray-700" />
+    </div>
+  );
+}
+
+const PENDING_DATE_BAR_IDS = Array.from(
+  { length: 90 },
+  (_, index) => `date-bar-${index}`,
+);

--- a/app/routes/{-$lang}/components/HomeLineSummariesSkeleton/index.tsx
+++ b/app/routes/{-$lang}/components/HomeLineSummariesSkeleton/index.tsx
@@ -1,0 +1,62 @@
+import classNames from 'classnames';
+import { HomeSkeletonDateBars } from './components/HomeSkeletonDateBars';
+
+interface HomeLineSummariesSkeletonProps {
+  dateKeys?: string[];
+  lineIds: string[];
+}
+
+export function HomeLineSummariesSkeleton(
+  props: HomeLineSummariesSkeletonProps,
+) {
+  const { dateKeys, lineIds } = props;
+  const skeletonLineIds =
+    lineIds.length > 0 ? lineIds : ['line-summary-skeleton'];
+  const dateBarCount = dateKeys?.length;
+
+  return (
+    <div
+      aria-busy="true"
+      className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800"
+    >
+      <span className="sr-only">Loading service status</span>
+      <div className="flex flex-col gap-y-4 px-2 py-2 sm:gap-y-6 sm:px-3 sm:py-4">
+        {skeletonLineIds.map((lineId) => (
+          <div
+            className="flex animate-pulse flex-col rounded-lg bg-gray-100 px-4 py-2 dark:bg-gray-800"
+            key={lineId}
+          >
+            <div className="mb-1.5 flex items-center">
+              <div className="h-5 w-12 rounded-sm bg-gray-300 dark:bg-gray-700" />
+              <div className="ms-1.5 h-4 w-36 rounded-sm bg-gray-300 dark:bg-gray-700" />
+              <div className="ms-auto h-4 w-20 rounded-sm bg-gray-300 dark:bg-gray-700" />
+            </div>
+
+            <div
+              className={classNames(
+                'grid items-center gap-x-1 sm:gap-x-0.5 lg:gap-x-px',
+                dateBarCount == null &&
+                  'grid-cols-30 sm:grid-cols-60 lg:grid-cols-90',
+              )}
+              style={
+                dateBarCount == null
+                  ? undefined
+                  : {
+                      gridTemplateColumns: `repeat(${dateBarCount}, minmax(0, 1fr))`,
+                    }
+              }
+            >
+              <HomeSkeletonDateBars dateKeys={dateKeys} />
+            </div>
+
+            <div className="mt-1.5 flex items-center justify-between gap-x-1">
+              <div className="h-3 w-20 rounded-sm bg-gray-300 dark:bg-gray-700" />
+              <div className="h-3 w-24 rounded-sm bg-gray-300 dark:bg-gray-700" />
+              <div className="h-3 w-14 rounded-sm bg-gray-300 dark:bg-gray-700" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/routes/{-$lang}/index.tsx
+++ b/app/routes/{-$lang}/index.tsx
@@ -1,5 +1,4 @@
 import { createFileRoute, notFound } from '@tanstack/react-router';
-import classNames from 'classnames';
 import { DateTime } from 'luxon';
 import { useEffect, useMemo } from 'react';
 import { createIntl, FormattedMessage } from 'react-intl';
@@ -13,6 +12,7 @@ import { getOverviewFn } from '~/util/overview.functions';
 import { CurrentAdvisoriesSection } from '../../components/CurrentAdvisoriesSection';
 import { countOperationalLineSummaries } from '../../components/CurrentAdvisoriesSection/helpers';
 import { assert } from '../../util/assert';
+import { HomeLineSummariesSkeleton } from './components/HomeLineSummariesSkeleton';
 import { sortLineSummariesWithFutureServiceLast } from './helpers/sortLineSummaries';
 
 const SearchParamsSchema = z.object({
@@ -327,99 +327,6 @@ function HomePagePending() {
   );
 }
 
-interface HomeLineSummariesSkeletonProps {
-  dateKeys?: string[];
-  lineIds: string[];
-}
-
-function HomeLineSummariesSkeleton(props: HomeLineSummariesSkeletonProps) {
-  const { dateKeys, lineIds } = props;
-  const skeletonLineIds =
-    lineIds.length > 0 ? lineIds : ['line-summary-skeleton'];
-  const dateBarCount = dateKeys?.length;
-
-  return (
-    <div
-      aria-busy="true"
-      className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800"
-    >
-      <span className="sr-only">Loading service status</span>
-      <div className="flex flex-col gap-y-4 px-2 py-2 sm:gap-y-6 sm:px-3 sm:py-4">
-        {skeletonLineIds.map((lineId) => (
-          <div
-            className="flex animate-pulse flex-col rounded-lg bg-gray-100 px-4 py-2 dark:bg-gray-800"
-            key={lineId}
-          >
-            <div className="mb-1.5 flex items-center">
-              <div className="h-5 w-12 rounded-sm bg-gray-300 dark:bg-gray-700" />
-              <div className="ms-1.5 h-4 w-36 rounded-sm bg-gray-300 dark:bg-gray-700" />
-              <div className="ms-auto h-4 w-20 rounded-sm bg-gray-300 dark:bg-gray-700" />
-            </div>
-
-            <div
-              className={classNames(
-                'grid items-center gap-x-1 sm:gap-x-0.5 lg:gap-x-px',
-                dateBarCount == null &&
-                  'grid-cols-30 sm:grid-cols-60 lg:grid-cols-90',
-              )}
-              style={
-                dateBarCount == null
-                  ? undefined
-                  : {
-                      gridTemplateColumns: `repeat(${dateBarCount}, minmax(0, 1fr))`,
-                    }
-              }
-            >
-              <HomeSkeletonDateBars dateKeys={dateKeys} />
-            </div>
-
-            <div className="mt-1.5 flex items-center justify-between gap-x-1">
-              <div className="h-3 w-20 rounded-sm bg-gray-300 dark:bg-gray-700" />
-              <div className="h-3 w-24 rounded-sm bg-gray-300 dark:bg-gray-700" />
-              <div className="h-3 w-14 rounded-sm bg-gray-300 dark:bg-gray-700" />
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-interface HomeSkeletonDateBarsProps {
-  dateKeys?: string[];
-}
-
-function HomeSkeletonDateBars(props: HomeSkeletonDateBarsProps) {
-  const { dateKeys } = props;
-
-  if (dateKeys != null) {
-    return dateKeys.map((dateKey) => <HomeSkeletonDateBar key={dateKey} />);
-  }
-
-  return PENDING_DATE_BAR_IDS.map((barId, index) => (
-    <HomeSkeletonDateBar
-      className={classNames({
-        'hidden sm:flex': index >= 30 && index < 60,
-        'hidden lg:flex': index >= 60,
-      })}
-      key={barId}
-    />
-  ));
-}
-
-function HomeSkeletonDateBar(props: { className?: string }) {
-  return (
-    <div
-      className={classNames(
-        'flex h-9 min-w-0 items-center justify-center rounded-sm',
-        props.className,
-      )}
-    >
-      <div className="h-7 w-full rounded-xs bg-gray-300 dark:bg-gray-700" />
-    </div>
-  );
-}
-
 const PENDING_LINE_IDS = ['skeleton-line-1', 'skeleton-line-2'];
 const PENDING_LEGEND_IDS = [
   'operational',
@@ -428,7 +335,3 @@ const PENDING_LEGEND_IDS = [
   'infrastructure',
   'closed',
 ];
-const PENDING_DATE_BAR_IDS = Array.from(
-  { length: 90 },
-  (_, index) => `date-bar-${index}`,
-);

--- a/app/routes/{-$lang}/index.tsx
+++ b/app/routes/{-$lang}/index.tsx
@@ -10,10 +10,10 @@ import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
 import { getDateCountForViewport } from '~/helpers/getDateCountForViewport';
 import { useViewport, ViewportSchema } from '~/hooks/useViewport';
 import { getOverviewFn } from '~/util/overview.functions';
-import { sortLineSummariesWithFutureServiceLast } from './helpers/sortLineSummaries';
 import { CurrentAdvisoriesSection } from '../../components/CurrentAdvisoriesSection';
 import { countOperationalLineSummaries } from '../../components/CurrentAdvisoriesSection/helpers';
 import { assert } from '../../util/assert';
+import { sortLineSummariesWithFutureServiceLast } from './helpers/sortLineSummaries';
 
 const SearchParamsSchema = z.object({
   viewport: ViewportSchema.optional(),
@@ -336,6 +336,7 @@ function HomeLineSummariesSkeleton(props: HomeLineSummariesSkeletonProps) {
   const { dateKeys, lineIds } = props;
   const skeletonLineIds =
     lineIds.length > 0 ? lineIds : ['line-summary-skeleton'];
+  const dateBarCount = dateKeys?.length;
 
   return (
     <div
@@ -355,7 +356,20 @@ function HomeLineSummariesSkeleton(props: HomeLineSummariesSkeletonProps) {
               <div className="ms-auto h-4 w-20 rounded-sm bg-gray-300 dark:bg-gray-700" />
             </div>
 
-            <div className="flex items-center justify-between gap-x-1">
+            <div
+              className={classNames(
+                'grid items-center gap-x-1 sm:gap-x-0.5 lg:gap-x-px',
+                dateBarCount == null &&
+                  'grid-cols-30 sm:grid-cols-60 lg:grid-cols-90',
+              )}
+              style={
+                dateBarCount == null
+                  ? undefined
+                  : {
+                      gridTemplateColumns: `repeat(${dateBarCount}, minmax(0, 1fr))`,
+                    }
+              }
+            >
               <HomeSkeletonDateBars dateKeys={dateKeys} />
             </div>
 
@@ -379,26 +393,31 @@ function HomeSkeletonDateBars(props: HomeSkeletonDateBarsProps) {
   const { dateKeys } = props;
 
   if (dateKeys != null) {
-    return dateKeys.map((dateKey) => (
-      <div
-        className="h-7 w-1.5 shrink-0 rounded-xs bg-gray-300 dark:bg-gray-700"
-        key={dateKey}
-      />
-    ));
+    return dateKeys.map((dateKey) => <HomeSkeletonDateBar key={dateKey} />);
   }
 
   return PENDING_DATE_BAR_IDS.map((barId, index) => (
-    <div
-      className={classNames(
-        'h-7 w-1.5 shrink-0 rounded-xs bg-gray-300 dark:bg-gray-700',
-        {
-          'hidden sm:block': index >= 30 && index < 60,
-          'hidden lg:block': index >= 60,
-        },
-      )}
+    <HomeSkeletonDateBar
+      className={classNames({
+        'hidden sm:flex': index >= 30 && index < 60,
+        'hidden lg:flex': index >= 60,
+      })}
       key={barId}
     />
   ));
+}
+
+function HomeSkeletonDateBar(props: { className?: string }) {
+  return (
+    <div
+      className={classNames(
+        'flex h-9 min-w-0 items-center justify-center rounded-sm',
+        props.className,
+      )}
+    >
+      <div className="h-7 w-full rounded-xs bg-gray-300 dark:bg-gray-700" />
+    </div>
+  );
 }
 
 const PENDING_LINE_IDS = ['skeleton-line-1', 'skeleton-line-2'];


### PR DESCRIPTION
## Summary

- Change home page day detail popups to activate by click instead of hover/focus.
- Rework the day strip into equal-width day slots with responsive divider spacing and a clearer active-day state.
- Remove bar drop shadows and align the loading skeleton with the real day-strip layout.
- Extract the home line-summary skeleton into focused component files.

## Validation

- `npm run verify`

## Notes

The first sandboxed verification run earlier in the change set could not complete the `tsx` migration check because IPC pipe creation was blocked, so verification was rerun outside the sandbox and passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added responsive loading skeleton UI for enhanced visual feedback during data loading.

* **Improvements**
  * Simplified date card interactions to click-based activation.
  * Enhanced responsive layout for date information display using grid-based design.
  * Improved accessibility with updated aria-labels for better screen reader support.
  * Refined visual styling for cleaner, more consistent appearance across date card components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-site/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->