### PR TITLE
feat: automate crowd report moderation

### DIFF
--- a/app/routes/api.reports.tsx
+++ b/app/routes/api.reports.tsx
@@ -2,6 +2,7 @@ import { env } from 'cloudflare:workers';
 import { createFileRoute } from '@tanstack/react-router';
 import { getDb } from '~/db';
 import {
+  automoderateCrowdReport,
   buildCrowdReportAbuseContext,
   CrowdReportRateLimitError,
   findMissingCrowdReportReferences,
@@ -169,11 +170,16 @@ export const Route = createFileRoute('/api/reports')({
               ),
             },
           );
+          const moderatedReport = await automoderateCrowdReport(
+            db,
+            report.id,
+            validation.data,
+          );
 
           return Response.json(
             {
               success: true,
-              data: report,
+              data: moderatedReport,
             },
             { status: 202 },
           );

--- a/app/routes/api.reports.tsx
+++ b/app/routes/api.reports.tsx
@@ -2,13 +2,12 @@ import { env } from 'cloudflare:workers';
 import { createFileRoute } from '@tanstack/react-router';
 import { getDb } from '~/db';
 import {
-  automoderateCrowdReport,
   buildCrowdReportAbuseContext,
   CrowdReportRateLimitError,
   findMissingCrowdReportReferences,
   getClientIp,
   parseCrowdReportJsonBody,
-  persistCrowdReport,
+  persistAutomoderatedCrowdReport,
   validateCrowdReportSubmission,
   verifyTurnstileToken,
 } from '~/util/crowdReports';
