### PR TITLE
perf: cache public HTML responses

### DIFF
--- a/app/server.ts
+++ b/app/server.ts
@@ -1,15 +1,46 @@
 import * as Sentry from '@sentry/cloudflare';
 import handler from '@tanstack/react-start/server-entry';
+import {
+  applyPublicHtmlCacheHeaders,
+  createPublicHtmlCacheResponse,
+  getPublicHtmlCacheKey,
+  isPublicHtmlCacheLookupRequest,
+  shouldCachePublicHtml,
+} from './util/publicHtmlCache';
 import { handleScheduledWorkflows } from './workflows/scheduled';
 
-async function appFetch(request: Request) {
+const PUBLIC_HTML_CACHE_NAME = 'mrtdown-public-html';
+
+async function appFetch(request: Request, _env: Env, ctx: ExecutionContext) {
   const startedAt = performance.now();
+  const cachedResponse = await getCachedPublicHtmlResponse(request);
+  if (cachedResponse != null) {
+    const elapsedMs = performance.now() - startedAt;
+    return addResponseInstrumentationHeaders(
+      cachedResponse,
+      elapsedMs,
+      'public-html-cache',
+    );
+  }
+
   const response = await handler.fetch(request);
   const elapsedMs = performance.now() - startedAt;
+  const shouldStorePublicHtml = shouldCachePublicHtml(request, response);
+  const responseWithCacheHeaders = applyPublicHtmlCacheHeaders(
+    request,
+    response,
+  );
+
+  if (shouldStorePublicHtml && isPublicHtmlCacheLookupRequest(request)) {
+    ctx.waitUntil(
+      storePublicHtmlResponse(request, responseWithCacheHeaders.clone()),
+    );
+  }
 
   const responseWithHeaders = addResponseInstrumentationHeaders(
-    response,
+    responseWithCacheHeaders,
     elapsedMs,
+    'worker',
   );
 
   if (import.meta.env.DEV && responseWithHeaders.status !== 101) {
@@ -22,10 +53,11 @@ async function appFetch(request: Request) {
 function addResponseInstrumentationHeaders(
   response: Response,
   elapsedMs: number,
+  render: 'public-html-cache' | 'worker',
 ) {
   const workerTiming = `worker_request;dur=${elapsedMs.toFixed(1)}`;
   try {
-    appendInstrumentationHeaders(response.headers, workerTiming);
+    appendInstrumentationHeaders(response.headers, workerTiming, render);
     return response;
   } catch {
     if (response.status === 101) {
@@ -33,7 +65,7 @@ function addResponseInstrumentationHeaders(
     }
 
     const headers = new Headers(response.headers);
-    appendInstrumentationHeaders(headers, workerTiming);
+    appendInstrumentationHeaders(headers, workerTiming, render);
     return new Response(response.body, {
       status: response.status,
       statusText: response.statusText,
@@ -42,7 +74,11 @@ function addResponseInstrumentationHeaders(
   }
 }
 
-function appendInstrumentationHeaders(headers: Headers, workerTiming: string) {
+function appendInstrumentationHeaders(
+  headers: Headers,
+  workerTiming: string,
+  render: 'public-html-cache' | 'worker',
+) {
   const currentServerTiming = headers.get('Server-Timing');
   headers.set(
     'Server-Timing',
@@ -50,7 +86,44 @@ function appendInstrumentationHeaders(headers: Headers, workerTiming: string) {
       ? `${currentServerTiming}, ${workerTiming}`
       : workerTiming,
   );
-  headers.set('X-MRTDown-Render', 'worker');
+  headers.set('X-MRTDown-Render', render);
+}
+
+async function getCachedPublicHtmlResponse(request: Request) {
+  if (!isPublicHtmlCacheLookupRequest(request)) {
+    return null;
+  }
+
+  try {
+    const cache = await caches.open(PUBLIC_HTML_CACHE_NAME);
+    const response = await cache.match(getPublicHtmlCacheKey(request));
+    if (response == null) {
+      return null;
+    }
+
+    const headers = new Headers(response.headers);
+    headers.set('X-MRTDown-Cache', 'hit');
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  } catch (error) {
+    console.warn('Failed to read public HTML cache', error);
+    return null;
+  }
+}
+
+async function storePublicHtmlResponse(request: Request, response: Response) {
+  try {
+    const cache = await caches.open(PUBLIC_HTML_CACHE_NAME);
+    await cache.put(
+      getPublicHtmlCacheKey(request),
+      createPublicHtmlCacheResponse(response),
+    );
+  } catch (error) {
+    console.warn('Failed to store public HTML cache', error);
+  }
 }
 
 async function logResponseByteEstimate(

--- a/app/util/publicHtmlCache.test.ts
+++ b/app/util/publicHtmlCache.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyPublicHtmlCacheHeaders,
+  createPublicHtmlCacheResponse,
+  getPublicHtmlCacheKey,
+  isPublicHtmlCacheLookupRequest,
+  shouldCachePublicHtml,
+} from './publicHtmlCache';
+
+function htmlResponse(init?: ResponseInit) {
+  const headers = new Headers(init?.headers);
+  if (!headers.has('content-type')) {
+    headers.set('content-type', 'text/html; charset=utf-8');
+  }
+  return new Response('<!doctype html>', {
+    ...init,
+    headers,
+  });
+}
+
+function request(pathname: string, init?: RequestInit) {
+  return new Request(`https://www.mrtdown.org${pathname}`, init);
+}
+
+describe('public HTML cache headers', () => {
+  it.each([
+    '/',
+    '/statistics',
+    '/zh-Hans/statistics',
+    '/history',
+    '/history/2025',
+    '/lines/EWL',
+    '/operators/SMRT',
+    '/stations/NS1',
+    '/system-map',
+    '/about',
+  ])('marks %s as cacheable public HTML', (pathname) => {
+    expect(shouldCachePublicHtml(request(pathname), htmlResponse())).toBe(true);
+  });
+
+  it.each([
+    '/api/reports',
+    '/internal/api/tasks/pull',
+    '/report',
+    '/issues/2024-001',
+    '/sitemap.xml',
+  ])('does not mark %s as cacheable public HTML', (pathname) => {
+    expect(shouldCachePublicHtml(request(pathname), htmlResponse())).toBe(
+      false,
+    );
+  });
+
+  it('requires a successful GET or HEAD HTML response without shared cache opt-outs', () => {
+    expect(
+      shouldCachePublicHtml(
+        request('/statistics', { method: 'HEAD' }),
+        htmlResponse(),
+      ),
+    ).toBe(true);
+
+    expect(
+      shouldCachePublicHtml(
+        request('/statistics', { method: 'POST' }),
+        htmlResponse(),
+      ),
+    ).toBe(false);
+    expect(
+      shouldCachePublicHtml(
+        request('/statistics'),
+        htmlResponse({ status: 404 }),
+      ),
+    ).toBe(false);
+    expect(
+      shouldCachePublicHtml(
+        request('/statistics'),
+        new Response('{}', {
+          headers: { 'content-type': 'application/json' },
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      shouldCachePublicHtml(
+        request('/statistics'),
+        htmlResponse({ headers: { 'set-cookie': 'sid=1' } }),
+      ),
+    ).toBe(false);
+    expect(
+      shouldCachePublicHtml(
+        request('/statistics'),
+        htmlResponse({ headers: { 'cache-control': 'private, max-age=0' } }),
+      ),
+    ).toBe(false);
+    expect(
+      shouldCachePublicHtml(
+        request('/statistics', {
+          headers: { 'cache-control': 'no-cache' },
+        }),
+        htmlResponse(),
+      ),
+    ).toBe(false);
+  });
+
+  it('sets short shared cache headers for cacheable public HTML', () => {
+    const response = applyPublicHtmlCacheHeaders(
+      request('/statistics?utm_source=test'),
+      htmlResponse(),
+    );
+
+    expect(response.headers.get('cache-control')).toBe(
+      'public, max-age=0, s-maxage=60, stale-while-revalidate=300',
+    );
+    expect(response.headers.get('x-mrtdown-cache')).toBe('public-html');
+  });
+
+  it('uses GET cache lookups for cacheable public pages unless the request opts out', () => {
+    expect(isPublicHtmlCacheLookupRequest(request('/statistics'))).toBe(true);
+    expect(
+      isPublicHtmlCacheLookupRequest(
+        request('/statistics', { method: 'HEAD' }),
+      ),
+    ).toBe(false);
+    expect(isPublicHtmlCacheLookupRequest(request('/api/reports'))).toBe(false);
+    expect(
+      isPublicHtmlCacheLookupRequest(
+        request('/statistics', {
+          headers: { 'cache-control': 'no-cache' },
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isPublicHtmlCacheLookupRequest(
+        request('/statistics', {
+          headers: { 'cache-control': 'max-age=0' },
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isPublicHtmlCacheLookupRequest(
+        request('/statistics', {
+          headers: { pragma: 'no-cache' },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('preserves the full URL in the cache key', () => {
+    const cacheKey = getPublicHtmlCacheKey(
+      request('/zh-Hans/statistics?viewport=lg'),
+    );
+
+    expect(cacheKey.method).toBe('GET');
+    expect(cacheKey.url).toBe(
+      'https://www.mrtdown.org/zh-Hans/statistics?viewport=lg',
+    );
+  });
+
+  it('removes request-specific instrumentation before storing cached HTML', () => {
+    const cachedResponse = createPublicHtmlCacheResponse(
+      htmlResponse({
+        headers: {
+          'content-type': 'text/html',
+          'server-timing': 'worker_request;dur=100',
+          'x-mrtdown-render': 'worker',
+        },
+      }),
+    );
+
+    expect(cachedResponse.headers.get('content-type')).toBe('text/html');
+    expect(cachedResponse.headers.get('server-timing')).toBeNull();
+    expect(cachedResponse.headers.get('x-mrtdown-render')).toBeNull();
+  });
+});

--- a/app/util/publicHtmlCache.ts
+++ b/app/util/publicHtmlCache.ts
@@ -1,0 +1,133 @@
+const PUBLIC_HTML_CACHE_CONTROL =
+  'public, max-age=0, s-maxage=60, stale-while-revalidate=300';
+
+const HTML_CONTENT_TYPES = ['text/html', 'application/xhtml+xml'];
+
+const CACHEABLE_ROUTE_PREFIXES = [
+  '/history/',
+  '/lines/',
+  '/operators/',
+  '/stations/',
+];
+
+const CACHEABLE_ROUTES = new Set([
+  '/',
+  '/about',
+  '/history',
+  '/statistics',
+  '/system-map',
+]);
+
+const LOCALE_SEGMENTS = new Set(['en-SG', 'zh-Hans', 'ms', 'ta']);
+
+function hasCacheBypassDirective(request: Request) {
+  const cacheControl = request.headers.get('cache-control')?.toLowerCase();
+  const pragma = request.headers.get('pragma')?.toLowerCase();
+  return (
+    cacheControl?.includes('no-cache') === true ||
+    cacheControl?.includes('no-store') === true ||
+    cacheControl?.includes('max-age=0') === true ||
+    pragma?.includes('no-cache') === true
+  );
+}
+
+function stripLocaleSegment(pathname: string) {
+  const [firstSegment = '', ...rest] = pathname.split('/').filter(Boolean);
+  if (!LOCALE_SEGMENTS.has(firstSegment)) {
+    return pathname;
+  }
+
+  return rest.length > 0 ? `/${rest.join('/')}` : '/';
+}
+
+function isCacheablePublicPath(pathname: string) {
+  const publicPath = stripLocaleSegment(pathname);
+  return (
+    CACHEABLE_ROUTES.has(publicPath) ||
+    CACHEABLE_ROUTE_PREFIXES.some((prefix) => publicPath.startsWith(prefix))
+  );
+}
+
+export function isPublicHtmlCacheLookupRequest(request: Request) {
+  return (
+    request.method === 'GET' &&
+    !hasCacheBypassDirective(request) &&
+    isCacheablePublicPath(new URL(request.url).pathname)
+  );
+}
+
+export function getPublicHtmlCacheKey(request: Request) {
+  return new Request(request.url, { method: 'GET' });
+}
+
+function isHtmlResponse(response: Response) {
+  const contentType = response.headers.get('content-type')?.toLowerCase() ?? '';
+  return HTML_CONTENT_TYPES.some((htmlType) => contentType.includes(htmlType));
+}
+
+function hasSharedCacheOptOut(response: Response) {
+  const cacheControl = response.headers.get('cache-control')?.toLowerCase();
+  return (
+    cacheControl != null &&
+    (cacheControl.includes('private') || cacheControl.includes('no-store'))
+  );
+}
+
+export function shouldCachePublicHtml(request: Request, response: Response) {
+  if (
+    (request.method !== 'GET' && request.method !== 'HEAD') ||
+    hasCacheBypassDirective(request)
+  ) {
+    return false;
+  }
+  if (response.status !== 200) {
+    return false;
+  }
+  if (!isHtmlResponse(response)) {
+    return false;
+  }
+  if (response.headers.has('set-cookie') || hasSharedCacheOptOut(response)) {
+    return false;
+  }
+
+  return isCacheablePublicPath(new URL(request.url).pathname);
+}
+
+export function applyPublicHtmlCacheHeaders(
+  request: Request,
+  response: Response,
+) {
+  if (!shouldCachePublicHtml(request, response)) {
+    return response;
+  }
+
+  try {
+    setPublicHtmlCacheHeaders(response.headers);
+    return response;
+  } catch {
+    const headers = new Headers(response.headers);
+    setPublicHtmlCacheHeaders(headers);
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
+}
+
+function setPublicHtmlCacheHeaders(headers: Headers) {
+  headers.set('Cache-Control', PUBLIC_HTML_CACHE_CONTROL);
+  headers.set('X-MRTDown-Cache', 'public-html');
+}
+
+export function createPublicHtmlCacheResponse(response: Response) {
+  const headers = new Headers(response.headers);
+  headers.delete('Server-Timing');
+  headers.delete('X-MRTDown-Render');
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/docs/plans/active/production-performance.md
+++ b/docs/plans/active/production-performance.md
@@ -265,6 +265,19 @@ Exit criteria:
 This order gives quick production relief through caching, then reduces the
 underlying compute and payload costs so uncached requests are also fast.
 
+## Progress Notes
+
+- 2026-05-25: Implemented Phase 1 Worker-side public HTML caching for
+  successful public `GET` responses on the planned cacheable route set, plus
+  origin cache headers for matching `GET`/`HEAD` responses. Cacheable pages now
+  emit `Cache-Control: public, max-age=0, s-maxage=60,
+  stale-while-revalidate=300` and `X-MRTDown-Cache: public-html`; cache hits
+  return before SSR with `X-MRTDown-Render: public-html-cache`. API/internal
+  routes, non-candidate pages, non-HTML responses, non-200 responses,
+  `Set-Cookie`, private/no-store opt-outs, and client no-cache requests are
+  excluded. Added focused route-matching and cache-key tests in
+  `app/util/publicHtmlCache.test.ts`.
+
 ## Validation
 
 For each phase:


### PR DESCRIPTION
## Summary

- Add Worker-side public HTML caching for eligible public GET routes before SSR runs.
- Add short shared cache headers and cache visibility markers for public HTML responses.
- Exclude API/internal routes, non-public pages, non-HTML responses, non-200 responses, shared-cache opt-outs, Set-Cookie responses, and client no-cache requests.
- Update the production performance plan with the Phase 1 progress note.

## Impact

Repeated requests for cacheable public pages such as `/statistics` can be served from the Workers Cache API instead of paying the SSR/data assembly cost every time. Cache hits are identifiable with `X-MRTDown-Render: public-html-cache`.

## Validation

- `npm run verify`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented public HTML response caching to accelerate page loads on eligible routes. Cached responses bypass rendering and serve instantly, with cache status indicated in response headers.

* **Tests**
  * Added comprehensive test suite for HTML caching behavior and route eligibility validation.

* **Documentation**
  * Updated progress documentation for production performance optimization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-site/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->