### PR TITLE
fix: unify db diagnostics

### DIFF
--- a/app/util/dbDiagnostics.test.ts
+++ b/app/util/dbDiagnostics.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DbDiagnosticError,
+  formatDbDiagnosticMessage,
+  withDbDiagnostics,
+} from './dbDiagnostics';
+
+describe('formatDbDiagnosticMessage', () => {
+  it('includes context and Postgres error fields from the cause chain', () => {
+    const error = new Error('Failed query', {
+      cause: {
+        name: 'DatabaseError',
+        message: 'invalid byte sequence for encoding "UTF8"',
+        code: '22021',
+        severity: 'ERROR',
+        table: 'public_holidays',
+        where: 'unnamed portal parameter $4',
+      },
+    });
+
+    expect(
+      formatDbDiagnosticMessage(
+        {
+          prefix: 'PUBLIC_HOLIDAYS_DB_ERROR',
+          operation: 'sync',
+          table: 'public_holidays',
+          rowCount: 80,
+          sample: ['sg-public-holiday-2020-01-01-new-year-s-day'],
+        },
+        error,
+      ),
+    ).toBe(
+      [
+        '[PUBLIC_HOLIDAYS_DB_ERROR] sync failed on public_holidays',
+        'row_count=80',
+        'sample=sg-public-holiday-2020-01-01-new-year-s-day',
+        'cause[0] Error: Failed query',
+        'cause[1] DatabaseError: invalid byte sequence for encoding "UTF8" (code=22021, severity=ERROR, table=public_holidays, where=unnamed portal parameter $4)',
+      ].join('\n'),
+    );
+  });
+});
+
+describe('withDbDiagnostics', () => {
+  it('logs and wraps failed operations', async () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const cause = new Error('boom');
+
+    await expect(() =>
+      withDbDiagnostics(
+        {
+          prefix: 'TEST_DB_ERROR',
+          operation: 'insert rows',
+          table: 'test_table',
+        },
+        async () => {
+          throw cause;
+        },
+        { errorName: 'TestDbError' },
+      ),
+    ).rejects.toMatchObject({
+      name: 'TestDbError',
+      cause,
+    });
+
+    expect(consoleError).toHaveBeenCalledWith(
+      [
+        '[TEST_DB_ERROR] insert rows failed on test_table',
+        'cause[0] Error: boom',
+      ].join('\n'),
+    );
+    consoleError.mockRestore();
+  });
+
+  it('does not double-wrap diagnostic errors', async () => {
+    const error = new DbDiagnosticError('already wrapped', {
+      cause: new Error('boom'),
+      name: 'ExistingDbError',
+    });
+
+    await expect(() =>
+      withDbDiagnostics(
+        {
+          prefix: 'TEST_DB_ERROR',
+          operation: 'insert rows',
+          table: 'test_table',
+        },
+        async () => {
+          throw error;
+        },
+      ),
+    ).rejects.toBe(error);
+  });
+});