@@ -160,7 +159,7 @@ export const Route = createFileRoute('/api/reports')({
         }
 
         try {
-          const report = await persistCrowdReport(
+          const report = await persistAutomoderatedCrowdReport(
             db,
             validation.data,
             abuseContext,
@@ -170,16 +169,11 @@ export const Route = createFileRoute('/api/reports')({
               ),
             },
           );
-          const moderatedReport = await automoderateCrowdReport(
-            db,
-            report.id,
-            validation.data,
-          );
 
           return Response.json(
             {
               success: true,
-              data: moderatedReport,
+              data: report,
             },
             { status: 202 },
           );

--- a/app/util/crowdReports.test.ts
+++ b/app/util/crowdReports.test.ts
@@ -62,6 +62,7 @@ function makeFakeDb(
   const inserts: Array<{ table: unknown; values: unknown }> = [];
   const conflictUpdates: unknown[] = [];
   const updates: Array<{ table: unknown; values: unknown }> = [];
+  const executes: unknown[] = [];
   let transactions = 0;
   const nextSelectResult = () => selectResults.shift() ?? [];
   const selectBuilder = {
@@ -79,6 +80,10 @@ function makeFakeDb(
     },
   };
   const tx = {
+    execute(query: unknown) {
+      executes.push(query);
+      return Promise.resolve();
+    },
     select() {
       return selectBuilder;
     },
@@ -128,6 +133,7 @@ function makeFakeDb(
     inserts,
     conflictUpdates,
     updates,
+    executes,
     get transactions() {
       return transactions;
     },
@@ -150,6 +156,7 @@ function makeFakeAutomoderationDb(
 ) {
   const inserts: Array<{ table: unknown; values: unknown }> = [];
   const updates: Array<{ table: unknown; values: unknown }> = [];
+  const executes: unknown[] = [];
   const nextSelectResult = () => selectResults.shift() ?? [];
   const selectBuilder = {
     from() {
@@ -167,6 +174,10 @@ function makeFakeAutomoderationDb(
   };
 
   const tx = {
+    execute(query: unknown) {
+      executes.push(query);
+      return Promise.resolve();
+    },
     select() {
       return selectBuilder;
     },
@@ -199,6 +210,7 @@ function makeFakeAutomoderationDb(
   return {
     inserts,
     updates,
+    executes,
     db: {
       transaction<T>(callback: (transaction: typeof tx) => Promise<T>) {
         return callback(tx);
@@ -548,6 +560,7 @@ describe('persistAutomoderatedCrowdReport', () => {
         duplicate_of_id: null,
       },
     });
+    expect(fake.executes).toHaveLength(1);
   });
 });
 
@@ -586,6 +599,7 @@ describe('automoderateCrowdReport', () => {
         note: 'Report accepted by automated moderation rules',
       },
     });
+    expect(fake.executes).toHaveLength(1);
   });
 
   it('marks a same-context report in the duplicate window as duplicate', async () => {

--- a/app/util/crowdReports.test.ts
+++ b/app/util/crowdReports.test.ts
@@ -13,6 +13,7 @@ import {
   CrowdReportRateLimitError,
   getCrowdReportRateLimitBucketStart,
   parseCrowdReportJsonBody,
+  persistAutomoderatedCrowdReport,
   persistCrowdReport,
   validateCrowdReportSubmission,
   verifyTurnstileToken,
@@ -49,10 +50,54 @@ function makeStreamingRequest(body: string) {
   } as RequestInit & { duplex: 'half' });
 }
 
-function makeFakeDb(rateLimitCount: number) {
+function makeFakeDb(
+  rateLimitCount: number,
+  selectResults: unknown[][] = [],
+  updatedReport = {
+    id: 'fixed-id',
+    status: 'accepted',
+    duplicateOfId: null as string | null,
+  },
+) {
   const inserts: Array<{ table: unknown; values: unknown }> = [];
   const conflictUpdates: unknown[] = [];
+  const updates: Array<{ table: unknown; values: unknown }> = [];
+  let transactions = 0;
+  const nextSelectResult = () => selectResults.shift() ?? [];
+  const selectBuilder = {
+    from() {
+      return this;
+    },
+    where() {
+      return this;
+    },
+    orderBy() {
+      return this;
+    },
+    limit() {
+      return Promise.resolve(nextSelectResult());
+    },
+  };
   const tx = {
+    select() {
+      return selectBuilder;
+    },
+    update(table: unknown) {
+      return {
+        set(values: unknown) {
+          updates.push({ table, values });
+          return {
+            where() {
+              return {
+                returning() {
+                  return Promise.resolve([updatedReport]);
+                },
+              };
+            },
+          };
+        },
+      };
+    },
     insert(table: unknown) {
       return {
         values(values: unknown) {
@@ -82,8 +127,13 @@ function makeFakeDb(rateLimitCount: number) {
   return {
     inserts,
     conflictUpdates,
+    updates,
+    get transactions() {
+      return transactions;
+    },
     db: {
       transaction<T>(callback: (transaction: typeof tx) => Promise<T>) {
+        transactions += 1;
         return callback(tx);
       },
     },
@@ -447,6 +497,55 @@ describe('persistCrowdReport', () => {
       set: {
         client_fingerprint_hash:
           crowdReportRateLimitsTable.client_fingerprint_hash,
+      },
+    });
+  });
+});
+
+describe('persistAutomoderatedCrowdReport', () => {
+  it('persists and automoderates a report in one transaction', async () => {
+    const fake = makeFakeDb(1, [[]], {
+      id: 'fixed-id',
+      status: 'accepted',
+      duplicateOfId: null,
+    });
+
+    await expect(
+      persistAutomoderatedCrowdReport(
+        fake.db as never,
+        VALID_SUBMISSION,
+        {
+          ipHash: 'ip-hash',
+          userAgentHash: 'ua-hash',
+          turnstileOutcome: 'passed',
+        },
+        {
+          now: NOW,
+          idFactory: () => 'fixed-id',
+        },
+      ),
+    ).resolves.toEqual({
+      id: 'fixed-id',
+      status: 'accepted',
+      duplicateOfId: null,
+    });
+
+    expect(fake.transactions).toBe(1);
+    expect(fake.inserts.map((insert) => insert.table)).toEqual([
+      crowdReportRateLimitsTable,
+      crowdReportsTable,
+      crowdReportLinesTable,
+      crowdReportStationsTable,
+      crowdReportAbuseEventsTable,
+      crowdReportModerationEventsTable,
+      crowdReportModerationEventsTable,
+    ]);
+    expect(fake.updates).toHaveLength(1);
+    expect(fake.updates[0]).toMatchObject({
+      table: crowdReportsTable,
+      values: {
+        status: 'accepted',
+        duplicate_of_id: null,
       },
     });
   });

--- a/app/util/crowdReports.test.ts
+++ b/app/util/crowdReports.test.ts
@@ -75,6 +75,9 @@ function makeFakeDb(
     orderBy() {
       return this;
     },
+    offset() {
+      return this;
+    },
     limit() {
       return Promise.resolve(nextSelectResult());
     },
@@ -166,6 +169,9 @@ function makeFakeAutomoderationDb(
       return this;
     },
     orderBy() {
+      return this;
+    },
+    offset() {
       return this;
     },
     limit() {
@@ -682,6 +688,53 @@ describe('automoderateCrowdReport', () => {
       values: {
         status: 'accepted',
         duplicate_of_id: null,
+      },
+    });
+  });
+
+  it('searches later duplicate candidate pages before accepting a report', async () => {
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({
+      id: `other-report-${index}`,
+      status: 'accepted',
+      directionText: 'Towards Another Terminal',
+    }));
+    const fake = makeFakeAutomoderationDb(
+      [
+        firstPage,
+        [],
+        [],
+        [
+          {
+            id: 'existing-report',
+            status: 'accepted',
+            directionText: 'Towards Choa Chu Kang',
+          },
+        ],
+        [{ reportId: 'existing-report', lineId: 'BPLRT' }],
+        [{ reportId: 'existing-report', stationId: 'BP6' }],
+      ],
+      {
+        id: 'report-1',
+        status: 'duplicate',
+        duplicateOfId: 'existing-report',
+      },
+    );
+
+    await expect(
+      automoderateCrowdReport(fake.db as never, 'report-1', VALID_SUBMISSION, {
+        idFactory: () => 'event-1',
+      }),
+    ).resolves.toEqual({
+      id: 'report-1',
+      status: 'duplicate',
+      duplicateOfId: 'existing-report',
+    });
+
+    expect(fake.updates[0]).toMatchObject({
+      table: crowdReportsTable,
+      values: {
+        status: 'duplicate',
+        duplicate_of_id: 'existing-report',
       },
     });
   });

--- a/app/util/crowdReports.test.ts
+++ b/app/util/crowdReports.test.ts
@@ -9,6 +9,7 @@ import {
   crowdReportStationsTable,
 } from '~/db/schema';
 import {
+  automoderateCrowdReport,
   CrowdReportRateLimitError,
   getCrowdReportRateLimitBucketStart,
   parseCrowdReportJsonBody,
@@ -81,6 +82,73 @@ function makeFakeDb(rateLimitCount: number) {
   return {
     inserts,
     conflictUpdates,
+    db: {
+      transaction<T>(callback: (transaction: typeof tx) => Promise<T>) {
+        return callback(tx);
+      },
+    },
+  };
+}
+
+function makeFakeAutomoderationDb(
+  selectResults: unknown[][],
+  updatedReport: {
+    id: string;
+    status: 'accepted' | 'duplicate';
+    duplicateOfId: string | null;
+  },
+) {
+  const inserts: Array<{ table: unknown; values: unknown }> = [];
+  const updates: Array<{ table: unknown; values: unknown }> = [];
+  const nextSelectResult = () => selectResults.shift() ?? [];
+  const selectBuilder = {
+    from() {
+      return this;
+    },
+    where() {
+      return this;
+    },
+    orderBy() {
+      return this;
+    },
+    limit() {
+      return Promise.resolve(nextSelectResult());
+    },
+  };
+
+  const tx = {
+    select() {
+      return selectBuilder;
+    },
+    update(table: unknown) {
+      return {
+        set(values: unknown) {
+          updates.push({ table, values });
+          return {
+            where() {
+              return {
+                returning() {
+                  return Promise.resolve([updatedReport]);
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+    insert(table: unknown) {
+      return {
+        values(values: unknown) {
+          inserts.push({ table, values });
+          return Promise.resolve();
+        },
+      };
+    },
+  };
+
+  return {
+    inserts,
+    updates,
     db: {
       transaction<T>(callback: (transaction: typeof tx) => Promise<T>) {
         return callback(tx);
@@ -379,6 +447,84 @@ describe('persistCrowdReport', () => {
       set: {
         client_fingerprint_hash:
           crowdReportRateLimitsTable.client_fingerprint_hash,
+      },
+    });
+  });
+});
+
+describe('automoderateCrowdReport', () => {
+  it('accepts a valid report when no duplicate candidate matches', async () => {
+    const fake = makeFakeAutomoderationDb([[]], {
+      id: 'report-1',
+      status: 'accepted',
+      duplicateOfId: null,
+    });
+
+    await expect(
+      automoderateCrowdReport(fake.db as never, 'report-1', VALID_SUBMISSION, {
+        idFactory: () => 'event-1',
+      }),
+    ).resolves.toEqual({
+      id: 'report-1',
+      status: 'accepted',
+      duplicateOfId: null,
+    });
+
+    expect(fake.updates[0]).toMatchObject({
+      table: crowdReportsTable,
+      values: {
+        status: 'accepted',
+        duplicate_of_id: null,
+      },
+    });
+    expect(fake.inserts[0]).toMatchObject({
+      table: crowdReportModerationEventsTable,
+      values: {
+        id: 'event-1',
+        report_id: 'report-1',
+        actor: 'system',
+        action: 'automated_accepted',
+        note: 'Report accepted by automated moderation rules',
+      },
+    });
+  });
+
+  it('marks a same-context report in the duplicate window as duplicate', async () => {
+    const fake = makeFakeAutomoderationDb(
+      [
+        [{ id: 'existing-report', directionText: 'Towards Choa Chu Kang' }],
+        [{ reportId: 'existing-report', lineId: 'BPLRT' }],
+        [{ reportId: 'existing-report', stationId: 'BP6' }],
+      ],
+      {
+        id: 'report-1',
+        status: 'duplicate',
+        duplicateOfId: 'existing-report',
+      },
+    );
+
+    await expect(
+      automoderateCrowdReport(fake.db as never, 'report-1', VALID_SUBMISSION, {
+        idFactory: () => 'event-1',
+      }),
+    ).resolves.toEqual({
+      id: 'report-1',
+      status: 'duplicate',
+      duplicateOfId: 'existing-report',
+    });
+
+    expect(fake.updates[0]).toMatchObject({
+      table: crowdReportsTable,
+      values: {
+        status: 'duplicate',
+        duplicate_of_id: 'existing-report',
+      },
+    });
+    expect(fake.inserts[0]).toMatchObject({
+      table: crowdReportModerationEventsTable,
+      values: {
+        action: 'automated_duplicate',
+        note: 'Report automatically marked as duplicate of existing-report',
       },
     });
   });

--- a/app/util/crowdReports.test.ts
+++ b/app/util/crowdReports.test.ts
@@ -492,7 +492,13 @@ describe('automoderateCrowdReport', () => {
   it('marks a same-context report in the duplicate window as duplicate', async () => {
     const fake = makeFakeAutomoderationDb(
       [
-        [{ id: 'existing-report', directionText: 'Towards Choa Chu Kang' }],
+        [
+          {
+            id: 'existing-report',
+            status: 'accepted',
+            directionText: 'Towards Choa Chu Kang',
+          },
+        ],
         [{ reportId: 'existing-report', lineId: 'BPLRT' }],
         [{ reportId: 'existing-report', stationId: 'BP6' }],
       ],
@@ -525,6 +531,44 @@ describe('automoderateCrowdReport', () => {
       values: {
         action: 'automated_duplicate',
         note: 'Report automatically marked as duplicate of existing-report',
+      },
+    });
+  });
+
+  it('ignores same-context pending reports to avoid reciprocal duplicates', async () => {
+    const fake = makeFakeAutomoderationDb(
+      [
+        [
+          {
+            id: 'pending-report',
+            status: 'pending',
+            directionText: 'Towards Choa Chu Kang',
+          },
+        ],
+        [{ reportId: 'pending-report', lineId: 'BPLRT' }],
+        [{ reportId: 'pending-report', stationId: 'BP6' }],
+      ],
+      {
+        id: 'report-1',
+        status: 'accepted',
+        duplicateOfId: null,
+      },
+    );
+
+    await automoderateCrowdReport(
+      fake.db as never,
+      'report-1',
+      VALID_SUBMISSION,
+      {
+        idFactory: () => 'event-1',
+      },
+    );
+
+    expect(fake.updates[0]).toMatchObject({
+      table: crowdReportsTable,
+      values: {
+        status: 'accepted',
+        duplicate_of_id: null,
       },
     });
   });

--- a/app/util/crowdReports.ts
+++ b/app/util/crowdReports.ts
@@ -81,12 +81,22 @@ export type CrowdReportJsonBodyResult =
   | { success: false; status: 400 | 413; error: string };
 
 type AppDb = ReturnType<typeof import('~/db').getDb>;
-type CrowdReportReadableDb = Pick<AppDb, 'select'>;
+type CrowdReportTransaction = Parameters<
+  Parameters<AppDb['transaction']>[0]
+>[0];
+type CrowdReportReadableDb = Pick<CrowdReportTransaction, 'select'>;
 
 type PersistCrowdReportOptions = {
   now?: DateTime;
   rateLimitPerHour?: number;
   idFactory?: () => string;
+};
+
+type PersistCrowdReportTransactionContext = {
+  rateLimitPerHour: number;
+  idFactory: () => string;
+  bucketStartAt: string;
+  reportId: string;
 };
 
 type AutomoderateCrowdReportOptions = {
@@ -553,48 +563,153 @@ export async function automoderateCrowdReport(
   const duplicateWindowMinutes =
     options.duplicateWindowMinutes ?? DEFAULT_DUPLICATE_WINDOW_MINUTES;
 
-  return db.transaction(async (tx) => {
-    const duplicate = await findDuplicateCrowdReport(
+  return db.transaction((tx) =>
+    automoderateCrowdReportInTransaction(
       tx,
       reportId,
       submission,
       duplicateWindowMinutes,
-    );
-    const status = duplicate == null ? 'accepted' : 'duplicate';
+      idFactory,
+    ),
+  );
+}
 
-    const [updatedReport] = await tx
-      .update(crowdReportsTable)
-      .set({
-        status,
-        duplicate_of_id: duplicate?.id ?? null,
-        updated_at: sql`now()`,
-      })
-      .where(eq(crowdReportsTable.id, reportId))
-      .returning({
-        id: crowdReportsTable.id,
-        status: crowdReportsTable.status,
-        duplicateOfId: crowdReportsTable.duplicate_of_id,
-      });
+async function automoderateCrowdReportInTransaction(
+  tx: CrowdReportTransaction,
+  reportId: string,
+  submission: CrowdReportSubmission,
+  duplicateWindowMinutes: number,
+  idFactory: () => string,
+) {
+  const duplicate = await findDuplicateCrowdReport(
+    tx,
+    reportId,
+    submission,
+    duplicateWindowMinutes,
+  );
+  const status = duplicate == null ? 'accepted' : 'duplicate';
 
-    await tx.insert(crowdReportModerationEventsTable).values({
-      id: idFactory(),
-      report_id: reportId,
-      actor: 'system',
-      action: duplicate == null ? 'automated_accepted' : 'automated_duplicate',
-      note:
-        duplicate == null
-          ? 'Report accepted by automated moderation rules'
-          : `Report automatically marked as duplicate of ${duplicate.id}`,
+  const [updatedReport] = await tx
+    .update(crowdReportsTable)
+    .set({
+      status,
+      duplicate_of_id: duplicate?.id ?? null,
+      updated_at: sql`now()`,
+    })
+    .where(eq(crowdReportsTable.id, reportId))
+    .returning({
+      id: crowdReportsTable.id,
+      status: crowdReportsTable.status,
+      duplicateOfId: crowdReportsTable.duplicate_of_id,
     });
 
-    return (
-      updatedReport ?? {
-        id: reportId,
-        status,
-        duplicateOfId: duplicate?.id ?? null,
-      }
-    );
+  await tx.insert(crowdReportModerationEventsTable).values({
+    id: idFactory(),
+    report_id: reportId,
+    actor: 'system',
+    action: duplicate == null ? 'automated_accepted' : 'automated_duplicate',
+    note:
+      duplicate == null
+        ? 'Report accepted by automated moderation rules'
+        : `Report automatically marked as duplicate of ${duplicate.id}`,
   });
+
+  return (
+    updatedReport ?? {
+      id: reportId,
+      status,
+      duplicateOfId: duplicate?.id ?? null,
+    }
+  );
+}
+
+async function persistCrowdReportInTransaction(
+  tx: CrowdReportTransaction,
+  submission: CrowdReportSubmission,
+  abuseContext: CrowdReportAbuseContext,
+  context: PersistCrowdReportTransactionContext,
+) {
+  const [rateLimit] = await tx
+    .insert(crowdReportRateLimitsTable)
+    .values({
+      ip_hash: abuseContext.ipHash,
+      bucket_start_at: context.bucketStartAt,
+      submission_count: 1,
+      client_fingerprint_hash: abuseContext.clientFingerprintHash,
+    })
+    .onConflictDoUpdate({
+      target: [
+        crowdReportRateLimitsTable.ip_hash,
+        crowdReportRateLimitsTable.bucket_start_at,
+      ],
+      set: {
+        submission_count: sql`${crowdReportRateLimitsTable.submission_count} + 1`,
+        client_fingerprint_hash:
+          abuseContext.clientFingerprintHash ??
+          crowdReportRateLimitsTable.client_fingerprint_hash,
+        updated_at: sql`now()`,
+      },
+    })
+    .returning({
+      submissionCount: crowdReportRateLimitsTable.submission_count,
+    });
+
+  if ((rateLimit?.submissionCount ?? 0) > context.rateLimitPerHour) {
+    throw new CrowdReportRateLimitError(
+      context.rateLimitPerHour,
+      context.bucketStartAt,
+    );
+  }
+
+  await tx.insert(crowdReportsTable).values({
+    id: context.reportId,
+    observed_at: submission.observedAt,
+    direction_text: submission.directionText,
+    effect: submission.effect,
+    delay_minutes: submission.delayMinutes,
+    still_happening: submission.isStillHappening,
+    text: submission.text,
+    status: 'pending',
+  });
+
+  if (submission.lineIds.length > 0) {
+    await tx.insert(crowdReportLinesTable).values(
+      submission.lineIds.map((lineId) => ({
+        report_id: context.reportId,
+        line_id: lineId,
+      })),
+    );
+  }
+
+  if (submission.stationIds.length > 0) {
+    await tx.insert(crowdReportStationsTable).values(
+      submission.stationIds.map((stationId) => ({
+        report_id: context.reportId,
+        station_id: stationId,
+      })),
+    );
+  }
+
+  await tx.insert(crowdReportAbuseEventsTable).values({
+    id: context.idFactory(),
+    report_id: context.reportId,
+    ip_hash: abuseContext.ipHash,
+    user_agent_hash: abuseContext.userAgentHash,
+    client_fingerprint_hash: abuseContext.clientFingerprintHash,
+    turnstile_token_hash: abuseContext.turnstileTokenHash,
+    turnstile_outcome: abuseContext.turnstileOutcome,
+    rate_limit_bucket_start_at: context.bucketStartAt,
+  });
+
+  await tx.insert(crowdReportModerationEventsTable).values({
+    id: context.idFactory(),
+    report_id: context.reportId,
+    actor: 'system',
+    action: 'submitted',
+    note: 'Report submitted through public API',
+  });
+
+  return { id: context.reportId, status: 'pending' as const };
 }
 
 export async function persistCrowdReport(
@@ -609,84 +724,50 @@ export async function persistCrowdReport(
   const idFactory = options.idFactory ?? (() => crypto.randomUUID());
   const reportId = idFactory();
 
+  return db.transaction((tx) =>
+    persistCrowdReportInTransaction(tx, submission, abuseContext, {
+      rateLimitPerHour: limit,
+      idFactory,
+      bucketStartAt,
+      reportId,
+    }),
+  );
+}
+
+export async function persistAutomoderatedCrowdReport(
+  db: AppDb,
+  submission: CrowdReportSubmission,
+  abuseContext: CrowdReportAbuseContext,
+  options: PersistCrowdReportOptions & AutomoderateCrowdReportOptions = {},
+) {
+  const now = options.now ?? DateTime.now().setZone(SG_TIMEZONE);
+  const bucketStartAt = getCrowdReportRateLimitBucketStart(now);
+  const rateLimitPerHour =
+    options.rateLimitPerHour ?? DEFAULT_RATE_LIMIT_PER_HOUR;
+  const duplicateWindowMinutes =
+    options.duplicateWindowMinutes ?? DEFAULT_DUPLICATE_WINDOW_MINUTES;
+  const idFactory = options.idFactory ?? (() => crypto.randomUUID());
+  const reportId = idFactory();
+
   return db.transaction(async (tx) => {
-    const [rateLimit] = await tx
-      .insert(crowdReportRateLimitsTable)
-      .values({
-        ip_hash: abuseContext.ipHash,
-        bucket_start_at: bucketStartAt,
-        submission_count: 1,
-        client_fingerprint_hash: abuseContext.clientFingerprintHash,
-      })
-      .onConflictDoUpdate({
-        target: [
-          crowdReportRateLimitsTable.ip_hash,
-          crowdReportRateLimitsTable.bucket_start_at,
-        ],
-        set: {
-          submission_count: sql`${crowdReportRateLimitsTable.submission_count} + 1`,
-          client_fingerprint_hash:
-            abuseContext.clientFingerprintHash ??
-            crowdReportRateLimitsTable.client_fingerprint_hash,
-          updated_at: sql`now()`,
-        },
-      })
-      .returning({
-        submissionCount: crowdReportRateLimitsTable.submission_count,
-      });
+    const report = await persistCrowdReportInTransaction(
+      tx,
+      submission,
+      abuseContext,
+      {
+        rateLimitPerHour,
+        idFactory,
+        bucketStartAt,
+        reportId,
+      },
+    );
 
-    if ((rateLimit?.submissionCount ?? 0) > limit) {
-      throw new CrowdReportRateLimitError(limit, bucketStartAt);
-    }
-
-    await tx.insert(crowdReportsTable).values({
-      id: reportId,
-      observed_at: submission.observedAt,
-      direction_text: submission.directionText,
-      effect: submission.effect,
-      delay_minutes: submission.delayMinutes,
-      still_happening: submission.isStillHappening,
-      text: submission.text,
-      status: 'pending',
-    });
-
-    if (submission.lineIds.length > 0) {
-      await tx.insert(crowdReportLinesTable).values(
-        submission.lineIds.map((lineId) => ({
-          report_id: reportId,
-          line_id: lineId,
-        })),
-      );
-    }
-
-    if (submission.stationIds.length > 0) {
-      await tx.insert(crowdReportStationsTable).values(
-        submission.stationIds.map((stationId) => ({
-          report_id: reportId,
-          station_id: stationId,
-        })),
-      );
-    }
-
-    await tx.insert(crowdReportAbuseEventsTable).values({
-      id: idFactory(),
-      report_id: reportId,
-      ip_hash: abuseContext.ipHash,
-      user_agent_hash: abuseContext.userAgentHash,
-      client_fingerprint_hash: abuseContext.clientFingerprintHash,
-      turnstile_token_hash: abuseContext.turnstileTokenHash,
-      turnstile_outcome: abuseContext.turnstileOutcome,
-      rate_limit_bucket_start_at: bucketStartAt,
-    });
-
-    await tx.insert(crowdReportModerationEventsTable).values({
-      id: idFactory(),
-      report_id: reportId,
-      actor: 'system',
-      action: 'submitted',
-      note: 'Report submitted through public API',
-    });
-
-    return { id: reportId, status: 'pending' as const };
+    return automoderateCrowdReportInTransaction(
+      tx,
+      report.id,
+      submission,
+      duplicateWindowMinutes,
+      idFactory,
+    );
   });
 }

--- a/app/util/crowdReports.ts
+++ b/app/util/crowdReports.ts
@@ -472,6 +472,7 @@ async function findDuplicateCrowdReport(
   const candidates = await db
     .select({
       id: crowdReportsTable.id,
+      status: crowdReportsTable.status,
       directionText: crowdReportsTable.direction_text,
     })
     .from(crowdReportsTable)
@@ -481,7 +482,7 @@ async function findDuplicateCrowdReport(
         submission.effect == null
           ? isNull(crowdReportsTable.effect)
           : eq(crowdReportsTable.effect, submission.effect),
-        inArray(crowdReportsTable.status, ['pending', 'accepted']),
+        eq(crowdReportsTable.status, 'accepted'),
         gte(crowdReportsTable.observed_at, windowStartAt),
         lte(crowdReportsTable.observed_at, windowEndAt),
       ),
@@ -514,6 +515,9 @@ async function findDuplicateCrowdReport(
   ]);
 
   for (const candidate of candidates) {
+    if (candidate.status !== 'accepted') {
+      continue;
+    }
     if (
       normalizeComparableText(candidate.directionText) !==
       normalizeComparableText(submission.directionText)

--- a/app/util/crowdReports.ts
+++ b/app/util/crowdReports.ts
@@ -2,7 +2,7 @@ import {
   type IngestContentCrowdReportEffect,
   IngestContentCrowdReportEffectSchema,
 } from '@mrtdown/ingest-contracts';
-import { inArray, sql } from 'drizzle-orm';
+import { and, desc, eq, gte, inArray, isNull, lte, ne, sql } from 'drizzle-orm';
 import { DateTime } from 'luxon';
 import { z } from 'zod';
 import {
@@ -20,6 +20,7 @@ const SG_TIMEZONE = 'Asia/Singapore';
 const DEFAULT_RATE_LIMIT_PER_HOUR = 5;
 const MAX_REPORT_AGE_HOURS = 24;
 const MAX_REPORT_FUTURE_MINUTES = 15;
+const DEFAULT_DUPLICATE_WINDOW_MINUTES = 10;
 export const MAX_CROWD_REPORT_REQUEST_BYTES = 10_000;
 
 export const CrowdReportEffectSchema = IngestContentCrowdReportEffectSchema;
@@ -80,10 +81,16 @@ export type CrowdReportJsonBodyResult =
   | { success: false; status: 400 | 413; error: string };
 
 type AppDb = ReturnType<typeof import('~/db').getDb>;
+type CrowdReportReadableDb = Pick<AppDb, 'select'>;
 
 type PersistCrowdReportOptions = {
   now?: DateTime;
   rateLimitPerHour?: number;
+  idFactory?: () => string;
+};
+
+type AutomoderateCrowdReportOptions = {
+  duplicateWindowMinutes?: number;
   idFactory?: () => string;
 };
 
@@ -103,6 +110,23 @@ export type TurnstileVerificationOptions = {
 export type TurnstileVerificationResult =
   | { success: true; outcome: 'skipped' | 'passed' }
   | { success: false; outcome: 'missing_token' | 'failed'; error: string };
+
+function normalizeComparableText(value: string | null | undefined) {
+  return value?.trim().toLocaleLowerCase() ?? '';
+}
+
+function normalizeIdSet(values: string[]) {
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+}
+
+function areSameIdSets(left: string[], right: string[]) {
+  const normalizedLeft = normalizeIdSet(left);
+  const normalizedRight = normalizeIdSet(right);
+  return (
+    normalizedLeft.length === normalizedRight.length &&
+    normalizedLeft.every((value, index) => value === normalizedRight[index])
+  );
+}
 
 export function validateCrowdReportSubmission(
   input: unknown,
@@ -422,6 +446,151 @@ export async function findMissingCrowdReportReferences(
       (id) => !existingStationIds.has(id),
     ),
   };
+}
+
+async function findDuplicateCrowdReport(
+  db: CrowdReportReadableDb,
+  reportId: string,
+  submission: CrowdReportSubmission,
+  duplicateWindowMinutes: number,
+) {
+  const observedAt = DateTime.fromISO(submission.observedAt, {
+    setZone: true,
+  });
+  const windowStartAt = observedAt
+    .minus({ minutes: duplicateWindowMinutes })
+    .toUTC()
+    .toISO();
+  const windowEndAt = observedAt
+    .plus({ minutes: duplicateWindowMinutes })
+    .toUTC()
+    .toISO();
+  if (windowStartAt == null || windowEndAt == null) {
+    return undefined;
+  }
+
+  const candidates = await db
+    .select({
+      id: crowdReportsTable.id,
+      directionText: crowdReportsTable.direction_text,
+    })
+    .from(crowdReportsTable)
+    .where(
+      and(
+        ne(crowdReportsTable.id, reportId),
+        submission.effect == null
+          ? isNull(crowdReportsTable.effect)
+          : eq(crowdReportsTable.effect, submission.effect),
+        inArray(crowdReportsTable.status, ['pending', 'accepted']),
+        gte(crowdReportsTable.observed_at, windowStartAt),
+        lte(crowdReportsTable.observed_at, windowEndAt),
+      ),
+    )
+    .orderBy(desc(crowdReportsTable.created_at))
+    .limit(20);
+
+  const candidateIds = candidates.map((candidate) => candidate.id);
+  if (candidateIds.length === 0) {
+    return undefined;
+  }
+
+  const [candidateLines, candidateStations] = await Promise.all([
+    db
+      .select({
+        reportId: crowdReportLinesTable.report_id,
+        lineId: crowdReportLinesTable.line_id,
+      })
+      .from(crowdReportLinesTable)
+      .where(inArray(crowdReportLinesTable.report_id, candidateIds))
+      .limit(160),
+    db
+      .select({
+        reportId: crowdReportStationsTable.report_id,
+        stationId: crowdReportStationsTable.station_id,
+      })
+      .from(crowdReportStationsTable)
+      .where(inArray(crowdReportStationsTable.report_id, candidateIds))
+      .limit(320),
+  ]);
+
+  for (const candidate of candidates) {
+    if (
+      normalizeComparableText(candidate.directionText) !==
+      normalizeComparableText(submission.directionText)
+    ) {
+      continue;
+    }
+
+    const lineIds = candidateLines
+      .filter((line) => line.reportId === candidate.id)
+      .map((line) => line.lineId);
+    const stationIds = candidateStations
+      .filter((station) => station.reportId === candidate.id)
+      .map((station) => station.stationId);
+
+    if (
+      areSameIdSets(lineIds, submission.lineIds) &&
+      areSameIdSets(stationIds, submission.stationIds)
+    ) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+export async function automoderateCrowdReport(
+  db: AppDb,
+  reportId: string,
+  submission: CrowdReportSubmission,
+  options: AutomoderateCrowdReportOptions = {},
+) {
+  const idFactory = options.idFactory ?? (() => crypto.randomUUID());
+  const duplicateWindowMinutes =
+    options.duplicateWindowMinutes ?? DEFAULT_DUPLICATE_WINDOW_MINUTES;
+
+  return db.transaction(async (tx) => {
+    const duplicate = await findDuplicateCrowdReport(
+      tx,
+      reportId,
+      submission,
+      duplicateWindowMinutes,
+    );
+    const status = duplicate == null ? 'accepted' : 'duplicate';
+
+    const [updatedReport] = await tx
+      .update(crowdReportsTable)
+      .set({
+        status,
+        duplicate_of_id: duplicate?.id ?? null,
+        updated_at: sql`now()`,
+      })
+      .where(eq(crowdReportsTable.id, reportId))
+      .returning({
+        id: crowdReportsTable.id,
+        status: crowdReportsTable.status,
+        duplicateOfId: crowdReportsTable.duplicate_of_id,
+      });
+
+    await tx.insert(crowdReportModerationEventsTable).values({
+      id: idFactory(),
+      report_id: reportId,
+      actor: 'system',
+      action: duplicate == null ? 'automated_accepted' : 'automated_duplicate',
+      note:
+        duplicate == null
+          ? 'Report accepted by automated moderation rules'
+          : `Report automatically marked as duplicate of ${duplicate.id}`,
+    });
+
+    return (
+      updatedReport ?? {
+        id: reportId,
+        status,
+        duplicateOfId: duplicate?.id ?? null,
+      }
+    );
+  });
 }
 
 export async function persistCrowdReport(

--- a/app/util/crowdReports.ts
+++ b/app/util/crowdReports.ts
@@ -138,6 +138,15 @@ function areSameIdSets(left: string[], right: string[]) {
   );
 }
 
+function buildDuplicateLockKey(submission: CrowdReportSubmission) {
+  return JSON.stringify({
+    effect: submission.effect ?? null,
+    directionText: normalizeComparableText(submission.directionText),
+    lineIds: normalizeIdSet(submission.lineIds),
+    stationIds: normalizeIdSet(submission.stationIds),
+  });
+}
+
 export function validateCrowdReportSubmission(
   input: unknown,
   now = DateTime.now().setZone(SG_TIMEZONE),
@@ -581,6 +590,10 @@ async function automoderateCrowdReportInTransaction(
   duplicateWindowMinutes: number,
   idFactory: () => string,
 ) {
+  await tx.execute(
+    sql`select pg_advisory_xact_lock(hashtextextended(${buildDuplicateLockKey(submission)}, 0::bigint))`,
+  );
+
   const duplicate = await findDuplicateCrowdReport(
     tx,
     reportId,

--- a/app/util/crowdReports.ts
+++ b/app/util/crowdReports.ts
@@ -21,6 +21,7 @@ const DEFAULT_RATE_LIMIT_PER_HOUR = 5;
 const MAX_REPORT_AGE_HOURS = 24;
 const MAX_REPORT_FUTURE_MINUTES = 15;
 const DEFAULT_DUPLICATE_WINDOW_MINUTES = 10;
+const DUPLICATE_CANDIDATE_PAGE_SIZE = 100;
 export const MAX_CROWD_REPORT_REQUEST_BYTES = 10_000;
 
 export const CrowdReportEffectSchema = IngestContentCrowdReportEffectSchema;
@@ -488,78 +489,85 @@ async function findDuplicateCrowdReport(
     return undefined;
   }
 
-  const candidates = await db
-    .select({
-      id: crowdReportsTable.id,
-      status: crowdReportsTable.status,
-      directionText: crowdReportsTable.direction_text,
-    })
-    .from(crowdReportsTable)
-    .where(
-      and(
-        ne(crowdReportsTable.id, reportId),
-        submission.effect == null
-          ? isNull(crowdReportsTable.effect)
-          : eq(crowdReportsTable.effect, submission.effect),
-        eq(crowdReportsTable.status, 'accepted'),
-        gte(crowdReportsTable.observed_at, windowStartAt),
-        lte(crowdReportsTable.observed_at, windowEndAt),
-      ),
-    )
-    .orderBy(desc(crowdReportsTable.created_at))
-    .limit(20);
-
-  const candidateIds = candidates.map((candidate) => candidate.id);
-  if (candidateIds.length === 0) {
-    return undefined;
-  }
-
-  const [candidateLines, candidateStations] = await Promise.all([
-    db
+  let offset = 0;
+  while (true) {
+    const candidates = await db
       .select({
-        reportId: crowdReportLinesTable.report_id,
-        lineId: crowdReportLinesTable.line_id,
+        id: crowdReportsTable.id,
+        status: crowdReportsTable.status,
+        directionText: crowdReportsTable.direction_text,
       })
-      .from(crowdReportLinesTable)
-      .where(inArray(crowdReportLinesTable.report_id, candidateIds))
-      .limit(160),
-    db
-      .select({
-        reportId: crowdReportStationsTable.report_id,
-        stationId: crowdReportStationsTable.station_id,
-      })
-      .from(crowdReportStationsTable)
-      .where(inArray(crowdReportStationsTable.report_id, candidateIds))
-      .limit(320),
-  ]);
+      .from(crowdReportsTable)
+      .where(
+        and(
+          ne(crowdReportsTable.id, reportId),
+          submission.effect == null
+            ? isNull(crowdReportsTable.effect)
+            : eq(crowdReportsTable.effect, submission.effect),
+          eq(crowdReportsTable.status, 'accepted'),
+          gte(crowdReportsTable.observed_at, windowStartAt),
+          lte(crowdReportsTable.observed_at, windowEndAt),
+        ),
+      )
+      .orderBy(desc(crowdReportsTable.created_at))
+      .offset(offset)
+      .limit(DUPLICATE_CANDIDATE_PAGE_SIZE);
 
-  for (const candidate of candidates) {
-    if (candidate.status !== 'accepted') {
-      continue;
-    }
-    if (
-      normalizeComparableText(candidate.directionText) !==
-      normalizeComparableText(submission.directionText)
-    ) {
-      continue;
+    const candidateIds = candidates.map((candidate) => candidate.id);
+    if (candidateIds.length === 0) {
+      return undefined;
     }
 
-    const lineIds = candidateLines
-      .filter((line) => line.reportId === candidate.id)
-      .map((line) => line.lineId);
-    const stationIds = candidateStations
-      .filter((station) => station.reportId === candidate.id)
-      .map((station) => station.stationId);
+    const [candidateLines, candidateStations] = await Promise.all([
+      db
+        .select({
+          reportId: crowdReportLinesTable.report_id,
+          lineId: crowdReportLinesTable.line_id,
+        })
+        .from(crowdReportLinesTable)
+        .where(inArray(crowdReportLinesTable.report_id, candidateIds))
+        .limit(DUPLICATE_CANDIDATE_PAGE_SIZE * 8),
+      db
+        .select({
+          reportId: crowdReportStationsTable.report_id,
+          stationId: crowdReportStationsTable.station_id,
+        })
+        .from(crowdReportStationsTable)
+        .where(inArray(crowdReportStationsTable.report_id, candidateIds))
+        .limit(DUPLICATE_CANDIDATE_PAGE_SIZE * 16),
+    ]);
 
-    if (
-      areSameIdSets(lineIds, submission.lineIds) &&
-      areSameIdSets(stationIds, submission.stationIds)
-    ) {
-      return candidate;
+    for (const candidate of candidates) {
+      if (candidate.status !== 'accepted') {
+        continue;
+      }
+      if (
+        normalizeComparableText(candidate.directionText) !==
+        normalizeComparableText(submission.directionText)
+      ) {
+        continue;
+      }
+
+      const lineIds = candidateLines
+        .filter((line) => line.reportId === candidate.id)
+        .map((line) => line.lineId);
+      const stationIds = candidateStations
+        .filter((station) => station.reportId === candidate.id)
+        .map((station) => station.stationId);
+
+      if (
+        areSameIdSets(lineIds, submission.lineIds) &&
+        areSameIdSets(stationIds, submission.stationIds)
+      ) {
+        return candidate;
+      }
     }
+
+    if (candidates.length < DUPLICATE_CANDIDATE_PAGE_SIZE) {
+      return undefined;
+    }
+    offset += DUPLICATE_CANDIDATE_PAGE_SIZE;
   }
-
-  return undefined;
 }
 
 export async function automoderateCrowdReport(

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -307,18 +307,20 @@ Exit criteria:
   failures.
 - `npm run verify` passes.
 
-### Phase 3: Moderation And Admin Surface
+### Phase 3: Automated Moderation
 
-- Add an internal route or protected API for listing pending reports.
-- Support accept, reject, duplicate, and merge-into-cluster actions.
+- Add deterministic automated moderation immediately after public submission.
+- Auto-accept structurally valid reports that pass validation and abuse gates.
+- Auto-mark same-context reports inside a short observation window as
+  duplicates.
 - Record moderation events for auditability.
-- Keep internal routes behind `internalMiddleware` or a stronger auth boundary.
+- Keep reports out of a long-lived manual pending queue.
 
 Exit criteria:
 
-- Operators can review pending reports without direct database access.
-- Accepted reports are ready for dispatch, but canonical data is still unchanged
-  until dispatch runs.
+- Valid reports become `accepted` or `duplicate` without operator action.
+- Accepted reports are ready for clustering or dispatch, but canonical data is
+  still unchanged until dispatch runs.
 
 ### Phase 4: Clustering And Community Signal
 
@@ -334,7 +336,7 @@ Exit criteria:
 
 - The public UI can show "community reports" without confusing them with
   canonical issues.
-- Single unverified reports remain private to moderation.
+- Single accepted reports remain site-local and are not displayed publicly.
 
 ### Phase 5: Dispatch To Canonical Ingest
 
@@ -353,16 +355,15 @@ Exit criteria:
 
 ### Phase 6: Automation Policy
 
-- Begin with manual review for all reports.
-- Add auto-reject rules for empty, stale, or non-transit reports.
-- Add auto-accept only for high-confidence clusters after manual review metrics
-  are good enough.
+- Expand deterministic auto-reject rules for empty, stale, non-transit, or
+  obviously abusive reports as production traffic reveals patterns.
+- Add auto-accept clustering thresholds for high-confidence clusters.
 - Revisit thresholds using observed false-positive and duplicate rates.
 
 Exit criteria:
 
-- Automation improves moderation load without making unreviewed single reports
-  canonical.
+- Automation keeps low-quality reports out while accepted site-local reports
+  remain non-canonical until dispatch and data-side review complete.
 
 ## Progress Log
 
@@ -389,6 +390,9 @@ Exit criteria:
 - 2026-05-24: Continued Phase 2A by adding field-level validation messages,
   validation focus management, and required reviewer notes for ambiguous
   `unknown` reports or `Other` direction submissions.
+- 2026-05-25: Changed Phase 3 direction from manual review to fully automated
+  moderation. Implemented automatic accept-or-duplicate moderation after public
+  submission, with audit events and same-context duplicate detection.
 
 ## Decision Log
 
@@ -409,6 +413,9 @@ Exit criteria:
   skipped stops and no-service-between-stations as explicit range cases instead.
 - 2026-05-24: Prefer structured direction choices derived from line context,
   with `Not sure` and `Other` fallbacks.
+- 2026-05-25: Use fully automated site-local moderation instead of a manual
+  operator queue. Accepted reports are still non-canonical until the dispatch
+  and `mrtdown-data` review path lands them in published archives.
 
 ## Validation
 


### PR DESCRIPTION
## Summary

- automatically moderate accepted crowd-report submissions after the public API write
- mark same-context reports within the duplicate window as duplicates with audit events
- update the crowd-sourced reports plan to reflect fully automated site-local moderation

## Validation

- `npm run verify`

Note: full verification was run outside the sandbox because `db:generate:check` needs `tsx` IPC pipe permissions.