### PR TITLE
fix: Localize Service Status Legend and add translations

### DIFF
--- a/app/routes/{-$lang}/index.tsx
+++ b/app/routes/{-$lang}/index.tsx
@@ -234,7 +234,10 @@ function HomePage() {
 
         <div className="rounded-2xl border border-gray-200 bg-gray-50 p-6 dark:border-gray-700 dark:bg-gray-800/50">
           <h3 className="mb-4 text-center font-semibold text-gray-700 text-sm dark:text-gray-300">
-            Service Status Legend
+            <FormattedMessage
+              id="home.service_status_legend"
+              defaultMessage="Service Status Legend"
+            />
           </h3>
           <div className="flex flex-wrap justify-center gap-x-6 gap-y-3">
             <div className="inline-flex items-center gap-x-2">

--- a/lang/en-SG.json
+++ b/lang/en-SG.json
@@ -56,6 +56,7 @@
   "general.home": "Home",
   "general.home_page_description": "See if the MRT is down right now. Get live updates, maintenance alerts, and crowd-sourced reports from fellow commuters on mrtdown.",
   "general.home_page_title": "Is the MRT Down? Train Disruption Status in Singapore",
+  "home.service_status_legend": "Service Status Legend",
   "general.infra_count": "{count, plural, one {{count} infrastructure issue} other {{count} infrastructure issues}}",
   "general.infrastructure": "Infrastructure",
   "general.infrastructure_works": "<bold>{count}</bold> Infrastructure {count, plural, one {Work} other {Works}}",

--- a/lang/ms.json
+++ b/lang/ms.json
@@ -52,6 +52,7 @@
   "general.home": "Laman Utama",
   "general.home_page_description": "Lihat sama ada MRT sedang tergendala sekarang. Dapatkan kemas kini langsung, makluman penyelenggaraan dan laporan komuniti di mrtdown.",
   "general.home_page_title": "Adakah MRT Sedang Tergendala? Status Gangguan Tren di Singapura",
+  "home.service_status_legend": "Petunjuk Status Perkhidmatan",
   "general.infra_count": "{count, plural, one {{count} isu infrastruktur} other {{count} isu infrastruktur}}",
   "general.infrastructure": "Infrastruktur",
   "general.infrastructure_works": "<bold>{count}</bold> {count, plural, one {Kerja Infrastruktur} other {Kerja-Kerja Infrastruktur}}",

--- a/lang/ta.json
+++ b/lang/ta.json
@@ -52,6 +52,7 @@
   "general.home": "முகப்பு",
   "general.home_page_description": "இப்போது MRT இயங்குகிறதா என்பதை பாருங்கள். திடீர் மாற்றங்கள், பராமரிப்பு அறிவிப்புகள் மற்றும் பயணிகளின் தகவல்களை mrtdown-ல் பெறுங்கள்.",
   "general.home_page_title": "MRT இயக்கத்தில் தாமதமா? சிங்கப்பூரின் ரயில்பாதை தடையமைப்பு நிலை",
+  "home.service_status_legend": "சேவை நிலை விளக்கம்",
   "general.infra_count": "{count, plural, one {{count} கட்டமைப்பு சிக்கல்} other {{count} கட்டமைப்பு சிக்கல்கள்}}",
   "general.infrastructure": "அடித்தளம்",
   "general.infrastructure_works": "<bold>{count}</bold> {count, plural, one {அடிப்படை வசதி பணி} other {அடிப்படை வசதி பணிகள்}}",

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -52,6 +52,7 @@
   "general.home": "首页",
   "general.home_page_description": "查看MRT目前是否停运。获取最新更新、维护通知和来自通勤者的实时报告，尽在mrtdown。",
   "general.home_page_title": "MRT有故障吗？新加坡地铁服务中断状态",
+  "home.service_status_legend": "服务状态图例",
   "general.infra_count": "{count, plural, one {{count}项基础设施问题} other {{count}项基础设施问题}}",
   "general.infrastructure": "基础设施问题",
   "general.infrastructure_works": "<bold>{count}</bold> {count, plural, one {基础设施施工} other {基础设施施工}}",


### PR DESCRIPTION
### Motivation
- Replace a hardcoded heading with a localized message to support internationalization for the service status legend.
- Provide the new i18n key across supported locales so the UI displays a translated label instead of the English literal.

### Description
- Replaced the literal string `Service Status Legend` in `app/routes/{-$lang}/index.tsx` with a `FormattedMessage` using the id `home.service_status_legend` and `defaultMessage` fallback.
- Added the `home.service_status_legend` key to the `en-SG.json`, `ms.json`, `ta.json`, and `zh-Hans.json` locale files with appropriate translations.
- Changes touch `app/routes/{-$lang}/index.tsx` and the four locale JSON files to keep the UI consistent across languages.

### Testing
- Ran the project build and typecheck with `yarn build` and they completed successfully.
- Executed the test suite with `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1031277144832085e520d665e4b830)