### PR TITLE
fix: handle midnight service hours

### DIFF
--- a/app/components/LineSummaryBlock/hooks/useOperatingHours.test.ts
+++ b/app/components/LineSummaryBlock/hooks/useOperatingHours.test.ts
@@ -1,0 +1,37 @@
+import { DateTime } from 'luxon';
+import { describe, expect, it } from 'vitest';
+import type { Line } from '~/types';
+import { getOperatingHours } from './useOperatingHours';
+
+const TEST_LINE: Line = {
+  id: 'BPLRT',
+  name: {
+    'en-SG': 'Bukit Panjang LRT',
+    'zh-Hans': null,
+    ms: null,
+    ta: null,
+  },
+  type: 'lrt',
+  color: '#748274',
+  startedAt: '1999-11-06',
+  operatingHours: {
+    weekdays: { start: '05:30', end: '05:30' },
+    weekends: { start: '05:30', end: '05:30' },
+  },
+  operators: [],
+};
+
+describe('getOperatingHours', () => {
+  it('treats matching start and end times as a next-day rollover', () => {
+    const hours = getOperatingHours(
+      TEST_LINE,
+      DateTime.fromISO('2026-02-23T00:00:00', {
+        zone: 'Asia/Singapore',
+      }),
+      'weekday',
+    );
+
+    expect(hours.start.toISO()).toBe('2026-02-23T05:30:00.000+08:00');
+    expect(hours.end.toISO()).toBe('2026-02-24T05:30:00.000+08:00');
+  });
+});

--- a/app/components/LineSummaryBlock/hooks/useOperatingHours.ts
+++ b/app/components/LineSummaryBlock/hooks/useOperatingHours.ts
@@ -3,42 +3,50 @@ import { useMemo } from 'react';
 import type { Line } from '~/types';
 import { assert } from '~/util/assert';
 
+export function getOperatingHours(
+  line: Line,
+  dateTime: DateTime,
+  dayType: 'weekday' | 'weekend' | 'public_holiday',
+) {
+  const { weekdays, weekends } = line.operatingHours;
+
+  let startTime = weekdays.start;
+  let endTime = weekdays.end;
+
+  switch (dayType) {
+    case 'public_holiday':
+    case 'weekend': {
+      startTime = weekends.start;
+      endTime = weekends.end;
+      break;
+    }
+  }
+
+  const start = DateTime.fromISO(`${dateTime.toISODate()}T${startTime}`, {
+    zone: 'Asia/Singapore',
+  });
+  assert(start.isValid);
+  let end = DateTime.fromISO(`${dateTime.toISODate()}T${endTime}`, {
+    zone: 'Asia/Singapore',
+  });
+  assert(end.isValid);
+  if (end < start) {
+    // If the end time is before the start time, it means the end time is on the next day
+    end = end.plus({ days: 1 });
+  }
+
+  return {
+    start,
+    end,
+  };
+}
+
 export function useOperatingHours(
   line: Line,
   dateTime: DateTime,
   dayType: 'weekday' | 'weekend' | 'public_holiday',
 ) {
   return useMemo(() => {
-    const { weekdays, weekends } = line.operatingHours;
-
-    let startTime = weekdays.start;
-    let endTime = weekdays.end;
-
-    switch (dayType) {
-      case 'public_holiday':
-      case 'weekend': {
-        startTime = weekends.start;
-        endTime = weekends.end;
-        break;
-      }
-    }
-
-    const start = DateTime.fromISO(`${dateTime.toISODate()}T${startTime}`, {
-      zone: 'Asia/Singapore',
-    });
-    assert(start.isValid);
-    let end = DateTime.fromISO(`${dateTime.toISODate()}T${endTime}`, {
-      zone: 'Asia/Singapore',
-    });
-    assert(end.isValid);
-    if (end < start) {
-      // If the end time is before the start time, it means the end time is on the next day
-      end = end.plus({ days: 1 });
-    }
-
-    return {
-      start,
-      end,
-    };
-  }, [dateTime, line.operatingHours, dayType]);
+    return getOperatingHours(line, dateTime, dayType);
+  }, [dateTime, line, dayType]);
 }

--- a/app/components/LineSummaryBlock/hooks/useOperatingHours.ts
+++ b/app/components/LineSummaryBlock/hooks/useOperatingHours.ts
@@ -30,7 +30,7 @@ export function getOperatingHours(
     zone: 'Asia/Singapore',
   });
   assert(end.isValid);
