### PR TITLE
feat: improve line schematic and focused system map

### DIFF
--- a/app/components/StationMap/index.tsx
+++ b/app/components/StationMap/index.tsx
@@ -308,14 +308,32 @@ export const StationMap: React.FC<Props> = (props) => {
 
     if (mode.type === 'focused-line') {
       const normalizedLineId = mode.lineId.toLowerCase();
-      const lineGroupElements = [
-        ...ref.querySelectorAll<SVGGElement>("g[id^='line_']"),
-      ].filter((element) => !element.id.includes(':'));
+      const focusedSegmentIds = new Set<string>();
+      const focusedComponentIds = new Set<string>();
 
-      for (const lineGroupElement of lineGroupElements) {
-        const lineGroupId = lineGroupElement.id.replace(/^line_/, '');
-        lineGroupElement.style.opacity =
-          lineGroupId === normalizedLineId ? '1' : '0.18';
+      for (const branch of mode.branches) {
+        for (let index = 0; index < branch.stationIds.length - 1; index++) {
+          const stationId = branch.stationIds[index].toLowerCase();
+          const nextStationId = branch.stationIds[index + 1].toLowerCase();
+          focusedSegmentIds.add(`line_${stationId}:${nextStationId}`);
+          focusedSegmentIds.add(`line_${nextStationId}:${stationId}`);
+        }
+      }
+
+      const lineSegmentElements = [
+        ...ref.querySelectorAll<SVGGElement>("g[id^='line_']"),
+      ].filter((element) => element.id.includes(':'));
+
+      for (const lineSegmentElement of lineSegmentElements) {
+        const isFocusedSegment = focusedSegmentIds.has(lineSegmentElement.id);
+        lineSegmentElement.style.opacity = isFocusedSegment ? '1' : '0.18';
+
+        if (isFocusedSegment) {
+          const parentElement = lineSegmentElement.parentElement;
+          if (parentElement?.id.startsWith('line_')) {
+            focusedComponentIds.add(parentElement.id.replace(/^line_/, ''));
+          }
+        }
       }
 
       const nodeElements = [
@@ -333,8 +351,12 @@ export const StationMap: React.FC<Props> = (props) => {
         for (const componentElement of nodeElement.querySelectorAll(
           ':scope > g',
         )) {
-          (componentElement as SVGGElement).style.opacity =
-            componentElement.id === normalizedLineId ? '1' : '0.25';
+          const isFocusedComponent =
+            componentElement.id === normalizedLineId ||
+            focusedComponentIds.has(componentElement.id);
+          (componentElement as SVGGElement).style.opacity = isFocusedComponent
+            ? '1'
+            : '0.25';
         }
       }
 

--- a/app/components/StationMap/index.tsx
+++ b/app/components/StationMap/index.tsx
@@ -321,7 +321,7 @@ export const StationMap: React.FC<Props> = (props) => {
       }
 
       const lineSegmentElements = [
-        ...ref.querySelectorAll<SVGGElement>("g[id^='line_']"),
+        ...ref.querySelectorAll<SVGElement>("[id^='line_']"),
       ].filter((element) => element.id.includes(':'));
 
       for (const lineSegmentElement of lineSegmentElements) {
@@ -336,6 +336,17 @@ export const StationMap: React.FC<Props> = (props) => {
         }
       }
 
+      const focusedComponentIdPrefixes = [
+        normalizedLineId,
+        ...focusedComponentIds,
+      ];
+      const isFocusedComponentId = (componentId: string) =>
+        focusedComponentIdPrefixes.some(
+          (focusedComponentId) =>
+            componentId === focusedComponentId ||
+            componentId.startsWith(`${focusedComponentId}_`),
+        );
+
       const nodeElements = [
         ...ref.querySelectorAll<SVGGElement>("g[id^='node_']"),
       ];
@@ -348,15 +359,11 @@ export const StationMap: React.FC<Props> = (props) => {
           continue;
         }
 
-        for (const componentElement of nodeElement.querySelectorAll(
-          ':scope > g',
+        for (const componentElement of nodeElement.querySelectorAll<SVGGElement>(
+          ':scope g[id]',
         )) {
-          const isFocusedComponent =
-            componentElement.id === normalizedLineId ||
-            focusedComponentIds.has(componentElement.id);
-          (componentElement as SVGGElement).style.opacity = isFocusedComponent
-            ? '1'
-            : '0.25';
+          const isFocusedComponent = isFocusedComponentId(componentElement.id);
+          componentElement.style.opacity = isFocusedComponent ? '1' : '0.25';
         }
       }
 

--- a/app/components/StationMap/index.tsx
+++ b/app/components/StationMap/index.tsx
@@ -22,13 +22,32 @@ import { MapNov2024 } from './components/MapNov2024';
 import { Timeline } from './components/Timeline';
 import { segmentText } from './helpers/segmentText';
 
+type FocusedLineBranch = {
+  id: string;
+  stationIds: string[];
+};
+
+export type StationMapMode =
+  | {
+      type: 'network';
+      branchesAffected: IssueAffectedBranch[];
+      showAffectedStationsSummary?: boolean;
+      showTimeline?: boolean;
+    }
+  | {
+      type: 'focused-line';
+      branches: FocusedLineBranch[];
+      lineId: string;
+      showTimeline?: boolean;
+    };
+
 interface Props {
-  branchesAffected: IssueAffectedBranch[];
   currentDate?: string;
+  mode: StationMapMode;
 }
 
 export const StationMap: React.FC<Props> = (props) => {
-  const { branchesAffected, currentDate } = props;
+  const { currentDate, mode } = props;
 
   const intl = useIntl();
   const navigate = useNavigate();
@@ -37,21 +56,41 @@ export const StationMap: React.FC<Props> = (props) => {
 
   const [ref, setRef] = useState<SVGElement | null>(null);
 
-  const stationIds = useMemo(() => {
+  const affectedStationIds = useMemo(() => {
     const result = new Set<string>();
-    for (const entry of branchesAffected) {
+    if (mode.type !== 'network') {
+      return result;
+    }
+
+    for (const entry of mode.branchesAffected) {
       for (const stationId of entry.stationIds) {
         result.add(stationId);
       }
     }
     return result;
-  }, [branchesAffected]);
+  }, [mode]);
+
+  const focusedStationIds = useMemo(() => {
+    const result = new Set<string>();
+    if (mode.type !== 'focused-line') {
+      return result;
+    }
+
+    for (const entry of mode.branches) {
+      for (const stationId of entry.stationIds) {
+        result.add(stationId);
+      }
+    }
+    return result;
+  }, [mode]);
 
   useEffect(() => {
     if (ref == null) {
       return;
     }
 
+    const branchesAffected =
+      mode.type === 'network' ? mode.branchesAffected : [];
     const linesByStationId: Record<string, Set<string>> = {};
     const linesPatchedByStationId: Record<string, Set<string>> = {};
     const componentByLineId: Record<string, string> = {};
@@ -266,7 +305,52 @@ export const StationMap: React.FC<Props> = (props) => {
         titleElement.textContent = stationName;
       }
     }
-  }, [ref, branchesAffected, included.stations, intl.locale, navigate]);
+
+    if (mode.type === 'focused-line') {
+      const normalizedLineId = mode.lineId.toLowerCase();
+      const lineGroupElements = [
+        ...ref.querySelectorAll<SVGGElement>("g[id^='line_']"),
+      ].filter((element) => !element.id.includes(':'));
+
+      for (const lineGroupElement of lineGroupElements) {
+        const lineGroupId = lineGroupElement.id.replace(/^line_/, '');
+        lineGroupElement.style.opacity =
+          lineGroupId === normalizedLineId ? '1' : '0.18';
+      }
+
+      const nodeElements = [
+        ...ref.querySelectorAll<SVGGElement>("g[id^='node_']"),
+      ];
+      for (const nodeElement of nodeElements) {
+        const stationId = nodeElement.id.replace(/^node_/, '').toUpperCase();
+        const isFocusedStation = focusedStationIds.has(stationId);
+        nodeElement.style.opacity = isFocusedStation ? '1' : '0.2';
+
+        if (!isFocusedStation) {
+          continue;
+        }
+
+        for (const componentElement of nodeElement.querySelectorAll(
+          ':scope > g',
+        )) {
+          (componentElement as SVGGElement).style.opacity =
+            componentElement.id === normalizedLineId ? '1' : '0.25';
+        }
+      }
+
+      const labelsElement: SVGGElement | null = ref.querySelector('#labels');
+      if (labelsElement != null) {
+        for (const labelElement of labelsElement.querySelectorAll('text')) {
+          const stationId = labelElement.id
+            .replace(/^label_/, '')
+            .toUpperCase();
+          labelElement.style.opacity = focusedStationIds.has(stationId)
+            ? '1'
+            : '0.18';
+        }
+      }
+    }
+  }, [ref, focusedStationIds, included.stations, intl.locale, mode, navigate]);
 
   const defaultTab = useMemo(() => {
     if (currentDate == null) {
@@ -301,13 +385,17 @@ export const StationMap: React.FC<Props> = (props) => {
     return '2012-01';
   }, [currentDate]);
 
+  const showTimeline = mode.showTimeline ?? mode.type === 'network';
+  const showAffectedStationsSummary =
+    mode.type === 'network' && mode.showAffectedStationsSummary !== false;
+
   return (
     <div className="flex flex-col fill-gray-800 dark:fill-gray-50">
       {/* Tailwind Class trappers */}
       <div className="hidden fill-gray-800 stroke-gray-800 dark:fill-gray-300 dark:stroke-gray-300" />
 
       <Tabs.Root defaultValue={defaultTab}>
-        <Timeline currentDate={currentDate} />
+        {showTimeline && <Timeline currentDate={currentDate} />}
         <div className="relative overflow-hidden">
           <div className="overflow-auto">
             <Tabs.Content value="2032-12">
@@ -342,20 +430,20 @@ export const StationMap: React.FC<Props> = (props) => {
         </div>
       </Tabs.Root>
 
-      {stationIds.size > 0 && (
+      {showAffectedStationsSummary && affectedStationIds.size > 0 && (
         <>
           <span className="font-bold text-gray-500 text-sm dark:text-gray-400">
             <FormattedMessage
               id="general.station_count"
               defaultMessage="{count, plural, one { {count} stations } other { {count} stations }}"
               values={{
-                count: stationIds.size,
+                count: affectedStationIds.size,
               }}
             />
           </span>
           <span className="text-gray-500 text-sm dark:text-gray-400">
             <FormattedList
-              value={Array.from(stationIds).map((stationId) => {
+              value={Array.from(affectedStationIds).map((stationId) => {
                 const station = included.stations[stationId];
 
                 return (

--- a/app/routes/{-$lang}/lines/$lineId/components/LineSchematicCard/index.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/components/LineSchematicCard/index.tsx
@@ -1,9 +1,16 @@
-import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/outline';
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  ListBulletIcon,
+  MapIcon,
+} from '@heroicons/react/24/outline';
 import { Link } from '@tanstack/react-router';
 import classNames from 'classnames';
-import { DropdownMenu } from 'radix-ui';
+import { DateTime } from 'luxon';
+import { DropdownMenu, Tabs } from 'radix-ui';
 import { Fragment, useMemo, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { StationMap } from '~/components/StationMap';
 import { useIncludedEntities } from '~/contexts/IncludedEntities';
 import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 import type { LineBranch } from '~/util/db.queries';
@@ -29,6 +36,122 @@ export const LineSchematicCard: React.FC<Props> = (props) => {
     return branches.find((branch) => branch.id === selectedBranchId) ?? null;
   }, [branches, selectedBranchId]);
 
+  const loopColumns = useMemo(() => {
+    if (selectedBranch == null) {
+      return { leftStationIds: [], rightStationIds: [] };
+    }
+
+    const midpoint = Math.ceil(selectedBranch.stationIds.length / 2);
+    return {
+      leftStationIds: selectedBranch.stationIds.slice(0, midpoint),
+      rightStationIds: selectedBranch.stationIds.slice(midpoint).reverse(),
+    };
+  }, [selectedBranch]);
+
+  const rowCount = Math.max(
+    loopColumns.leftStationIds.length,
+    loopColumns.rightStationIds.length,
+  );
+
+  const renderCodePills = (stationId: string) => (
+    <div className="flex shrink-0 items-center overflow-hidden rounded-md">
+      {Object.entries(
+        Object.fromEntries(
+          stations[stationId].memberships.map((membership) => {
+            const key = `${membership.code}@${membership.lineId}`;
+            return [key, membership];
+          }),
+        ),
+      )
+        .sort((a, b) => {
+          if (a[1].lineId === line.id) {
+            return -1;
+          }
+          if (b[1].lineId === line.id) {
+            return 1;
+          }
+          return 0;
+        })
+        .map(([key, membership]) => (
+          <div
+            key={key}
+            className="z-10 flex h-4 w-10 items-center justify-center px-1.5"
+            style={{
+              backgroundColor: lines[membership.lineId].color,
+            }}
+          >
+            <span className="font-semibold text-white text-xs leading-none">
+              {membership.code}
+            </span>
+          </div>
+        ))}
+    </div>
+  );
+
+  const renderStationLabel = (stationId: string, side: 'left' | 'right') => {
+    const stationName = getLocalizedTranslation(
+      stations[stationId].name,
+      intl.locale,
+    );
+
+    return (
+      <div
+        className={classNames('flex items-center gap-x-2', {
+          'justify-end text-right': side === 'left',
+        })}
+      >
+        {side === 'left' && (
+          <>
+            <Link
+              to="/{-$lang}/stations/$stationId"
+              params={{ stationId }}
+              className="group min-w-0"
+            >
+              <span className="text-gray-800 text-sm group-hover:underline dark:text-gray-200">
+                {stationName}
+              </span>
+            </Link>
+            {renderCodePills(stationId)}
+          </>
+        )}
+        {side === 'right' && (
+          <>
+            {renderCodePills(stationId)}
+            <Link
+              to="/{-$lang}/stations/$stationId"
+              params={{ stationId }}
+              className="group min-w-0"
+            >
+              <span className="text-gray-800 text-sm group-hover:underline dark:text-gray-200">
+                {stationName}
+              </span>
+            </Link>
+          </>
+        )}
+      </div>
+    );
+  };
+
+  const renderRailMarker = (index: number) => (
+    <div className="relative flex h-14 items-center justify-center">
+      <div
+        className={classNames('-translate-x-1/2 absolute left-1/2 z-10 w-1', {
+          'top-1/2 bottom-0': index === 0,
+          'top-0 bottom-0': index > 0,
+        })}
+        style={{
+          backgroundColor: line.color,
+        }}
+      />
+      <div
+        className="z-20 size-4 rounded-full border-4 bg-white dark:bg-gray-900"
+        style={{
+          borderColor: line.color,
+        }}
+      />
+    </div>
+  );
+
   return (
     <div className="flex flex-col rounded-lg border border-gray-300 p-6 text-gray-800 shadow-lg md:col-span-8 md:row-span-2 dark:border-gray-700 dark:text-gray-200">
       <span className="mb-2 font-semibold text-base text-gray-900 dark:text-white">
@@ -37,165 +160,171 @@ export const LineSchematicCard: React.FC<Props> = (props) => {
           defaultMessage="Line Schematic"
         />
       </span>
-      <div className="min-w-64 md:self-start">
-        <DropdownMenu.Root>
-          <DropdownMenu.Trigger className="flex w-full items-center justify-between rounded-lg border border-gray-300 bg-white px-4 py-1 text-left font-medium text-gray-900 text-sm shadow-sm transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700">
-            <span>
-              {selectedBranch != null ? (
-                <BranchItem branch={selectedBranch} />
-              ) : (
-                <FormattedMessage
-                  id="general.select_branch"
-                  defaultMessage="Select Branch"
-                />
-              )}
-            </span>
-            <ChevronDownIcon className="ml-2 h-5 w-5 text-gray-400" />
-          </DropdownMenu.Trigger>
-          <DropdownMenu.Portal>
-            <DropdownMenu.Content
-              className="z-50 w-[var(--radix-dropdown-menu-trigger-width)] overflow-hidden rounded-lg border border-gray-300 bg-white p-1 shadow-lg dark:border-gray-600 dark:bg-gray-800"
-              sideOffset={5}
-            >
-              {branches.map((branch) => (
-                <DropdownMenu.Item
-                  key={branch.id}
-                  className="relative flex cursor-pointer select-none items-center rounded-md px-3 py-2 text-gray-900 text-sm outline-none transition-colors hover:bg-gray-100 focus:bg-gray-100 data-[state=checked]:bg-blue-50 data-[state=checked]:text-blue-900 dark:text-gray-100 dark:data-[state=checked]:bg-blue-900 dark:data-[state=checked]:text-blue-100 dark:focus:bg-gray-700 dark:hover:bg-gray-700"
-                  onSelect={() => {
-                    setSelectedBranchId(branch.id);
-                  }}
-                >
-                  <BranchItem branch={branch} />
-                  {selectedBranchId === branch.id && (
-                    <div className="ml-auto h-2 w-2 rounded-full bg-blue-600" />
+      <Tabs.Root
+        defaultValue="schematic"
+        className="mt-2 flex min-h-0 flex-col"
+      >
+        <Tabs.List className="mb-4 inline-flex self-start rounded-lg bg-gray-100 p-1 dark:bg-gray-800">
+          <Tabs.Trigger
+            value="schematic"
+            className="flex items-center gap-2 rounded-md px-3 py-1.5 font-medium text-gray-600 text-sm transition-colors data-[state=active]:bg-white data-[state=active]:text-gray-900 data-[state=active]:shadow-sm dark:text-gray-300 dark:data-[state=active]:bg-gray-700 dark:data-[state=active]:text-white"
+          >
+            <ListBulletIcon className="h-4 w-4" />
+            <FormattedMessage
+              id="general.line_schematic"
+              defaultMessage="Line Schematic"
+            />
+          </Tabs.Trigger>
+          <Tabs.Trigger
+            value="system-map"
+            className="flex items-center gap-2 rounded-md px-3 py-1.5 font-medium text-gray-600 text-sm transition-colors data-[state=active]:bg-white data-[state=active]:text-gray-900 data-[state=active]:shadow-sm dark:text-gray-300 dark:data-[state=active]:bg-gray-700 dark:data-[state=active]:text-white"
+          >
+            <MapIcon className="h-4 w-4" />
+            <FormattedMessage
+              id="general.system_map"
+              defaultMessage="System Map"
+            />
+          </Tabs.Trigger>
+        </Tabs.List>
+
+        <Tabs.Content value="schematic" className="min-h-0">
+          <div className="min-w-64 md:self-start">
+            <DropdownMenu.Root>
+              <DropdownMenu.Trigger className="flex w-full items-center justify-between rounded-lg border border-gray-300 bg-white px-4 py-1 text-left font-medium text-gray-900 text-sm shadow-sm transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700">
+                <span>
+                  {selectedBranch != null ? (
+                    <BranchItem branch={selectedBranch} />
+                  ) : (
+                    <FormattedMessage
+                      id="general.select_branch"
+                      defaultMessage="Select Branch"
+                    />
                   )}
-                </DropdownMenu.Item>
-              ))}
-            </DropdownMenu.Content>
-          </DropdownMenu.Portal>
-        </DropdownMenu.Root>
-      </div>
-      {selectedBranch != null && (
-        <div className="flex flex-col">
-          <div
-            className={classNames(
-              'relative mt-4 overflow-hidden transition-all duration-300',
-              {
-                'max-h-96': !isExpanded,
-                'max-h-none': isExpanded,
-              },
-            )}
-          >
-            <div
-              key={selectedBranchId}
-              className="grid grid-flow-row grid-cols-[auto_1fr] gap-x-4"
-            >
-              {selectedBranch.stationIds.map((stationId, index) => (
-                <Fragment key={stationId}>
-                  <div className="relative flex h-12 items-center justify-center">
-                    <div
-                      className="z-20 size-4 rounded-full border-4 bg-white"
-                      style={{
-                        borderColor: line.color,
+                </span>
+                <ChevronDownIcon className="ml-2 h-5 w-5 text-gray-400" />
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content
+                  className="z-50 w-[var(--radix-dropdown-menu-trigger-width)] overflow-hidden rounded-lg border border-gray-300 bg-white p-1 shadow-lg dark:border-gray-600 dark:bg-gray-800"
+                  sideOffset={5}
+                >
+                  {branches.map((branch) => (
+                    <DropdownMenu.Item
+                      key={branch.id}
+                      className="relative flex cursor-pointer select-none items-center rounded-md px-3 py-2 text-gray-900 text-sm outline-none transition-colors hover:bg-gray-100 focus:bg-gray-100 data-[state=checked]:bg-blue-50 data-[state=checked]:text-blue-900 dark:text-gray-100 dark:data-[state=checked]:bg-blue-900 dark:data-[state=checked]:text-blue-100 dark:focus:bg-gray-700 dark:hover:bg-gray-700"
+                      onSelect={() => {
+                        setSelectedBranchId(branch.id);
                       }}
-                    />
-                    <div
-                      className={classNames(
-                        '-translate-x-1/2 absolute left-1/2 z-10 w-1',
-                        {
-                          'top-1/2 bottom-0': index === 0,
-                          'top-0 bottom-1/2':
-                            index === selectedBranch.stationIds.length - 1,
-                          'top-0 bottom-0':
-                            index > 0 &&
-                            index < selectedBranch.stationIds.length - 1,
-                        },
+                    >
+                      <BranchItem branch={branch} />
+                      {selectedBranchId === branch.id && (
+                        <div className="ml-auto h-2 w-2 rounded-full bg-blue-600" />
                       )}
-                      style={{
-                        backgroundColor: line.color,
-                      }}
-                    />
-                  </div>
-                  <div className="relative flex items-center gap-x-2">
-                    <div className="flex items-center overflow-hidden rounded-md">
-                      {Object.entries(
-                        Object.fromEntries(
-                          stations[stationId].memberships.map((membership) => {
-                            const key = `${membership.code}@${membership.lineId}`;
-                            return [key, membership];
-                          }),
-                        ),
-                      )
-                        .sort((a, b) => {
-                          if (a[1].lineId === line.id) {
-                            return -1;
-                          }
-                          if (b[1].lineId === line.id) {
-                            return 1;
-                          }
-                          return 0;
-                        })
-                        .map(([key, membership]) => (
-                          <div
-                            key={key}
-                            className="z-10 flex h-4 w-10 items-center justify-center px-1.5"
-                            style={{
-                              backgroundColor: lines[membership.lineId].color,
-                            }}
-                          >
-                            <span className="font-semibold text-white text-xs leading-none">
-                              {membership.code}
-                            </span>
-                          </div>
-                        ))}
-                    </div>
-                    <div className="flex">
-                      <Link
-                        to="/{-$lang}/stations/$stationId"
-                        params={{ stationId }}
-                        className="group flex"
-                      >
-                        <span className="text-gray-800 text-sm group-hover:underline dark:text-gray-200">
-                          {getLocalizedTranslation(
-                            stations[stationId].name,
-                            intl.locale,
-                          )}
-                        </span>
-                      </Link>
-                    </div>
-                  </div>
-                </Fragment>
-              ))}
-            </div>
-            {!isExpanded && (
-              <div className="pointer-events-none absolute right-0 bottom-0 left-0 h-16 bg-gradient-to-t from-white via-white/80 to-transparent dark:from-gray-900/95 dark:via-gray-900/60 dark:to-transparent" />
-            )}
+                    </DropdownMenu.Item>
+                  ))}
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
+            </DropdownMenu.Root>
           </div>
-          <button
-            type="button"
-            onClick={() => setIsExpanded(!isExpanded)}
-            className="mt-2 flex items-center justify-center gap-2 rounded-md px-4 py-2 text-blue-600 text-sm hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/20"
-          >
-            {isExpanded ? (
-              <>
-                <FormattedMessage
-                  id="general.show_less"
-                  defaultMessage="Show less"
-                />
-                <ChevronUpIcon className="h-4 w-4" />
-              </>
-            ) : (
-              <>
-                <FormattedMessage
-                  id="general.show_more"
-                  defaultMessage="Show More"
-                />
-                <ChevronDownIcon className="h-4 w-4" />
-              </>
-            )}
-          </button>
-        </div>
-      )}
+          {selectedBranch != null && (
+            <div className="flex flex-col">
+              <div
+                className={classNames(
+                  'relative mt-4 overflow-hidden transition-all duration-300',
+                  {
+                    'max-h-96': !isExpanded,
+                    'max-h-none': isExpanded,
+                  },
+                )}
+              >
+                <div className="overflow-x-auto">
+                  <div
+                    key={selectedBranchId}
+                    className="grid min-w-[42rem] grid-cols-[minmax(12rem,1fr)_2.5rem_minmax(3rem,6rem)_2.5rem_minmax(12rem,1fr)] items-stretch"
+                  >
+                    {Array.from({ length: rowCount }).map((_, index) => {
+                      const leftStationId = loopColumns.leftStationIds[index];
+                      const rightStationId = loopColumns.rightStationIds[index];
+
+                      return (
+                        <Fragment
+                          key={`${leftStationId ?? 'empty'}-${rightStationId ?? 'empty'}`}
+                        >
+                          <div className="flex min-w-0 items-center pr-2">
+                            {leftStationId != null &&
+                              renderStationLabel(leftStationId, 'left')}
+                          </div>
+                          <div>
+                            {leftStationId != null && renderRailMarker(index)}
+                          </div>
+                          <div />
+                          <div>
+                            {rightStationId != null && renderRailMarker(index)}
+                          </div>
+                          <div className="flex min-w-0 items-center pl-2">
+                            {rightStationId != null &&
+                              renderStationLabel(rightStationId, 'right')}
+                          </div>
+                        </Fragment>
+                      );
+                    })}
+                    {loopColumns.rightStationIds.length > 0 && (
+                      <div className="col-start-2 col-end-5 h-8 px-[1.25rem]">
+                        <div
+                          className="h-full rounded-b-[2rem] border-r-4 border-b-4 border-l-4"
+                          style={{
+                            borderColor: line.color,
+                          }}
+                        />
+                      </div>
+                    )}
+                  </div>
+                </div>
+                {!isExpanded && (
+                  <div className="pointer-events-none absolute right-0 bottom-0 left-0 h-16 bg-gradient-to-t from-white via-white/80 to-transparent dark:from-gray-900/95 dark:via-gray-900/60 dark:to-transparent" />
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => setIsExpanded(!isExpanded)}
+                className="mt-2 flex items-center justify-center gap-2 rounded-md px-4 py-2 text-blue-600 text-sm hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/20"
+              >
+                {isExpanded ? (
+                  <>
+                    <FormattedMessage
+                      id="general.show_less"
+                      defaultMessage="Show less"
+                    />
+                    <ChevronUpIcon className="h-4 w-4" />
+                  </>
+                ) : (
+                  <>
+                    <FormattedMessage
+                      id="general.show_more"
+                      defaultMessage="Show More"
+                    />
+                    <ChevronDownIcon className="h-4 w-4" />
+                  </>
+                )}
+              </button>
+            </div>
+          )}
+        </Tabs.Content>
+
+        <Tabs.Content
+          value="system-map"
+          className="min-h-0 bg-gray-100 p-3 dark:bg-gray-800"
+        >
+          <StationMap
+            currentDate={DateTime.now().toISODate()}
+            mode={{
+              type: 'focused-line',
+              lineId: line.id,
+              branches,
+            }}
+          />
+        </Tabs.Content>
+      </Tabs.Root>
     </div>
   );
 };

--- a/app/routes/{-$lang}/lines/$lineId/components/LineSchematicCard/index.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/components/LineSchematicCard/index.tsx
@@ -38,13 +38,21 @@ export const LineSchematicCard: React.FC<Props> = (props) => {
 
   const loopColumns = useMemo(() => {
     if (selectedBranch == null) {
-      return { leftStationIds: [], rightStationIds: [] };
+      return { bottomStationId: null, leftStationIds: [], rightStationIds: [] };
     }
 
-    const midpoint = Math.ceil(selectedBranch.stationIds.length / 2);
+    const hasBottomStation = selectedBranch.stationIds.length % 2 === 1;
+    const sideCount = Math.floor(selectedBranch.stationIds.length / 2);
+    const rightStartIndex = hasBottomStation ? sideCount + 1 : sideCount;
+
     return {
-      leftStationIds: selectedBranch.stationIds.slice(0, midpoint),
-      rightStationIds: selectedBranch.stationIds.slice(midpoint).reverse(),
+      bottomStationId: hasBottomStation
+        ? selectedBranch.stationIds[sideCount]
+        : null,
+      leftStationIds: selectedBranch.stationIds.slice(0, sideCount),
+      rightStationIds: selectedBranch.stationIds
+        .slice(rightStartIndex)
+        .reverse(),
     };
   }, [selectedBranch]);
 
@@ -255,7 +263,7 @@ export const LineSchematicCard: React.FC<Props> = (props) => {
                 className={classNames(
                   'relative mt-4 overflow-hidden transition-all duration-300',
                   {
-                    'max-h-[60rem]': !isExpanded,
+                    'max-h-96 md:max-h-none': !isExpanded,
                     'max-h-none': isExpanded,
                   },
                 )}
@@ -313,26 +321,64 @@ export const LineSchematicCard: React.FC<Props> = (props) => {
                         </Fragment>
                       );
                     })}
-                    {loopColumns.rightStationIds.length > 0 && (
-                      <div className="col-start-2 col-end-5 h-8 px-[1.25rem]">
-                        <div
-                          className="h-full rounded-b-[2rem] border-r-4 border-b-4 border-l-4"
-                          style={{
-                            borderColor: line.color,
-                          }}
-                        />
+                    {(loopColumns.rightStationIds.length > 0 ||
+                      loopColumns.bottomStationId != null) && (
+                      <div
+                        className={classNames(
+                          'relative col-start-2 col-end-5',
+                          {
+                            'h-8': loopColumns.bottomStationId == null,
+                            'h-10': loopColumns.bottomStationId != null,
+                          },
+                        )}
+                      >
+                        <svg
+                          aria-hidden="true"
+                          className="absolute inset-y-0 right-[1.25rem] left-[1.25rem] overflow-visible"
+                          preserveAspectRatio="none"
+                          viewBox="0 0 100 40"
+                        >
+                          <path
+                            d="M 0 0 V 12 C 0 26 12 32 28 32 H 72 C 88 32 100 26 100 12 V 0"
+                            fill="none"
+                            stroke={line.color}
+                            strokeLinecap="butt"
+                            strokeLinejoin="round"
+                            strokeWidth="4"
+                            vectorEffect="non-scaling-stroke"
+                          />
+                          {loopColumns.bottomStationId != null && (
+                            <circle
+                              className="fill-white dark:fill-gray-900"
+                              cx="50"
+                              cy="32"
+                              r="6"
+                              stroke={line.color}
+                              strokeWidth="4"
+                              vectorEffect="non-scaling-stroke"
+                            />
+                          )}
+                        </svg>
+                      </div>
+                    )}
+                    {loopColumns.bottomStationId != null && (
+                      <div className="col-start-1 col-end-6 flex justify-center pt-1">
+                        {renderStationLabel(
+                          loopColumns.bottomStationId,
+                          'right',
+                        )}
                       </div>
                     )}
                   </div>
                 </div>
                 {!isExpanded && (
-                  <div className="pointer-events-none absolute right-0 bottom-0 left-0 h-16 bg-gradient-to-t from-white via-white/80 to-transparent dark:from-gray-900/95 dark:via-gray-900/60 dark:to-transparent" />
+                  <div className="pointer-events-none absolute right-0 bottom-0 left-0 h-16 bg-gradient-to-t from-white via-white/80 to-transparent md:hidden dark:from-gray-900/95 dark:via-gray-900/60 dark:to-transparent" />
                 )}
               </div>
               <button
                 type="button"
                 onClick={() => setIsExpanded(!isExpanded)}
-                className="mt-2 flex items-center justify-center gap-2 rounded-md px-4 py-2 text-blue-600 text-sm hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/20"
+                className="mt-2 flex items-center justify-center gap-2 rounded-md px-4 py-2 text-blue-600 text-sm hover:bg-blue-50 md:hidden dark:text-blue-400 dark:hover:bg-blue-900/20"
               >
                 {isExpanded ? (
                   <>

--- a/app/routes/{-$lang}/lines/$lineId/components/LineSchematicCard/index.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/components/LineSchematicCard/index.tsx
@@ -104,7 +104,7 @@ export const LineSchematicCard: React.FC<Props> = (props) => {
 
     return (
       <div
-        className={classNames('flex items-center gap-x-2', {
+        className={classNames('flex w-full items-center gap-x-2', {
           'justify-end text-right': side === 'left',
         })}
       >
@@ -136,6 +136,28 @@ export const LineSchematicCard: React.FC<Props> = (props) => {
             </Link>
           </>
         )}
+      </div>
+    );
+  };
+
+  const renderBottomStationLabel = (stationId: string) => {
+    const stationName = getLocalizedTranslation(
+      stations[stationId].name,
+      intl.locale,
+    );
+
+    return (
+      <div className="flex flex-col items-center gap-y-1 text-center">
+        {renderCodePills(stationId)}
+        <Link
+          to="/{-$lang}/stations/$stationId"
+          params={{ stationId }}
+          className="group min-w-0"
+        >
+          <span className="text-gray-800 text-sm group-hover:underline dark:text-gray-200">
+            {stationName}
+          </span>
+        </Link>
       </div>
     );
   };
@@ -301,7 +323,7 @@ export const LineSchematicCard: React.FC<Props> = (props) => {
                         <Fragment
                           key={`${leftStationId ?? 'empty'}-${rightStationId ?? 'empty'}`}
                         >
-                          <div className="flex min-w-0 items-center pr-2">
+                          <div className="flex min-w-0 items-center justify-end pr-2">
                             {hasLeftStation &&
                               renderStationLabel(leftStationId, 'left')}
                           </div>
@@ -362,11 +384,8 @@ export const LineSchematicCard: React.FC<Props> = (props) => {
                       </div>
                     )}
                     {loopColumns.bottomStationId != null && (
-                      <div className="col-start-1 col-end-6 flex justify-center pt-1">
-                        {renderStationLabel(
-                          loopColumns.bottomStationId,
-                          'right',
-                        )}
+                      <div className="col-start-1 col-end-6 flex justify-center pt-4">
+                        {renderBottomStationLabel(loopColumns.bottomStationId)}
                       </div>
                     )}
                   </div>

--- a/app/routes/{-$lang}/lines/$lineId/components/LineSchematicCard/index.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/components/LineSchematicCard/index.tsx
@@ -384,7 +384,7 @@ export const LineSchematicCard: React.FC<Props> = (props) => {
                       </div>
                     )}
                     {loopColumns.bottomStationId != null && (
-                      <div className="col-start-1 col-end-6 flex justify-center pt-4">
+                      <div className="col-start-1 col-end-6 flex justify-center pt-6">
                         {renderBottomStationLabel(loopColumns.bottomStationId)}
                       </div>
                     )}

--- a/app/routes/{-$lang}/lines/$lineId/components/LineSchematicCard/index.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/components/LineSchematicCard/index.tsx
@@ -132,21 +132,44 @@ export const LineSchematicCard: React.FC<Props> = (props) => {
     );
   };
 
-  const renderRailMarker = (index: number) => (
+  const renderLoopRailMarker = (index: number, hasStation: boolean) => (
     <div className="relative flex h-14 items-center justify-center">
       <div
         className={classNames('-translate-x-1/2 absolute left-1/2 z-10 w-1', {
-          'top-1/2 bottom-0': index === 0,
-          'top-0 bottom-0': index > 0,
+          'top-1/2 bottom-0': index === 0 && hasStation,
+          'top-0 bottom-0': index > 0 || !hasStation,
         })}
         style={{
           backgroundColor: line.color,
         }}
       />
+      {hasStation && (
+        <div
+          className="z-20 size-4 rounded-full border-4 bg-white dark:bg-gray-900"
+          style={{
+            borderColor: line.color,
+          }}
+        />
+      )}
+    </div>
+  );
+
+  const renderStraightRailMarker = (index: number, total: number) => (
+    <div className="relative flex h-12 items-center justify-center">
       <div
         className="z-20 size-4 rounded-full border-4 bg-white dark:bg-gray-900"
         style={{
           borderColor: line.color,
+        }}
+      />
+      <div
+        className={classNames('-translate-x-1/2 absolute left-1/2 z-10 w-1', {
+          'top-1/2 bottom-0': index === 0,
+          'top-0 bottom-1/2': index === total - 1,
+          'top-0 bottom-0': index > 0 && index < total - 1,
+        })}
+        style={{
+          backgroundColor: line.color,
         }}
       />
     </div>
@@ -237,32 +260,54 @@ export const LineSchematicCard: React.FC<Props> = (props) => {
                   },
                 )}
               >
-                <div className="overflow-x-auto">
+                <div className="md:hidden">
+                  <div
+                    key={`${selectedBranchId}-mobile`}
+                    className="grid grid-cols-[2.5rem_minmax(0,1fr)] gap-x-3"
+                  >
+                    {selectedBranch.stationIds.map((stationId, index) => (
+                      <Fragment key={stationId}>
+                        {renderStraightRailMarker(
+                          index,
+                          selectedBranch.stationIds.length,
+                        )}
+                        <div className="flex min-w-0 items-center">
+                          {renderStationLabel(stationId, 'right')}
+                        </div>
+                      </Fragment>
+                    ))}
+                  </div>
+                </div>
+                <div className="hidden overflow-x-auto md:block">
                   <div
                     key={selectedBranchId}
-                    className="grid min-w-[42rem] grid-cols-[minmax(12rem,1fr)_2.5rem_minmax(3rem,6rem)_2.5rem_minmax(12rem,1fr)] items-stretch"
+                    className="grid grid-cols-[minmax(12rem,1fr)_2.5rem_minmax(3rem,6rem)_2.5rem_minmax(12rem,1fr)] items-stretch"
                   >
                     {Array.from({ length: rowCount }).map((_, index) => {
                       const leftStationId = loopColumns.leftStationIds[index];
                       const rightStationId = loopColumns.rightStationIds[index];
+                      const hasLeftStation = leftStationId != null;
+                      const hasRightStation = rightStationId != null;
 
                       return (
                         <Fragment
                           key={`${leftStationId ?? 'empty'}-${rightStationId ?? 'empty'}`}
                         >
                           <div className="flex min-w-0 items-center pr-2">
-                            {leftStationId != null &&
+                            {hasLeftStation &&
                               renderStationLabel(leftStationId, 'left')}
                           </div>
                           <div>
-                            {leftStationId != null && renderRailMarker(index)}
+                            {(hasLeftStation || index > 0) &&
+                              renderLoopRailMarker(index, hasLeftStation)}
                           </div>
                           <div />
                           <div>
-                            {rightStationId != null && renderRailMarker(index)}
+                            {(hasRightStation || index > 0) &&
+                              renderLoopRailMarker(index, hasRightStation)}
                           </div>
                           <div className="flex min-w-0 items-center pl-2">
-                            {rightStationId != null &&
+                            {hasRightStation &&
                               renderStationLabel(rightStationId, 'right')}
                           </div>
                         </Fragment>

--- a/app/routes/{-$lang}/lines/$lineId/components/LineSchematicCard/index.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/components/LineSchematicCard/index.tsx
@@ -1,16 +1,9 @@
-import {
-  ChevronDownIcon,
-  ChevronUpIcon,
-  ListBulletIcon,
-  MapIcon,
-} from '@heroicons/react/24/outline';
+import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/outline';
 import { Link } from '@tanstack/react-router';
 import classNames from 'classnames';
-import { DateTime } from 'luxon';
-import { DropdownMenu, Tabs } from 'radix-ui';
+import { DropdownMenu } from 'radix-ui';
 import { Fragment, useMemo, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { StationMap } from '~/components/StationMap';
 import { useIncludedEntities } from '~/contexts/IncludedEntities';
 import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 import type { LineBranch } from '~/util/db.queries';
@@ -213,228 +206,181 @@ export const LineSchematicCard: React.FC<Props> = (props) => {
           defaultMessage="Line Schematic"
         />
       </span>
-      <Tabs.Root
-        defaultValue="schematic"
-        className="mt-2 flex min-h-0 flex-col"
-      >
-        <Tabs.List className="mb-4 inline-flex self-start rounded-lg bg-gray-100 p-1 dark:bg-gray-800">
-          <Tabs.Trigger
-            value="schematic"
-            className="flex items-center gap-2 rounded-md px-3 py-1.5 font-medium text-gray-600 text-sm transition-colors data-[state=active]:bg-white data-[state=active]:text-gray-900 data-[state=active]:shadow-sm dark:text-gray-300 dark:data-[state=active]:bg-gray-700 dark:data-[state=active]:text-white"
-          >
-            <ListBulletIcon className="h-4 w-4" />
-            <FormattedMessage
-              id="general.line_schematic"
-              defaultMessage="Line Schematic"
-            />
-          </Tabs.Trigger>
-          <Tabs.Trigger
-            value="system-map"
-            className="flex items-center gap-2 rounded-md px-3 py-1.5 font-medium text-gray-600 text-sm transition-colors data-[state=active]:bg-white data-[state=active]:text-gray-900 data-[state=active]:shadow-sm dark:text-gray-300 dark:data-[state=active]:bg-gray-700 dark:data-[state=active]:text-white"
-          >
-            <MapIcon className="h-4 w-4" />
-            <FormattedMessage
-              id="general.system_map"
-              defaultMessage="System Map"
-            />
-          </Tabs.Trigger>
-        </Tabs.List>
-
-        <Tabs.Content value="schematic" className="min-h-0">
-          <div className="min-w-64 md:self-start">
-            <DropdownMenu.Root>
-              <DropdownMenu.Trigger className="flex w-full items-center justify-between rounded-lg border border-gray-300 bg-white px-4 py-1 text-left font-medium text-gray-900 text-sm shadow-sm transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700">
-                <span>
-                  {selectedBranch != null ? (
-                    <BranchItem branch={selectedBranch} />
-                  ) : (
-                    <FormattedMessage
-                      id="general.select_branch"
-                      defaultMessage="Select Branch"
-                    />
-                  )}
-                </span>
-                <ChevronDownIcon className="ml-2 h-5 w-5 text-gray-400" />
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Portal>
-                <DropdownMenu.Content
-                  className="z-50 w-[var(--radix-dropdown-menu-trigger-width)] overflow-hidden rounded-lg border border-gray-300 bg-white p-1 shadow-lg dark:border-gray-600 dark:bg-gray-800"
-                  sideOffset={5}
+      <div className="mt-2 min-w-64 md:self-start">
+        <DropdownMenu.Root>
+          <DropdownMenu.Trigger className="flex w-full items-center justify-between rounded-lg border border-gray-300 bg-white px-4 py-1 text-left font-medium text-gray-900 text-sm shadow-sm transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700">
+            <span>
+              {selectedBranch != null ? (
+                <BranchItem branch={selectedBranch} />
+              ) : (
+                <FormattedMessage
+                  id="general.select_branch"
+                  defaultMessage="Select Branch"
+                />
+              )}
+            </span>
+            <ChevronDownIcon className="ml-2 h-5 w-5 text-gray-400" />
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Portal>
+            <DropdownMenu.Content
+              className="z-50 w-[var(--radix-dropdown-menu-trigger-width)] overflow-hidden rounded-lg border border-gray-300 bg-white p-1 shadow-lg dark:border-gray-600 dark:bg-gray-800"
+              sideOffset={5}
+            >
+              {branches.map((branch) => (
+                <DropdownMenu.Item
+                  key={branch.id}
+                  className="relative flex cursor-pointer select-none items-center rounded-md px-3 py-2 text-gray-900 text-sm outline-none transition-colors hover:bg-gray-100 focus:bg-gray-100 data-[state=checked]:bg-blue-50 data-[state=checked]:text-blue-900 dark:text-gray-100 dark:data-[state=checked]:bg-blue-900 dark:data-[state=checked]:text-blue-100 dark:focus:bg-gray-700 dark:hover:bg-gray-700"
+                  onSelect={() => {
+                    setSelectedBranchId(branch.id);
+                  }}
                 >
-                  {branches.map((branch) => (
-                    <DropdownMenu.Item
-                      key={branch.id}
-                      className="relative flex cursor-pointer select-none items-center rounded-md px-3 py-2 text-gray-900 text-sm outline-none transition-colors hover:bg-gray-100 focus:bg-gray-100 data-[state=checked]:bg-blue-50 data-[state=checked]:text-blue-900 dark:text-gray-100 dark:data-[state=checked]:bg-blue-900 dark:data-[state=checked]:text-blue-100 dark:focus:bg-gray-700 dark:hover:bg-gray-700"
-                      onSelect={() => {
-                        setSelectedBranchId(branch.id);
-                      }}
-                    >
-                      <BranchItem branch={branch} />
-                      {selectedBranchId === branch.id && (
-                        <div className="ml-auto h-2 w-2 rounded-full bg-blue-600" />
-                      )}
-                    </DropdownMenu.Item>
-                  ))}
-                </DropdownMenu.Content>
-              </DropdownMenu.Portal>
-            </DropdownMenu.Root>
-          </div>
-          {selectedBranch != null && (
-            <div className="flex flex-col">
+                  <BranchItem branch={branch} />
+                  {selectedBranchId === branch.id && (
+                    <div className="ml-auto h-2 w-2 rounded-full bg-blue-600" />
+                  )}
+                </DropdownMenu.Item>
+              ))}
+            </DropdownMenu.Content>
+          </DropdownMenu.Portal>
+        </DropdownMenu.Root>
+      </div>
+      {selectedBranch != null && (
+        <div className="flex flex-col">
+          <div
+            className={classNames(
+              'relative mt-4 overflow-hidden transition-all duration-300',
+              {
+                'max-h-96 md:max-h-none': !isExpanded,
+                'max-h-none': isExpanded,
+              },
+            )}
+          >
+            <div className="md:hidden">
               <div
-                className={classNames(
-                  'relative mt-4 overflow-hidden transition-all duration-300',
-                  {
-                    'max-h-96 md:max-h-none': !isExpanded,
-                    'max-h-none': isExpanded,
-                  },
-                )}
+                key={`${selectedBranchId}-mobile`}
+                className="grid grid-cols-[2.5rem_minmax(0,1fr)] gap-x-3"
               >
-                <div className="md:hidden">
-                  <div
-                    key={`${selectedBranchId}-mobile`}
-                    className="grid grid-cols-[2.5rem_minmax(0,1fr)] gap-x-3"
-                  >
-                    {selectedBranch.stationIds.map((stationId, index) => (
-                      <Fragment key={stationId}>
-                        {renderStraightRailMarker(
-                          index,
-                          selectedBranch.stationIds.length,
-                        )}
-                        <div className="flex min-w-0 items-center">
-                          {renderStationLabel(stationId, 'right')}
-                        </div>
-                      </Fragment>
-                    ))}
-                  </div>
-                </div>
-                <div className="hidden overflow-x-auto md:block">
-                  <div
-                    key={selectedBranchId}
-                    className="grid grid-cols-[minmax(12rem,1fr)_2.5rem_minmax(3rem,6rem)_2.5rem_minmax(12rem,1fr)] items-stretch"
-                  >
-                    {Array.from({ length: rowCount }).map((_, index) => {
-                      const leftStationId = loopColumns.leftStationIds[index];
-                      const rightStationId = loopColumns.rightStationIds[index];
-                      const hasLeftStation = leftStationId != null;
-                      const hasRightStation = rightStationId != null;
+                {selectedBranch.stationIds.map((stationId, index) => (
+                  <Fragment key={stationId}>
+                    {renderStraightRailMarker(
+                      index,
+                      selectedBranch.stationIds.length,
+                    )}
+                    <div className="flex min-w-0 items-center">
+                      {renderStationLabel(stationId, 'right')}
+                    </div>
+                  </Fragment>
+                ))}
+              </div>
+            </div>
+            <div className="hidden overflow-x-auto md:block">
+              <div
+                key={selectedBranchId}
+                className="grid grid-cols-[minmax(12rem,1fr)_2.5rem_minmax(3rem,6rem)_2.5rem_minmax(12rem,1fr)] items-stretch"
+              >
+                {Array.from({ length: rowCount }).map((_, index) => {
+                  const leftStationId = loopColumns.leftStationIds[index];
+                  const rightStationId = loopColumns.rightStationIds[index];
+                  const hasLeftStation = leftStationId != null;
+                  const hasRightStation = rightStationId != null;
 
-                      return (
-                        <Fragment
-                          key={`${leftStationId ?? 'empty'}-${rightStationId ?? 'empty'}`}
-                        >
-                          <div className="flex min-w-0 items-center justify-end pr-2">
-                            {hasLeftStation &&
-                              renderStationLabel(leftStationId, 'left')}
-                          </div>
-                          <div>
-                            {(hasLeftStation || index > 0) &&
-                              renderLoopRailMarker(index, hasLeftStation)}
-                          </div>
-                          <div />
-                          <div>
-                            {(hasRightStation || index > 0) &&
-                              renderLoopRailMarker(index, hasRightStation)}
-                          </div>
-                          <div className="flex min-w-0 items-center pl-2">
-                            {hasRightStation &&
-                              renderStationLabel(rightStationId, 'right')}
-                          </div>
-                        </Fragment>
-                      );
+                  return (
+                    <Fragment
+                      key={`${leftStationId ?? 'empty'}-${rightStationId ?? 'empty'}`}
+                    >
+                      <div className="flex min-w-0 items-center justify-end pr-2">
+                        {hasLeftStation &&
+                          renderStationLabel(leftStationId, 'left')}
+                      </div>
+                      <div>
+                        {(hasLeftStation || index > 0) &&
+                          renderLoopRailMarker(index, hasLeftStation)}
+                      </div>
+                      <div />
+                      <div>
+                        {(hasRightStation || index > 0) &&
+                          renderLoopRailMarker(index, hasRightStation)}
+                      </div>
+                      <div className="flex min-w-0 items-center pl-2">
+                        {hasRightStation &&
+                          renderStationLabel(rightStationId, 'right')}
+                      </div>
+                    </Fragment>
+                  );
+                })}
+                {(loopColumns.rightStationIds.length > 0 ||
+                  loopColumns.bottomStationId != null) && (
+                  <div
+                    className={classNames('relative col-start-2 col-end-5', {
+                      'h-8': loopColumns.bottomStationId == null,
+                      'h-10': loopColumns.bottomStationId != null,
                     })}
-                    {(loopColumns.rightStationIds.length > 0 ||
-                      loopColumns.bottomStationId != null) && (
-                      <div
-                        className={classNames(
-                          'relative col-start-2 col-end-5',
-                          {
-                            'h-8': loopColumns.bottomStationId == null,
-                            'h-10': loopColumns.bottomStationId != null,
-                          },
-                        )}
-                      >
-                        <svg
-                          aria-hidden="true"
-                          className="absolute inset-y-0 right-[1.25rem] left-[1.25rem] overflow-visible"
-                          preserveAspectRatio="none"
-                          viewBox="0 0 100 40"
-                        >
-                          <path
-                            d="M 0 0 V 12 C 0 26 12 32 28 32 H 72 C 88 32 100 26 100 12 V 0"
-                            fill="none"
-                            stroke={line.color}
-                            strokeLinecap="butt"
-                            strokeLinejoin="round"
-                            strokeWidth="4"
-                            vectorEffect="non-scaling-stroke"
-                          />
-                          {loopColumns.bottomStationId != null && (
-                            <circle
-                              className="fill-white dark:fill-gray-900"
-                              cx="50"
-                              cy="32"
-                              r="6"
-                              stroke={line.color}
-                              strokeWidth="4"
-                              vectorEffect="non-scaling-stroke"
-                            />
-                          )}
-                        </svg>
-                      </div>
-                    )}
-                    {loopColumns.bottomStationId != null && (
-                      <div className="col-start-1 col-end-6 flex justify-center pt-6">
-                        {renderBottomStationLabel(loopColumns.bottomStationId)}
-                      </div>
-                    )}
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="absolute inset-y-0 right-[1.25rem] left-[1.25rem] overflow-visible"
+                      preserveAspectRatio="none"
+                      viewBox="0 0 100 40"
+                    >
+                      <path
+                        d="M 0 0 V 12 C 0 26 12 32 28 32 H 72 C 88 32 100 26 100 12 V 0"
+                        fill="none"
+                        stroke={line.color}
+                        strokeLinecap="butt"
+                        strokeLinejoin="round"
+                        strokeWidth="4"
+                        vectorEffect="non-scaling-stroke"
+                      />
+                      {loopColumns.bottomStationId != null && (
+                        <circle
+                          className="fill-white dark:fill-gray-900"
+                          cx="50"
+                          cy="32"
+                          r="6"
+                          stroke={line.color}
+                          strokeWidth="4"
+                          vectorEffect="non-scaling-stroke"
+                        />
+                      )}
+                    </svg>
                   </div>
-                </div>
-                {!isExpanded && (
-                  <div className="pointer-events-none absolute right-0 bottom-0 left-0 h-16 bg-gradient-to-t from-white via-white/80 to-transparent md:hidden dark:from-gray-900/95 dark:via-gray-900/60 dark:to-transparent" />
+                )}
+                {loopColumns.bottomStationId != null && (
+                  <div className="col-start-1 col-end-6 flex justify-center pt-6">
+                    {renderBottomStationLabel(loopColumns.bottomStationId)}
+                  </div>
                 )}
               </div>
-              <button
-                type="button"
-                onClick={() => setIsExpanded(!isExpanded)}
-                className="mt-2 flex items-center justify-center gap-2 rounded-md px-4 py-2 text-blue-600 text-sm hover:bg-blue-50 md:hidden dark:text-blue-400 dark:hover:bg-blue-900/20"
-              >
-                {isExpanded ? (
-                  <>
-                    <FormattedMessage
-                      id="general.show_less"
-                      defaultMessage="Show less"
-                    />
-                    <ChevronUpIcon className="h-4 w-4" />
-                  </>
-                ) : (
-                  <>
-                    <FormattedMessage
-                      id="general.show_more"
-                      defaultMessage="Show More"
-                    />
-                    <ChevronDownIcon className="h-4 w-4" />
-                  </>
-                )}
-              </button>
             </div>
-          )}
-        </Tabs.Content>
-
-        <Tabs.Content
-          value="system-map"
-          className="min-h-0 bg-gray-100 p-3 dark:bg-gray-800"
-        >
-          <StationMap
-            currentDate={DateTime.now().toISODate()}
-            mode={{
-              type: 'focused-line',
-              lineId: line.id,
-              branches,
-            }}
-          />
-        </Tabs.Content>
-      </Tabs.Root>
+            {!isExpanded && (
+              <div className="pointer-events-none absolute right-0 bottom-0 left-0 h-16 bg-gradient-to-t from-white via-white/80 to-transparent md:hidden dark:from-gray-900/95 dark:via-gray-900/60 dark:to-transparent" />
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="mt-2 flex items-center justify-center gap-2 rounded-md px-4 py-2 text-blue-600 text-sm hover:bg-blue-50 md:hidden dark:text-blue-400 dark:hover:bg-blue-900/20"
+          >
+            {isExpanded ? (
+              <>
+                <FormattedMessage
+                  id="general.show_less"
+                  defaultMessage="Show less"
+                />
+                <ChevronUpIcon className="h-4 w-4" />
+              </>
+            ) : (
+              <>
+                <FormattedMessage
+                  id="general.show_more"
+                  defaultMessage="Show More"
+                />
+                <ChevronDownIcon className="h-4 w-4" />
+              </>
+            )}
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/app/routes/{-$lang}/lines/$lineId/components/LineSchematicCard/index.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/components/LineSchematicCard/index.tsx
@@ -232,7 +232,7 @@ export const LineSchematicCard: React.FC<Props> = (props) => {
                 className={classNames(
                   'relative mt-4 overflow-hidden transition-all duration-300',
                   {
-                    'max-h-96': !isExpanded,
+                    'max-h-[60rem]': !isExpanded,
                     'max-h-none': isExpanded,
                   },
                 )}

--- a/app/routes/{-$lang}/lines/$lineId/components/LineSystemMapCard.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/components/LineSystemMapCard.tsx
@@ -1,0 +1,32 @@
+import { DateTime } from 'luxon';
+import { FormattedMessage } from 'react-intl';
+import { StationMap } from '~/components/StationMap';
+import type { LineBranch } from '~/util/db.queries';
+import type { Line } from '~/types';
+
+interface Props {
+  line: Line;
+  branches: LineBranch[];
+}
+
+export const LineSystemMapCard: React.FC<Props> = (props) => {
+  const { line, branches } = props;
+
+  return (
+    <div className="flex flex-col rounded-lg border border-gray-300 p-6 text-gray-800 shadow-lg md:col-span-4 dark:border-gray-700 dark:text-gray-200">
+      <span className="mb-2 font-semibold text-base text-gray-900 dark:text-white">
+        <FormattedMessage id="general.system_map" defaultMessage="System Map" />
+      </span>
+      <div className="min-h-0 bg-gray-100 p-3 dark:bg-gray-800">
+        <StationMap
+          currentDate={DateTime.now().toISODate()}
+          mode={{
+            type: 'focused-line',
+            lineId: line.id,
+            branches,
+          }}
+        />
+      </div>
+    </div>
+  );
+};

--- a/app/routes/{-$lang}/lines/$lineId/index.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/index.tsx
@@ -17,6 +17,7 @@ import { getLineProfileFn } from '~/util/lines.functions';
 import { CountTrendCards } from './components/CountTrendCards';
 import { CurrentStatusCard } from './components/CurrentStatusCard';
 import { LineSchematicCard } from './components/LineSchematicCard';
+import { LineSystemMapCard } from './components/LineSystemMapCard';
 import { NextMaintenanceCard } from './components/NextMaintenanceCard';
 import { QuickFactsCard } from './components/QuickFactsCard';
 import { RecentIssuesSection } from './components/RecentIssuesSection';
@@ -303,6 +304,8 @@ function ComponentPage() {
         <LineSchematicCard line={line} branches={branches} />
 
         <QuickFactsCard line={line} branches={branches} />
+
+        <LineSystemMapCard line={line} branches={branches} />
 
         {lineProfile.lineSummary.status !== 'future_service' && (
           <UptimeRatioTrendCards

--- a/app/routes/{-$lang}/system-map.tsx
+++ b/app/routes/{-$lang}/system-map.tsx
@@ -131,8 +131,11 @@ function SystemMapPage() {
 
         <div className="flex flex-col bg-gray-100 p-4 dark:bg-gray-800">
           <StationMap
-            branchesAffected={branchesAffected}
             currentDate={DateTime.now().toISODate()}
+            mode={{
+              type: 'network',
+              branchesAffected,
+            }}
           />
 
           <div className="mt-2 flex bg-gray-50 px-4 py-2.5 dark:bg-gray-900">


### PR DESCRIPTION
## Summary

- Add a focused line mode to the system map so the selected line stays highlighted while the rest of the network is greyed out.
- Update the line schematic to use a desktop loop layout, including balanced odd station counts and mobile fallback to the straight layout.
- Move the focused system map into its own card below Quick Facts, keeping the Line Schematic card dedicated to the schematic.

## Validation

- `npm run verify`
- Browser checked `http://localhost:3000/lines/BTL` at desktop and mobile viewport sizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a System Map card on line detail pages displaying focused line visualizations with relevant station highlighting.

* **Improvements**
  * Enhanced schematic rendering with optimized mobile and desktop layouts.
  * Improved map display modes for better visual presentation across different contexts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-site/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->