--- a/app/util/dbDiagnostics.ts
+++ b/app/util/dbDiagnostics.ts
@@ -1,0 +1,116 @@
+export type DbDiagnosticContext = {
+  prefix: string;
+  operation: string;
+  table: string;
+  rowCount?: number;
+  sample?: readonly string[];
+};
+
+export class DbDiagnosticError extends Error {
+  constructor(message: string, options: { cause: unknown; name?: string }) {
+    super(message, { cause: options.cause });
+    this.name = options.name ?? 'DbDiagnosticError';
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function stringifyErrorField(value: unknown): string | null {
+  if (value == null) return null;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return null;
+}
+
+function readErrorField(error: unknown, field: string): string | null {
+  if (!isRecord(error)) return null;
+  return stringifyErrorField(error[field]);
+}
+
+export function formatErrorCauseChain(error: unknown): string[] {
+  const lines: string[] = [];
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+
+  for (let depth = 0; current != null && depth < 6; depth++) {
+    if (seen.has(current)) break;
+    seen.add(current);
+
+    const name =
+      current instanceof Error
+        ? current.name
+        : (readErrorField(current, 'name') ?? typeof current);
+    const message =
+      current instanceof Error
+        ? current.message
+        : (readErrorField(current, 'message') ?? String(current));
+    const fields = [
+      'code',
+      'severity',
+      'schema',
+      'table',
+      'column',
+      'constraint',
+      'detail',
+      'hint',
+      'where',
+      'routine',
+    ]
+      .map((field) => {
+        const value = readErrorField(current, field);
+        return value == null ? null : `${field}=${value}`;
+      })
+      .filter((field): field is string => field != null);
+
+    lines.push(
+      `cause[${depth}] ${name}: ${message}${
+        fields.length > 0 ? ` (${fields.join(', ')})` : ''
+      }`,
+    );
+
+    current = isRecord(current) ? current.cause : null;
+  }
+
+  return lines;
+}
+
+export function formatDbDiagnosticMessage(
+  context: DbDiagnosticContext,
+  error: unknown,
+): string {
+  const lines = [
+    `[${context.prefix}] ${context.operation} failed on ${context.table}`,
+  ];
+  if (context.rowCount != null) {
+    lines.push(`row_count=${context.rowCount}`);
+  }
+  if (context.sample != null && context.sample.length > 0) {
+    lines.push(`sample=${context.sample.join(' | ')}`);
+  }
+  lines.push(...formatErrorCauseChain(error));
+  return lines.join('\n');
+}
+
+export async function withDbDiagnostics<T>(
+  context: DbDiagnosticContext,
+  operation: () => Promise<T>,
+  options: { errorName?: string } = {},
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (error instanceof DbDiagnosticError) {
+      throw error;
+    }
+    const message = formatDbDiagnosticMessage(context, error);
+    console.error(message);
+    throw new DbDiagnosticError(message, {
+      cause: error,
+      name: options.errorName,
+    });
+  }
+}

--- a/app/workflows/publicHolidays/helpers/syncPublicHolidays.test.ts
+++ b/app/workflows/publicHolidays/helpers/syncPublicHolidays.test.ts
@@ -16,8 +16,18 @@ describe('normalizeDataGovPublicHolidayRecord', () => {
       id: 'sg-public-holiday-2026-05-01-labour-day',
       date: '2026-05-01',
       holidayName: 'Labour Day',
-      hash: '2026-05-01\0Labour Day',
+      hash: '["2026-05-01","Labour Day"]',
     });
+  });
+
+  it('uses a Postgres text-safe hash', () => {
+    const row = normalizeDataGovPublicHolidayRecord({
+      date: '2026-01-01',
+      day: 'Thursday',
+      holiday: "New Year's Day",
+    });
+
+    expect(row.hash).not.toContain('\0');
   });
 
   it('rejects invalid calendar dates', () => {

--- a/app/workflows/publicHolidays/helpers/syncPublicHolidays.ts
+++ b/app/workflows/publicHolidays/helpers/syncPublicHolidays.ts
@@ -2,6 +2,7 @@ import { and, gte, lte, notInArray, sql } from 'drizzle-orm';
 import { z } from 'zod';
 import type { getDb } from '../../../db/index.js';
 import { publicHolidaysTable } from '../../../db/schema.js';
+import { withDbDiagnostics } from '../../../util/dbDiagnostics.js';
 
 const DATA_GOV_PUBLIC_HOLIDAYS_DATASET_ID =
   'd_8ef23381f9417e4d4254ee8b4dcdb176';
@@ -75,6 +76,29 @@ function slug(value: string): string {
     .replace(/^-|-$/g, '');
 }
 
+function publicHolidayHash(date: string, holidayName: string): string {
+  return JSON.stringify([date, holidayName]);
+}
+
+async function withPublicHolidayDbDiagnostics<T>(
+  rows: readonly PublicHolidaySyncRow[],
+  operation: () => Promise<T>,
+): Promise<T> {
+  return withDbDiagnostics(
+    {
+      prefix: 'PUBLIC_HOLIDAYS_DB_ERROR',
+      operation: 'sync',
+      table: 'public_holidays',
+      rowCount: rows.length,
+      sample: rows
+        .slice(0, 5)
+        .map((row) => `${row.id}:${row.date}:${row.holidayName}`),
+    },
+    operation,
+    { errorName: 'PublicHolidayDbSyncError' },
+  );
+}
+
 export function normalizeDataGovPublicHolidayRecord(
   record: Record<string, unknown>,
 ): PublicHolidaySyncRow {
@@ -86,7 +110,7 @@ export function normalizeDataGovPublicHolidayRecord(
     id,
     date,
     holidayName,
-    hash: `${date}\0${holidayName}`,
+    hash: publicHolidayHash(date, holidayName),
   };
 }
 
@@ -181,40 +205,42 @@ export async function syncPublicHolidays(
     changedDates.add(row.date);
   }
 
-  await db.transaction(async (tx) => {
-    const now = new Date();
-    await tx
-      .insert(publicHolidaysTable)
-      .values(
-        sortedRows.map((row) => ({
-          id: row.id,
-          date: row.date,
-          holiday_name: row.holidayName,
-          hash: row.hash,
-        })),
-      )
-      .onConflictDoUpdate({
-        target: publicHolidaysTable.id,
-        set: {
-          date: sql.raw(`excluded.${publicHolidaysTable.date.name}`),
-          holiday_name: sql.raw(
-            `excluded.${publicHolidaysTable.holiday_name.name}`,
-          ),
-          hash: sql.raw(`excluded.${publicHolidaysTable.hash.name}`),
-          updated_at: now,
-        },
-      });
+  await withPublicHolidayDbDiagnostics(sortedRows, () =>
+    db.transaction(async (tx) => {
+      const now = new Date();
+      await tx
+        .insert(publicHolidaysTable)
+        .values(
+          sortedRows.map((row) => ({
+            id: row.id,
+            date: row.date,
+            holiday_name: row.holidayName,
+            hash: row.hash,
+          })),
+        )
+        .onConflictDoUpdate({
+          target: publicHolidaysTable.id,
+          set: {
+            date: sql.raw(`excluded.${publicHolidaysTable.date.name}`),
+            holiday_name: sql.raw(
+              `excluded.${publicHolidaysTable.holiday_name.name}`,
+            ),
+            hash: sql.raw(`excluded.${publicHolidaysTable.hash.name}`),
+            updated_at: now,
+          },
+        });
 
-    await tx
-      .delete(publicHolidaysTable)
-      .where(
-        and(
-          gte(publicHolidaysTable.date, start),
-          lte(publicHolidaysTable.date, end),
-          notInArray(publicHolidaysTable.id, [...incomingIds]),
-        ),
-      );
-  });
+      await tx
+        .delete(publicHolidaysTable)
+        .where(
+          and(
+            gte(publicHolidaysTable.date, start),
+            lte(publicHolidaysTable.date, end),
+            notInArray(publicHolidaysTable.id, [...incomingIds]),
+          ),
+        );
+    }),
+  );
 
   return {
     fetched: sortedRows.length,

--- a/app/workflows/pull/helpers/stagingSync.ts
+++ b/app/workflows/pull/helpers/stagingSync.ts
@@ -63,6 +63,10 @@ import {
   townsNextTable,
   townsTable,
 } from '../../../db/schema.js';
+import {
+  type DbDiagnosticContext,
+  withDbDiagnostics as withSharedDbDiagnostics,
+} from '../../../util/dbDiagnostics.js';
 
 /** Max rows per `insert().values()` batch to stay within driver/param limits. */
 const BATCH = 500;
@@ -77,120 +81,19 @@ function serviceRevisionEndAt(revision: ServiceRevision): string | null {
   return revision.endAt;
 }
 
-type DbDiagnosticContext = {
-  operation: string;
-  table: string;
-  rowCount?: number;
-  sample?: readonly string[];
-};
-
-class PullDbDiagnosticError extends Error {
-  constructor(message: string, options: { cause: unknown }) {
-    super(message, { cause: options.cause });
-    this.name = 'PullDbDiagnosticError';
-  }
-}
-
 function assertUnreachable(value: never, message: string): never {
   throw new Error(`${message}: ${String(value)}`);
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-function stringifyErrorField(value: unknown): string | null {
-  if (value == null) return null;
-  if (typeof value === 'string') return value;
-  if (typeof value === 'number' || typeof value === 'boolean') {
-    return String(value);
-  }
-  return null;
-}
-
-function readErrorField(error: unknown, field: string): string | null {
-  if (!isRecord(error)) return null;
-  return stringifyErrorField(error[field]);
-}
-
-function formatErrorCauseChain(error: unknown): string[] {
-  const lines: string[] = [];
-  let current: unknown = error;
-  const seen = new Set<unknown>();
-
-  for (let depth = 0; current != null && depth < 6; depth++) {
-    if (seen.has(current)) break;
-    seen.add(current);
-
-    const name =
-      current instanceof Error
-        ? current.name
-        : (readErrorField(current, 'name') ?? typeof current);
-    const message =
-      current instanceof Error
-        ? current.message
-        : (readErrorField(current, 'message') ?? String(current));
-    const fields = [
-      'code',
-      'severity',
-      'schema',
-      'table',
-      'column',
-      'constraint',
-      'detail',
-      'hint',
-      'where',
-      'routine',
-    ]
-      .map((field) => {
-        const value = readErrorField(current, field);
-        return value == null ? null : `${field}=${value}`;
-      })
-      .filter((field): field is string => field != null);
-
-    lines.push(
-      `cause[${depth}] ${name}: ${message}${
-        fields.length > 0 ? ` (${fields.join(', ')})` : ''
-      }`,
-    );
-
-    current = isRecord(current) ? current.cause : null;
-  }
-
-  return lines;
-}
-
-function formatDbDiagnosticMessage(
-  context: DbDiagnosticContext,
-  error: unknown,
-): string {
-  const lines = [
-    `[PULL_DB_ERROR] ${context.operation} failed on ${context.table}`,
-  ];
-  if (context.rowCount != null) {
-    lines.push(`row_count=${context.rowCount}`);
-  }
-  if (context.sample != null && context.sample.length > 0) {
-    lines.push(`sample=${context.sample.join(' | ')}`);
-  }
-  lines.push(...formatErrorCauseChain(error));
-  return lines.join('\n');
-}
-
 async function withDbDiagnostics<T>(
-  context: DbDiagnosticContext,
+  context: Omit<DbDiagnosticContext, 'prefix'>,
   operation: () => Promise<T>,
 ): Promise<T> {
-  try {
-    return await operation();
-  } catch (error) {
-    if (error instanceof PullDbDiagnosticError) {
-      throw error;
-    }
-    const message = formatDbDiagnosticMessage(context, error);
-    console.error(message);
-    throw new PullDbDiagnosticError(message, { cause: error });
-  }
+  return withSharedDbDiagnostics(
+    { prefix: 'PULL_DB_ERROR', ...context },
+    operation,
+    { errorName: 'PullDbDiagnosticError' },
+  );
 }
 
 function sampleRows<T>(


### PR DESCRIPTION
## Summary

- Add a shared DB diagnostic helper for workflow database operations.
- Route both pull workflow staging sync diagnostics and public holiday sync diagnostics through the shared helper.
- Fix public holiday hashes to avoid NUL bytes, which Postgres `text` cannot store.
- Add focused tests for diagnostic formatting/wrapping and the public holiday hash format.

## Root Cause

The public holidays sync generated hashes as `${date}\0${holidayName}`. Postgres rejects NUL bytes in `text` values, which explains the failing insert and the truncated-looking hash parameter in the Cloudflare workflow log.

## Validation

- `npm run test:run -- app/util/dbDiagnostics.test.ts app/workflows/publicHolidays/helpers/syncPublicHolidays.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run verify`