-  if (end < start) {
+  if (end <= start) {
     // If the end time is before the start time, it means the end time is on the next day
     end = end.plus({ days: 1 });
   }

--- a/app/components/LineSummaryBlock/index.tsx
+++ b/app/components/LineSummaryBlock/index.tsx
@@ -21,6 +21,7 @@ import {
   ServiceEndedDateCardDetails,
 } from './components/ServiceEndedDateCard';
 import { UptimeCard } from './components/UptimeCard';
+import { getOperatingHours } from './hooks/useOperatingHours';
 
 interface Props {
   data: LineSummary;
@@ -54,10 +55,11 @@ export const LineSummaryBlock: React.FC<Props> = (props) => {
   }, [line.startedAt]);
 
   const now = dateTimes[dateTimes.length - 1];
-  const serviceStartToday = useMemo(
-    () => now.set({ hour: 5, minute: 30 }),
-    [now],
-  );
+  const serviceStartToday = useMemo(() => {
+    const todayDayType =
+      breakdownByDates[now.toISODate() ?? '']?.dayType ?? 'weekday';
+    return getOperatingHours(line, now, todayDayType).start;
+  }, [breakdownByDates, line, now]);
 
   const isHydrated = useHydrated();
 
@@ -165,7 +167,11 @@ export const LineSummaryBlock: React.FC<Props> = (props) => {
             ) {
               return <NonOperationalDateCard key={dateTime.valueOf()} />;
             }
-            if (dateTime.hasSame(now, 'day') && now < serviceStartToday) {
+            if (
+              dateTime.hasSame(now, 'day') &&
+              status === 'closed_for_day' &&
+              now < serviceStartToday
+            ) {
               const isoDate = dateTime.toISODate();
               return (
                 <ServiceEndedDateCard

--- a/app/util/db.queries.test.ts
+++ b/app/util/db.queries.test.ts
@@ -109,4 +109,65 @@ describe('buildLineSummary', () => {
     expect(summary.durationSecondsByIssueType.disruption).toBe(18 * 60 * 60);
     expect(summary.uptimeRatio).toBe(0);
   });
+
+  it('treats lines as operating during service windows that spill into the next day', () => {
+    const summary = buildLineSummary(
+      {
+        ...TEST_LINE,
+        operatingHours: {
+          weekdays: { start: '05:30', end: '00:30' },
+          weekends: { start: '05:30', end: '00:30' },
+        },
+      },
+      [],
+      1,
+      new Set(),
+      DateTime.fromISO('2026-02-24T00:15:00', {
+        zone: 'Asia/Singapore',
+      }),
+    );
+
+    expect(summary.status).toBe('normal');
+  });
+
+  it('treats lines as closed after a next-day spillover service window ends', () => {
+    const summary = buildLineSummary(
+      {
+        ...TEST_LINE,
+        operatingHours: {
+          weekdays: { start: '05:30', end: '00:30' },
+          weekends: { start: '05:30', end: '00:30' },
+        },
+      },
+      [],
+      1,
+      new Set(),
+      DateTime.fromISO('2026-02-24T00:31:00', {
+        zone: 'Asia/Singapore',
+      }),
+    );
+
+    expect(summary.status).toBe('closed_for_day');
+  });
+
+  it('does not apply previous-day spillover before a line starts service', () => {
+    const summary = buildLineSummary(
+      {
+        ...TEST_LINE,
+        startedAt: '2026-02-24',
+        operatingHours: {
+          weekdays: { start: '05:30', end: '00:30' },
+          weekends: { start: '05:30', end: '00:30' },
+        },
+      },
+      [],
+      1,
+      new Set(),
+      DateTime.fromISO('2026-02-24T00:15:00', {
+        zone: 'Asia/Singapore',
+      }),
+    );
+
+    expect(summary.status).toBe('closed_for_day');
+  });
 });

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -488,6 +488,24 @@ function serviceWindowForDate(
   };
 }
 
+function serviceWindowContains(
+  serviceWindow: ReturnType<typeof serviceWindowForDate>,
+  date: DateTime,
+) {
+  return date >= serviceWindow.start && date <= serviceWindow.end;
+}
+
+function serviceWindowIsAfterLineStart(
+  line: Line,
+  serviceWindow: ReturnType<typeof serviceWindowForDate>,
+) {
+  if (line.startedAt == null) {
+    return true;
+  }
+
+  return serviceWindow.start.startOf('day') >= parseDateTime(line.startedAt);
+}
+
 function serviceWindowAfterLineStart(
   line: Line,
   serviceWindow: ReturnType<typeof serviceWindowForDate>,
@@ -531,7 +549,19 @@ function isLineOperatingNow(
   }
 
   const window = serviceWindowForDate(line, referenceNow, publicHolidaySet);
-  return referenceNow >= window.start && referenceNow <= window.end;
+  if (serviceWindowContains(window, referenceNow)) {
+    return true;
+  }
+
+  const previousWindow = serviceWindowForDate(
+    line,
+    referenceNow.minus({ day: 1 }),
+    publicHolidaySet,
+  );
+  return (
+    serviceWindowIsAfterLineStart(line, previousWindow) &&
+    serviceWindowContains(previousWindow, referenceNow)
+  );
 }
 
 function pickIssueTypes<T extends { type: IssueType }>(items: T[]) {


### PR DESCRIPTION
## Summary

- Treat lines as operating during operating-hour windows that extend past midnight into the next calendar day.
- Update the home line summary grid so early-morning cards use each line's configured service start and the server-computed status instead of a fixed 05:30 cutoff.
- Add regression coverage for active spillover, post-spillover closure, and first-service-day behavior.

## Root Cause

The current-status calculation only checked the service window for the current calendar day. During times like 00:00-00:30, lines whose previous day's operating hours extended past midnight were incorrectly classified as outside service hours.

## Validation

- `npm run test:run -- app/util/db.queries.test.ts`
- `npm run typecheck`
- `npm run verify`

Note: the first sandboxed `npm run verify` reached lint and format successfully, then failed because `tsx` could not create its IPC pipe under `/var/folders`. The same command passed when rerun with escalated permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of transit line operating hours that extend past midnight, ensuring lines are correctly shown as operating during spillover service windows.
  * Fixed service status calculations to accurately account for lines whose operating hours cross day boundaries.

* **Tests**
  * Added test coverage for midnight spillover behavior validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-site/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->