### PR TITLE
feat: dispatch crowd reports to canonical ingest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,11 @@ TIER=
 GIT_SHA=
 
 VITE_ROOT_URL=http://localhost:3000
+
+# Crowd report canonical ingest dispatch. Set the token as a secret in
+# deployed environments; it needs repository dispatch permission on mrtdown-data.
+CROWD_REPORT_DISPATCH_GITHUB_TOKEN=
+CROWD_REPORT_DISPATCH_GITHUB_OWNER=foldaway
+CROWD_REPORT_DISPATCH_GITHUB_REPO=mrtdown-data
+CROWD_REPORT_DISPATCH_GITHUB_EVENT_TYPE=ingest
+CROWD_REPORT_DISPATCH_LIMIT=10

--- a/app/routeTree.gen.ts
+++ b/app/routeTree.gen.ts
@@ -31,6 +31,7 @@ import { Route as Char123LangChar125HistoryYearMonthRouteImport } from './routes
 import { Route as InternalApiTasksPullRouteImport } from './routes/internal.api.tasks.pull'
 import { Route as InternalApiTasksPublicHolidaysRouteImport } from './routes/internal.api.tasks.public-holidays'
 import { Route as InternalApiTasksFactsRouteImport } from './routes/internal.api.tasks.facts'
+import { Route as InternalApiTasksCrowdReportDispatchRouteImport } from './routes/internal.api.tasks.crowd-report-dispatch'
 
 const Char123LangChar125Route = Char123LangChar125RouteImport.update({
   id: '/{-$lang}',
@@ -156,6 +157,12 @@ const InternalApiTasksFactsRoute = InternalApiTasksFactsRouteImport.update({
   path: '/internal/api/tasks/facts',
   getParentRoute: () => rootRouteImport,
 } as any)
+const InternalApiTasksCrowdReportDispatchRoute =
+  InternalApiTasksCrowdReportDispatchRouteImport.update({
+    id: '/internal/api/tasks/crowd-report-dispatch',
+    path: '/internal/api/tasks/crowd-report-dispatch',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/{-$lang}': typeof Char123LangChar125RouteWithChildren
@@ -171,6 +178,7 @@ export interface FileRoutesByFullPath {
   '/{-$lang}/status/$lineId': typeof Char123LangChar125StatusLineIdRoute
   '/{-$lang}/history/': typeof Char123LangChar125HistoryIndexRoute
   '/{-$lang}/statistics/': typeof Char123LangChar125StatisticsIndexRoute
+  '/internal/api/tasks/crowd-report-dispatch': typeof InternalApiTasksCrowdReportDispatchRoute
   '/internal/api/tasks/facts': typeof InternalApiTasksFactsRoute
   '/internal/api/tasks/public-holidays': typeof InternalApiTasksPublicHolidaysRoute
   '/internal/api/tasks/pull': typeof InternalApiTasksPullRoute
@@ -194,6 +202,7 @@ export interface FileRoutesByTo {
   '/{-$lang}/status/$lineId': typeof Char123LangChar125StatusLineIdRoute
   '/{-$lang}/history': typeof Char123LangChar125HistoryIndexRoute
   '/{-$lang}/statistics': typeof Char123LangChar125StatisticsIndexRoute
+  '/internal/api/tasks/crowd-report-dispatch': typeof InternalApiTasksCrowdReportDispatchRoute
   '/internal/api/tasks/facts': typeof InternalApiTasksFactsRoute
   '/internal/api/tasks/public-holidays': typeof InternalApiTasksPublicHolidaysRoute
   '/internal/api/tasks/pull': typeof InternalApiTasksPullRoute
@@ -219,6 +228,7 @@ export interface FileRoutesById {
   '/{-$lang}/status/$lineId': typeof Char123LangChar125StatusLineIdRoute
   '/{-$lang}/history/': typeof Char123LangChar125HistoryIndexRoute
   '/{-$lang}/statistics/': typeof Char123LangChar125StatisticsIndexRoute
+  '/internal/api/tasks/crowd-report-dispatch': typeof InternalApiTasksCrowdReportDispatchRoute
   '/internal/api/tasks/facts': typeof InternalApiTasksFactsRoute
   '/internal/api/tasks/public-holidays': typeof InternalApiTasksPublicHolidaysRoute
   '/internal/api/tasks/pull': typeof InternalApiTasksPullRoute
@@ -245,6 +255,7 @@ export interface FileRouteTypes {
     | '/{-$lang}/status/$lineId'
     | '/{-$lang}/history/'
     | '/{-$lang}/statistics/'
+    | '/internal/api/tasks/crowd-report-dispatch'
     | '/internal/api/tasks/facts'
     | '/internal/api/tasks/public-holidays'
     | '/internal/api/tasks/pull'
@@ -268,6 +279,7 @@ export interface FileRouteTypes {
     | '/{-$lang}/status/$lineId'
     | '/{-$lang}/history'
     | '/{-$lang}/statistics'
+    | '/internal/api/tasks/crowd-report-dispatch'
     | '/internal/api/tasks/facts'
     | '/internal/api/tasks/public-holidays'
     | '/internal/api/tasks/pull'
@@ -292,6 +304,7 @@ export interface FileRouteTypes {
     | '/{-$lang}/status/$lineId'
     | '/{-$lang}/history/'
     | '/{-$lang}/statistics/'
+    | '/internal/api/tasks/crowd-report-dispatch'
     | '/internal/api/tasks/facts'
     | '/internal/api/tasks/public-holidays'
     | '/internal/api/tasks/pull'
@@ -308,6 +321,7 @@ export interface RootRouteChildren {
   ApiIssuesDayRoute: typeof ApiIssuesDayRoute
   ApiReportsRoute: typeof ApiReportsRoute
   ApiPhSplatRoute: typeof ApiPhSplatRoute
+  InternalApiTasksCrowdReportDispatchRoute: typeof InternalApiTasksCrowdReportDispatchRoute
   InternalApiTasksFactsRoute: typeof InternalApiTasksFactsRoute
   InternalApiTasksPublicHolidaysRoute: typeof InternalApiTasksPublicHolidaysRoute
   InternalApiTasksPullRoute: typeof InternalApiTasksPullRoute
@@ -469,6 +483,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof InternalApiTasksFactsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/internal/api/tasks/crowd-report-dispatch': {
+      id: '/internal/api/tasks/crowd-report-dispatch'
+      path: '/internal/api/tasks/crowd-report-dispatch'
+      fullPath: '/internal/api/tasks/crowd-report-dispatch'
+      preLoaderRoute: typeof InternalApiTasksCrowdReportDispatchRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -524,6 +545,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiIssuesDayRoute: ApiIssuesDayRoute,
   ApiReportsRoute: ApiReportsRoute,
   ApiPhSplatRoute: ApiPhSplatRoute,
+  InternalApiTasksCrowdReportDispatchRoute:
+    InternalApiTasksCrowdReportDispatchRoute,
   InternalApiTasksFactsRoute: InternalApiTasksFactsRoute,
   InternalApiTasksPublicHolidaysRoute: InternalApiTasksPublicHolidaysRoute,
   InternalApiTasksPullRoute: InternalApiTasksPullRoute,

--- a/app/routes/internal.api.tasks.crowd-report-dispatch.ts
+++ b/app/routes/internal.api.tasks.crowd-report-dispatch.ts
@@ -1,0 +1,144 @@
+import { env } from 'cloudflare:workers';
+import { createFileRoute } from '@tanstack/react-router';
+import { z } from 'zod';
+import { getDb } from '~/db';
+import {
+  dispatchPendingCrowdReports,
+  getDispatchableCrowdReportCandidates,
+} from '~/util/crowdReportDispatch';
+import { internalMiddleware } from '~/util/internal.middleware';
+
+type CrowdReportDispatchRuntimeEnv = typeof env & {
+  CROWD_REPORT_DISPATCH_GITHUB_TOKEN?: string;
+  CROWD_REPORT_DISPATCH_GITHUB_OWNER?: string;
+  CROWD_REPORT_DISPATCH_GITHUB_REPO?: string;
+  CROWD_REPORT_DISPATCH_GITHUB_EVENT_TYPE?: string;
+};
+
+const RequestSchema = z
+  .object({
+    dryRun: z.boolean().default(false),
+    kind: z.enum(['any', 'cluster', 'report']).default('any'),
+    limit: z.number().int().min(1).max(50).default(10),
+  })
+  .strict();
+
+async function parseOptionalJsonBody(request: Request) {
+  if (request.headers.get('content-length') === '0') {
+    return {};
+  }
+
+  try {
+    const text = await request.text();
+    return text.trim().length === 0 ? {} : JSON.parse(text);
+  } catch {
+    throw new Response(
+      JSON.stringify({
+        success: false,
+        error: 'Invalid JSON request body',
+      }),
+      {
+        status: 400,
+        headers: { 'content-type': 'application/json' },
+      },
+    );
+  }
+}
+
+function getRuntimeEnv() {
+  return env as CrowdReportDispatchRuntimeEnv;
+}
+
+export const Route = createFileRoute(
+  '/internal/api/tasks/crowd-report-dispatch',
+)({
+  server: {
+    middleware: [internalMiddleware],
+    handlers: {
+      async POST({ request }) {
+        let json: unknown;
+        try {
+          json = await parseOptionalJsonBody(request);
+        } catch (error) {
+          if (error instanceof Response) {
+            return error;
+          }
+          throw error;
+        }
+
+        const parsed = RequestSchema.safeParse(json);
+        if (!parsed.success) {
+          return Response.json(
+            {
+              success: false,
+              error: 'Invalid crowd report dispatch request',
+              issues: parsed.error.issues,
+            },
+            { status: 400 },
+          );
+        }
+
+        const runtimeEnv = getRuntimeEnv();
+        const rootUrl = runtimeEnv.VITE_ROOT_URL;
+        if (!rootUrl) {
+          return Response.json(
+            { success: false, error: 'VITE_ROOT_URL is missing' },
+            { status: 503 },
+          );
+        }
+
+        const db = getDb();
+        if (parsed.data.dryRun) {
+          const candidates = await getDispatchableCrowdReportCandidates(db, {
+            kind: parsed.data.kind,
+            limit: parsed.data.limit,
+            rootUrl,
+          });
+          return Response.json({
+            success: true,
+            dryRun: true,
+            count: candidates.length,
+            candidates,
+          });
+        }
+
+        const token = runtimeEnv.CROWD_REPORT_DISPATCH_GITHUB_TOKEN;
+        if (!token) {
+          return Response.json(
+            {
+              success: false,
+              error: 'Crowd report dispatch GitHub token is missing',
+            },
+            { status: 503 },
+          );
+        }
+
+        const result = await dispatchPendingCrowdReports(db, {
+          kind: parsed.data.kind,
+          limit: parsed.data.limit,
+          rootUrl,
+          token,
+          owner: runtimeEnv.CROWD_REPORT_DISPATCH_GITHUB_OWNER,
+          repo: runtimeEnv.CROWD_REPORT_DISPATCH_GITHUB_REPO,
+          eventType: runtimeEnv.CROWD_REPORT_DISPATCH_GITHUB_EVENT_TYPE,
+        });
+        for (const failure of result.results.filter((item) => !item.success)) {
+          console.error('Crowd report dispatch failed', failure);
+        }
+
+        return Response.json(
+          {
+            success: result.success,
+            count: result.count,
+            dispatched: result.dispatched,
+            failed: result.failed,
+            results: result.results,
+          },
+          {
+            status: result.count === 0 ? 200 : result.failed > 0 ? 207 : 202,
+          },
+        );
+      },
+    },
+  },
+});

--- a/app/util/crowdReportDispatch.test.ts
+++ b/app/util/crowdReportDispatch.test.ts
@@ -1,0 +1,186 @@
+import { IngestPayloadSchema } from '@mrtdown/ingest-contracts';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildCrowdReportIngestPayload,
+  buildCrowdReportSourceUrl,
+  dispatchCrowdReportPayloadToGitHub,
+} from './crowdReportDispatch';
+
+describe('buildCrowdReportIngestPayload', () => {
+  it('builds a valid crowd-report ingest payload without site-local metadata', () => {
+    const candidate = buildCrowdReportIngestPayload({
+      kind: 'cluster',
+      id: 'cluster-1',
+      reportIds: ['report-1', 'report-2', 'report-3'],
+      text: 'The train has been stopped for a while.',
+      createdAt: '2026-05-24T04:40:00.000Z',
+      observedAt: '2026-05-24T12:30:00.000+08:00',
+      lineIds: ['BPLRT'],
+      stationIds: ['BP6'],
+      directionText: 'Towards Choa Chu Kang',
+      effect: 'delay',
+      delayMinutes: 10,
+      reportCount: 3,
+      isStillHappening: true,
+      rootUrl: 'https://mrtdown.example',
+    });
+
+    expect(IngestPayloadSchema.safeParse(candidate.payload).success).toBe(true);
+    expect(candidate.payload.content[0]).toMatchObject({
+      source: 'crowd-report',
+      reportId: 'cluster:cluster-1',
+      lineIds: ['BPLRT'],
+      stationIds: ['BP6'],
+      effect: 'delay',
+      delayMinutes: 10,
+      reportCount: 3,
+      url: 'https://mrtdown.example/report?communitySource=cluster%3Acluster-1',
+    });
+    expect(candidate.payload.content[0]).not.toHaveProperty('ipHash');
+    expect(candidate.payload.content[0]).not.toHaveProperty(
+      'turnstileTokenHash',
+    );
+  });
+
+  it('requires at least one affected line or station through the ingest contract', () => {
+    expect(() =>
+      buildCrowdReportIngestPayload({
+        kind: 'report',
+        id: 'report-1',
+        reportIds: ['report-1'],
+        text: 'The train has been stopped for a while.',
+        createdAt: '2026-05-24T04:40:00.000Z',
+        observedAt: '2026-05-24T12:30:00.000+08:00',
+        lineIds: [],
+        stationIds: [],
+        directionText: null,
+        effect: 'delay',
+        delayMinutes: null,
+        reportCount: 1,
+        isStillHappening: null,
+        rootUrl: 'https://mrtdown.example',
+      }),
+    ).toThrow();
+  });
+});
+
+describe('buildCrowdReportSourceUrl', () => {
+  it('uses a stable public report URL with a non-PII community source id', () => {
+    expect(
+      buildCrowdReportSourceUrl('https://mrtdown.example', 'report', 'r1'),
+    ).toBe('https://mrtdown.example/report?communitySource=report%3Ar1');
+  });
+});
+
+describe('dispatchCrowdReportPayloadToGitHub', () => {
+  it('posts the ingest payload as a repository_dispatch event', async () => {
+    const payload = IngestPayloadSchema.parse({
+      content: [
+        {
+          source: 'crowd-report',
+          reportId: 'report:report-1',
+          text: 'A community report describes this issue.',
+          createdAt: '2026-05-24T04:40:00.000Z',
+          observedAt: '2026-05-24T12:30:00.000+08:00',
+          lineIds: ['BPLRT'],
+          url: 'https://mrtdown.example/report?communitySource=report%3Areport-1',
+        },
+      ],
+    });
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(null, {
+        status: 204,
+      }),
+    );
+
+    await expect(
+      dispatchCrowdReportPayloadToGitHub(
+        payload,
+        {
+          token: 'github-token',
+          owner: 'foldaway',
+          repo: 'mrtdown-data',
+          eventType: 'ingest',
+        },
+        fetchImpl,
+      ),
+    ).resolves.toEqual({ status: 204, responseText: '' });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.github.com/repos/foldaway/mrtdown-data/dispatches',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer github-token',
+          'X-GitHub-Api-Version': '2022-11-28',
+        }),
+        body: JSON.stringify({
+          event_type: 'ingest',
+          client_payload: payload,
+        }),
+      }),
+    );
+  });
+
+  it('surfaces GitHub dispatch failures with response context', async () => {
+    const payload = IngestPayloadSchema.parse({
+      content: [
+        {
+          source: 'crowd-report',
+          reportId: 'report:report-1',
+          text: 'A community report describes this issue.',
+          createdAt: '2026-05-24T04:40:00.000Z',
+          observedAt: '2026-05-24T12:30:00.000+08:00',
+          lineIds: ['BPLRT'],
+          url: 'https://mrtdown.example/report?communitySource=report%3Areport-1',
+        },
+      ],
+    });
+
+    await expect(
+      dispatchCrowdReportPayloadToGitHub(
+        payload,
+        { token: 'github-token' },
+        vi.fn().mockResolvedValue(
+          new Response('bad credentials', {
+            status: 401,
+          }),
+        ),
+      ),
+    ).rejects.toThrow(
+      'GitHub repository_dispatch failed with 401: bad credentials',
+    );
+  });
+
+  it('times out hanging GitHub dispatch requests', async () => {
+    const payload = IngestPayloadSchema.parse({
+      content: [
+        {
+          source: 'crowd-report',
+          reportId: 'report:report-1',
+          text: 'A community report describes this issue.',
+          createdAt: '2026-05-24T04:40:00.000Z',
+          observedAt: '2026-05-24T12:30:00.000+08:00',
+          lineIds: ['BPLRT'],
+          url: 'https://mrtdown.example/report?communitySource=report%3Areport-1',
+        },
+      ],
+    });
+    const fetchImpl = vi.fn(
+      (_url: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(new DOMException('The operation was aborted', 'AbortError'));
+          });
+        }),
+    );
+
+    await expect(
+      dispatchCrowdReportPayloadToGitHub(
+        payload,
+        { token: 'github-token', timeoutMs: 1 },
+        fetchImpl,
+      ),
+    ).rejects.toThrow('GitHub repository_dispatch timed out after 1ms');
+  });
+});

--- a/app/util/crowdReportDispatch.ts
+++ b/app/util/crowdReportDispatch.ts
@@ -1,0 +1,695 @@
+import {
+  IngestContentCrowdReportSource,
+  IngestPayloadSchema,
+  type IngestContentCrowdReport,
+  type IngestPayload,
+} from '@mrtdown/ingest-contracts';
+import { and, desc, eq, inArray, isNull, or, sql } from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import {
+  crowdReportClusterLinesTable,
+  crowdReportClustersTable,
+  crowdReportClusterStationsTable,
+  crowdReportLinesTable,
+  crowdReportsTable,
+  crowdReportStationsTable,
+} from '~/db/schema';
+
+const DEFAULT_DISPATCH_OWNER = 'foldaway';
+const DEFAULT_DISPATCH_REPO = 'mrtdown-data';
+const DEFAULT_DISPATCH_EVENT_TYPE = 'ingest';
+const DEFAULT_DISPATCH_LIMIT = 10;
+const DEFAULT_DISPATCH_TIMEOUT_MS = 15_000;
+const MAX_DISPATCH_LIMIT = 50;
+
+type AppDb = ReturnType<typeof import('~/db').getDb>;
+type CrowdReportTransaction = Parameters<
+  Parameters<AppDb['transaction']>[0]
+>[0];
+
+export type CrowdReportDispatchKind = 'cluster' | 'report';
+
+export type CrowdReportDispatchCandidate = {
+  kind: CrowdReportDispatchKind;
+  id: string;
+  reportIds: string[];
+  payload: IngestPayload;
+};
+
+export type CrowdReportDispatchConfig = {
+  token: string;
+  owner?: string;
+  repo?: string;
+  eventType?: string;
+  timeoutMs?: number;
+};
+
+export type CrowdReportDispatchResponse = {
+  status: number;
+  responseText: string;
+};
+
+export type CrowdReportDispatchRunResult = {
+  success: boolean;
+  count: number;
+  dispatched: number;
+  failed: number;
+  results: Array<{
+    kind: CrowdReportDispatchKind;
+    id: string;
+    success: boolean;
+    status?: number;
+    error?: string;
+    skipped?: boolean;
+  }>;
+};
+
+type CrowdReportDispatchOptions = {
+  candidates?: CrowdReportDispatchCandidate[];
+  limit?: number;
+  kind?: CrowdReportDispatchKind | 'any';
+  rootUrl: string;
+};
+
+type ReportContentInput = {
+  id: string;
+  kind: CrowdReportDispatchKind;
+  reportIds: string[];
+  text: string;
+  createdAt: string | Date;
+  observedAt: string | Date;
+  lineIds: string[];
+  stationIds: string[];
+  directionText: string | null;
+  effect: IngestContentCrowdReport['effect'] | null;
+  delayMinutes: number | null;
+  reportCount?: number;
+  isStillHappening?: boolean | null;
+  rootUrl: string;
+};
+
+function clampDispatchLimit(limit: number | undefined) {
+  if (limit == null) {
+    return DEFAULT_DISPATCH_LIMIT;
+  }
+  return Math.max(1, Math.min(MAX_DISPATCH_LIMIT, limit));
+}
+
+function normalizeTimestamp(value: string | Date) {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function hasCrowdReportClusterScope() {
+  return or(
+    sql`exists (select 1 from ${crowdReportClusterLinesTable} where ${crowdReportClusterLinesTable.cluster_id} = ${crowdReportClustersTable.id})`,
+    sql`exists (select 1 from ${crowdReportClusterStationsTable} where ${crowdReportClusterStationsTable.cluster_id} = ${crowdReportClustersTable.id})`,
+  );
+}
+
+export function buildCrowdReportSourceUrl(
+  rootUrl: string,
+  kind: CrowdReportDispatchKind,
+  id: string,
+) {
+  const url = new URL('/report', rootUrl);
+  url.searchParams.set('communitySource', `${kind}:${id}`);
+  return url.toString();
+}
+
+export function buildCrowdReportDispatchText(
+  input: Pick<
+    ReportContentInput,
+    | 'delayMinutes'
+    | 'directionText'
+    | 'effect'
+    | 'isStillHappening'
+    | 'lineIds'
+    | 'reportCount'
+    | 'stationIds'
+    | 'text'
+  >,
+) {
+  const contextParts = [
+    input.lineIds.length > 0 ? `lines ${input.lineIds.join(', ')}` : undefined,
+    input.stationIds.length > 0
+      ? `stations ${input.stationIds.join(', ')}`
+      : undefined,
+  ].filter((part): part is string => part != null);
+
+  const summary: string[] = [];
+  if (input.reportCount && input.reportCount > 1) {
+    summary.push(`${input.reportCount} community reports describe this issue.`);
+  } else {
+    summary.push('A community report describes this issue.');
+  }
+  if (input.effect) {
+    summary.push(`Reported effect: ${input.effect}.`);
+  }
+  if (contextParts.length > 0) {
+    summary.push(`Affected ${contextParts.join('; ')}.`);
+  }
+  if (input.directionText) {
+    summary.push(`Direction: ${input.directionText}.`);
+  }
+  if (input.delayMinutes != null) {
+    summary.push(`Reported delay: ${input.delayMinutes} minutes.`);
+  }
+  if (input.isStillHappening != null) {
+    summary.push(
+      input.isStillHappening
+        ? 'The reporter said this was still happening.'
+        : 'The reporter said this was no longer happening.',
+    );
+  }
+
+  summary.push(`Reporter note: ${input.text}`);
+  return summary.join(' ');
+}
+
+export function buildCrowdReportIngestPayload(
+  input: ReportContentInput,
+): CrowdReportDispatchCandidate {
+  const content: IngestContentCrowdReport = {
+    source: IngestContentCrowdReportSource,
+    reportId: `${input.kind}:${input.id}`,
+    text: buildCrowdReportDispatchText(input),
+    createdAt: normalizeTimestamp(input.createdAt),
+    observedAt: normalizeTimestamp(input.observedAt),
+    lineIds: input.lineIds.length > 0 ? input.lineIds : undefined,
+    stationIds: input.stationIds.length > 0 ? input.stationIds : undefined,
+    directionText: input.directionText ?? undefined,
+    effect: input.effect ?? undefined,
+    delayMinutes: input.delayMinutes ?? undefined,
+    reportCount: input.reportCount,
+    url: buildCrowdReportSourceUrl(input.rootUrl, input.kind, input.id),
+  };
+  const payload = IngestPayloadSchema.parse({ content: [content] });
+  return {
+    kind: input.kind,
+    id: input.id,
+    reportIds: input.reportIds,
+    payload,
+  };
+}
+
+export async function getDispatchableCrowdReportCandidates(
+  db: AppDb,
+  options: CrowdReportDispatchOptions,
+): Promise<CrowdReportDispatchCandidate[]> {
+  const limit = clampDispatchLimit(options.limit);
+  const candidates: CrowdReportDispatchCandidate[] = [];
+
+  if (options.kind !== 'report') {
+    candidates.push(
+      ...(await getDispatchableCrowdReportClusterCandidates(db, {
+        limit,
+        rootUrl: options.rootUrl,
+      })),
+    );
+  }
+
+  if (options.kind !== 'cluster' && candidates.length < limit) {
+    candidates.push(
+      ...(await getDispatchableSingleCrowdReportCandidates(db, {
+        limit: limit - candidates.length,
+        rootUrl: options.rootUrl,
+      })),
+    );
+  }
+
+  return candidates;
+}
+
+async function getDispatchableCrowdReportClusterCandidates(
+  db: AppDb,
+  options: { limit: number; rootUrl: string },
+) {
+  const clusterRows = await db
+    .select({
+      id: crowdReportClustersTable.id,
+      effect: crowdReportClustersTable.effect,
+      reportCount: crowdReportClustersTable.report_count,
+      windowEndAt: crowdReportClustersTable.window_end_at,
+      updatedAt: crowdReportClustersTable.updated_at,
+    })
+    .from(crowdReportClustersTable)
+    .where(
+      and(
+        eq(crowdReportClustersTable.status, 'accepted'),
+        isNull(crowdReportClustersTable.dispatched_at),
+        hasCrowdReportClusterScope(),
+      ),
+    )
+    .orderBy(desc(crowdReportClustersTable.window_end_at))
+    .limit(options.limit);
+
+  const clusterIds = clusterRows.map((cluster) => cluster.id);
+  if (clusterIds.length === 0) {
+    return [];
+  }
+
+  const [lineRows, stationRows, reportRows] = await Promise.all([
+    db
+      .select({
+        clusterId: crowdReportClusterLinesTable.cluster_id,
+        lineId: crowdReportClusterLinesTable.line_id,
+      })
+      .from(crowdReportClusterLinesTable)
+      .where(inArray(crowdReportClusterLinesTable.cluster_id, clusterIds)),
+    db
+      .select({
+        clusterId: crowdReportClusterStationsTable.cluster_id,
+        stationId: crowdReportClusterStationsTable.station_id,
+      })
+      .from(crowdReportClusterStationsTable)
+      .where(inArray(crowdReportClusterStationsTable.cluster_id, clusterIds)),
+    db
+      .select({
+        id: crowdReportsTable.id,
+        clusterId: crowdReportsTable.cluster_id,
+        observedAt: crowdReportsTable.observed_at,
+        text: crowdReportsTable.text,
+        directionText: crowdReportsTable.direction_text,
+        delayMinutes: crowdReportsTable.delay_minutes,
+        stillHappening: crowdReportsTable.still_happening,
+      })
+      .from(crowdReportsTable)
+      .where(
+        and(
+          inArray(crowdReportsTable.cluster_id, clusterIds),
+          inArray(crowdReportsTable.status, ['accepted', 'duplicate']),
+        ),
+      )
+      .orderBy(desc(crowdReportsTable.observed_at)),
+  ]);
+
+  return clusterRows.flatMap((cluster) => {
+    const lineIds = lineRows
+      .filter((row) => row.clusterId === cluster.id)
+      .map((row) => row.lineId)
+      .sort((a, b) => a.localeCompare(b));
+    const stationIds = stationRows
+      .filter((row) => row.clusterId === cluster.id)
+      .map((row) => row.stationId)
+      .sort((a, b) => a.localeCompare(b));
+    const reports = reportRows.filter((row) => row.clusterId === cluster.id);
+    const representative = reports[0];
+    if (
+      representative == null ||
+      (lineIds.length === 0 && stationIds.length === 0)
+    ) {
+      return [];
+    }
+
+    const observedAt = reports.reduce(
+      (earliest, report) =>
+        report.observedAt < earliest ? report.observedAt : earliest,
+      representative.observedAt,
+    );
+
+    return [
+      buildCrowdReportIngestPayload({
+        kind: 'cluster',
+        id: cluster.id,
+        reportIds: reports.map((report) => report.id),
+        text: representative.text,
+        createdAt: cluster.updatedAt,
+        observedAt,
+        lineIds,
+        stationIds,
+        directionText: representative.directionText,
+        effect: cluster.effect,
+        delayMinutes: representative.delayMinutes,
+        reportCount: cluster.reportCount,
+        isStillHappening: representative.stillHappening,
+        rootUrl: options.rootUrl,
+      }),
+    ];
+  });
+}
+
+async function getDispatchableSingleCrowdReportCandidates(
+  db: AppDb,
+  options: { limit: number; rootUrl: string },
+) {
+  if (options.limit <= 0) {
+    return [];
+  }
+
+  const reportRows = await db
+    .select({
+      id: crowdReportsTable.id,
+      observedAt: crowdReportsTable.observed_at,
+      text: crowdReportsTable.text,
+      directionText: crowdReportsTable.direction_text,
+      effect: crowdReportsTable.effect,
+      delayMinutes: crowdReportsTable.delay_minutes,
+      stillHappening: crowdReportsTable.still_happening,
+      updatedAt: crowdReportsTable.updated_at,
+    })
+    .from(crowdReportsTable)
+    .where(
+      and(
+        eq(crowdReportsTable.status, 'accepted'),
+        isNull(crowdReportsTable.dispatched_at),
+        isNull(crowdReportsTable.cluster_id),
+      ),
+    )
+    .orderBy(desc(crowdReportsTable.observed_at))
+    .limit(options.limit);
+
+  const reportIds = reportRows.map((report) => report.id);
+  if (reportIds.length === 0) {
+    return [];
+  }
+
+  const [lineRows, stationRows] = await Promise.all([
+    db
+      .select({
+        reportId: crowdReportLinesTable.report_id,
+        lineId: crowdReportLinesTable.line_id,
+      })
+      .from(crowdReportLinesTable)
+      .where(inArray(crowdReportLinesTable.report_id, reportIds)),
+    db
+      .select({
+        reportId: crowdReportStationsTable.report_id,
+        stationId: crowdReportStationsTable.station_id,
+      })
+      .from(crowdReportStationsTable)
+      .where(inArray(crowdReportStationsTable.report_id, reportIds)),
+  ]);
+
+  return reportRows.flatMap((report) => {
+    const lineIds = lineRows
+      .filter((row) => row.reportId === report.id)
+      .map((row) => row.lineId)
+      .sort((a, b) => a.localeCompare(b));
+    const stationIds = stationRows
+      .filter((row) => row.reportId === report.id)
+      .map((row) => row.stationId)
+      .sort((a, b) => a.localeCompare(b));
+    if (lineIds.length === 0 && stationIds.length === 0) {
+      return [];
+    }
+
+    return [
+      buildCrowdReportIngestPayload({
+        kind: 'report',
+        id: report.id,
+        reportIds: [report.id],
+        text: report.text,
+        createdAt: report.updatedAt,
+        observedAt: report.observedAt,
+        lineIds,
+        stationIds,
+        directionText: report.directionText,
+        effect: report.effect,
+        delayMinutes: report.delayMinutes,
+        reportCount: 1,
+        isStillHappening: report.stillHappening,
+        rootUrl: options.rootUrl,
+      }),
+    ];
+  });
+}
+
+export async function dispatchCrowdReportPayloadToGitHub(
+  payload: IngestPayload,
+  config: CrowdReportDispatchConfig,
+  fetchImpl: typeof fetch = fetch,
+): Promise<CrowdReportDispatchResponse> {
+  const owner = config.owner?.trim() || DEFAULT_DISPATCH_OWNER;
+  const repo = config.repo?.trim() || DEFAULT_DISPATCH_REPO;
+  const eventType = config.eventType?.trim() || DEFAULT_DISPATCH_EVENT_TYPE;
+  const timeoutMs = config.timeoutMs ?? DEFAULT_DISPATCH_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort();
+  }, timeoutMs);
+
+  let response: Response;
+  try {
+    response = await fetchImpl(
+      `https://api.github.com/repos/${owner}/${repo}/dispatches`,
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${config.token}`,
+          'Content-Type': 'application/json',
+          'User-Agent': 'mrtdown-site-crowd-report-dispatch',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+        body: JSON.stringify({
+          event_type: eventType,
+          client_payload: payload,
+        }),
+        signal: controller.signal,
+      },
+    );
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error(
+        `GitHub repository_dispatch timed out after ${timeoutMs}ms`,
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  const responseText = await response.text();
+  if (!response.ok) {
+    throw new Error(
+      `GitHub repository_dispatch failed with ${response.status}: ${responseText.slice(
+        0,
+        500,
+      )}`,
+    );
+  }
+
+  return { status: response.status, responseText };
+}
+
+export async function markCrowdReportDispatchSuccess(
+  db: AppDb,
+  candidate: CrowdReportDispatchCandidate,
+  dispatchedAt = DateTime.now().toUTC().toISO() ?? new Date().toISOString(),
+) {
+  await db.transaction((tx) =>
+    markCrowdReportDispatchSuccessInTransaction(tx, candidate, dispatchedAt),
+  );
+}
+
+export async function markCrowdReportDispatchFailure(
+  db: AppDb,
+  candidate: CrowdReportDispatchCandidate,
+  error: unknown,
+) {
+  const message = error instanceof Error ? error.message : String(error);
+  await markCrowdReportDispatchFailureInTransaction(db, candidate, message);
+}
+
+async function markCrowdReportDispatchSuccessInTransaction(
+  tx: CrowdReportTransaction,
+  candidate: CrowdReportDispatchCandidate,
+  dispatchedAt: string,
+) {
+  if (candidate.kind === 'cluster') {
+    await tx
+      .update(crowdReportClustersTable)
+      .set({
+        status: 'dispatched',
+        dispatched_at: dispatchedAt,
+        updated_at: sql`now()`,
+      })
+      .where(eq(crowdReportClustersTable.id, candidate.id));
+  }
+
+  await tx
+    .update(crowdReportsTable)
+    .set({
+      status: 'dispatched',
+      dispatched_at: dispatchedAt,
+      dispatch_payload: candidate.payload,
+      dispatch_error: null,
+      updated_at: sql`now()`,
+    })
+    .where(getCrowdReportDispatchReportScope(candidate));
+}
+
+async function markCrowdReportDispatchFailureInTransaction(
+  tx: Pick<CrowdReportTransaction, 'update'>,
+  candidate: CrowdReportDispatchCandidate,
+  message: string,
+) {
+  await tx
+    .update(crowdReportsTable)
+    .set({
+      dispatch_payload: candidate.payload,
+      dispatch_error: message.slice(0, 2000),
+      updated_at: sql`now()`,
+    })
+    .where(getCrowdReportDispatchReportScope(candidate));
+}
+
+function getCrowdReportDispatchReportScope(
+  candidate: CrowdReportDispatchCandidate,
+) {
+  if (candidate.kind === 'cluster') {
+    return and(
+      eq(crowdReportsTable.cluster_id, candidate.id),
+      inArray(crowdReportsTable.status, ['accepted', 'duplicate']),
+    );
+  }
+
+  return inArray(crowdReportsTable.id, candidate.reportIds);
+}
+
+async function tryAcquireCrowdReportDispatchLock(
+  tx: CrowdReportTransaction,
+  candidate: CrowdReportDispatchCandidate,
+) {
+  const result = await tx.execute<{ locked: boolean }>(
+    sql`select pg_try_advisory_xact_lock(hashtextextended(${`crowd-report-dispatch:${candidate.kind}:${candidate.id}`}, 0::bigint)) as "locked"`,
+  );
+  return result.rows[0]?.locked === true;
+}
+
+async function isCrowdReportDispatchCandidateEligible(
+  tx: CrowdReportTransaction,
+  candidate: CrowdReportDispatchCandidate,
+) {
+  if (candidate.kind === 'cluster') {
+    const rows = await tx
+      .select({ id: crowdReportClustersTable.id })
+      .from(crowdReportClustersTable)
+      .where(
+        and(
+          eq(crowdReportClustersTable.id, candidate.id),
+          eq(crowdReportClustersTable.status, 'accepted'),
+          isNull(crowdReportClustersTable.dispatched_at),
+          hasCrowdReportClusterScope(),
+        ),
+      )
+      .limit(1);
+    return rows.length > 0;
+  }
+
+  const rows = await tx
+    .select({ id: crowdReportsTable.id })
+    .from(crowdReportsTable)
+    .where(
+      and(
+        eq(crowdReportsTable.id, candidate.id),
+        eq(crowdReportsTable.status, 'accepted'),
+        isNull(crowdReportsTable.dispatched_at),
+        isNull(crowdReportsTable.cluster_id),
+      ),
+    )
+    .limit(1);
+  return rows.length > 0;
+}
+
+async function dispatchCrowdReportCandidateWithLock(
+  db: AppDb,
+  candidate: CrowdReportDispatchCandidate,
+  config: CrowdReportDispatchConfig,
+  fetchImpl: typeof fetch,
+) {
+  return db.transaction(async (tx) => {
+    if (!(await tryAcquireCrowdReportDispatchLock(tx, candidate))) {
+      return { skipped: true as const };
+    }
+    if (!(await isCrowdReportDispatchCandidateEligible(tx, candidate))) {
+      return { skipped: true as const };
+    }
+
+    try {
+      const dispatchResponse = await dispatchCrowdReportPayloadToGitHub(
+        candidate.payload,
+        config,
+        fetchImpl,
+      );
+      await markCrowdReportDispatchSuccessInTransaction(
+        tx,
+        candidate,
+        DateTime.now().toUTC().toISO() ?? new Date().toISOString(),
+      );
+      return { skipped: false as const, dispatchResponse };
+    } catch (error) {
+      await markCrowdReportDispatchFailureInTransaction(
+        tx,
+        candidate,
+        error instanceof Error ? error.message : String(error),
+      );
+      return { skipped: false as const, error };
+    }
+  });
+}
+
+export async function dispatchPendingCrowdReports(
+  db: AppDb,
+  options: CrowdReportDispatchOptions & CrowdReportDispatchConfig,
+  fetchImpl: typeof fetch = fetch,
+): Promise<CrowdReportDispatchRunResult> {
+  const candidates =
+    options.candidates ??
+    (await getDispatchableCrowdReportCandidates(db, options));
+  const results: CrowdReportDispatchRunResult['results'] = [];
+
+  for (const candidate of candidates) {
+    try {
+      const result = await dispatchCrowdReportCandidateWithLock(
+        db,
+        candidate,
+        options,
+        fetchImpl,
+      );
+      if (result.skipped) {
+        results.push({
+          kind: candidate.kind,
+          id: candidate.id,
+          success: true,
+          skipped: true,
+        });
+        continue;
+      }
+      if ('error' in result) {
+        results.push({
+          kind: candidate.kind,
+          id: candidate.id,
+          success: false,
+          error:
+            result.error instanceof Error
+              ? result.error.message
+              : String(result.error),
+        });
+        continue;
+      }
+      results.push({
+        kind: candidate.kind,
+        id: candidate.id,
+        success: true,
+        status: result.dispatchResponse.status,
+      });
+    } catch (error) {
+      results.push({
+        kind: candidate.kind,
+        id: candidate.id,
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  const failed = results.filter((result) => !result.success).length;
+  return {
+    success: failed === 0,
+    count: candidates.length,
+    dispatched: results.filter((result) => !result.skipped).length - failed,
+    failed,
+    results,
+  };
+}

--- a/app/workflows/scheduled.test.ts
+++ b/app/workflows/scheduled.test.ts
@@ -1,4 +1,22 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const scheduledMocks = vi.hoisted(() => {
+  return {
+    dispatchPendingCrowdReports: vi.fn(),
+    getDb: vi.fn(),
+  };
+});
+
+vi.mock('../db/index.js', () => {
+  return { getDb: scheduledMocks.getDb };
+});
+
+vi.mock('../util/crowdReportDispatch.js', () => {
+  return {
+    dispatchPendingCrowdReports: scheduledMocks.dispatchPendingCrowdReports,
+  };
+});
+
 import { handleScheduledWorkflows } from './scheduled';
 
 type WorkflowStatus = Awaited<ReturnType<WorkflowInstance['status']>>['status'];
@@ -62,6 +80,11 @@ function createWorkflow(statuses: Record<string, WorkflowStatus | 'missing'>) {
   return { createdIds, workflow };
 }
 
+beforeEach(() => {
+  scheduledMocks.dispatchPendingCrowdReports.mockReset();
+  scheduledMocks.getDb.mockReset();
+});
+
 describe('handleScheduledWorkflows', () => {
   it('routes pull cron triggers to the pull workflow', async () => {
     const scheduledTime = Date.UTC(2026, 4, 1);
@@ -83,6 +106,51 @@ describe('handleScheduledWorkflows', () => {
       `pull-scheduled-${Math.floor(scheduledTime / (30 * 60 * 1000))}`,
     ]);
     expect(publicHolidaysWorkflow.createdIds).toEqual([]);
+    expect(scheduledMocks.dispatchPendingCrowdReports).not.toHaveBeenCalled();
+  });
+
+  it('dispatches crowd reports on pull cron triggers when configured', async () => {
+    const scheduledTime = Date.UTC(2026, 4, 1);
+    const pullWorkflow = createWorkflow({});
+    const publicHolidaysWorkflow = createWorkflow({});
+    const fakeDb = {};
+    scheduledMocks.getDb.mockReturnValue(fakeDb);
+    scheduledMocks.dispatchPendingCrowdReports.mockResolvedValue({
+      success: true,
+      count: 2,
+      dispatched: 2,
+      failed: 0,
+      results: [],
+    });
+    const { ctx, pending } = createExecutionContext();
+
+    await handleScheduledWorkflows(
+      createScheduledEvent(scheduledTime, PULL_CRON),
+      {
+        PULL_WORKFLOW: pullWorkflow.workflow,
+        PUBLIC_HOLIDAYS_WORKFLOW: publicHolidaysWorkflow.workflow,
+        VITE_ROOT_URL: 'https://mrtdown.example',
+        CROWD_REPORT_DISPATCH_GITHUB_TOKEN: 'github-token',
+        CROWD_REPORT_DISPATCH_GITHUB_OWNER: 'foldaway',
+        CROWD_REPORT_DISPATCH_GITHUB_REPO: 'mrtdown-data',
+        CROWD_REPORT_DISPATCH_GITHUB_EVENT_TYPE: 'ingest',
+        CROWD_REPORT_DISPATCH_LIMIT: '3',
+      } as unknown as Env,
+      ctx,
+    );
+    await Promise.all(pending);
+
+    expect(scheduledMocks.dispatchPendingCrowdReports).toHaveBeenCalledWith(
+      fakeDb,
+      {
+        rootUrl: 'https://mrtdown.example',
+        token: 'github-token',
+        limit: 3,
+        owner: 'foldaway',
+        repo: 'mrtdown-data',
+        eventType: 'ingest',
+      },
+    );
   });
 
   it('creates a retry public holidays workflow when the scheduled instance errored', async () => {

--- a/app/workflows/scheduled.ts
+++ b/app/workflows/scheduled.ts
@@ -1,3 +1,6 @@
+import { getDb } from '../db/index.js';
+import { dispatchPendingCrowdReports } from '../util/crowdReportDispatch.js';
+
 const SCHEDULED_PULL_SLOT_MS = 30 * 60 * 1000;
 const SCHEDULED_PULL_LOOKBACK_SLOTS = 48;
 const SCHEDULED_PULL_CRONS = new Set(['*/30 * * * *', '0 * * * *']);
@@ -11,6 +14,14 @@ const ACTIVE_WORKFLOW_STATUSES = new Set([
 ]);
 const COMPLETED_WORKFLOW_STATUSES = new Set(['complete']);
 const RETRYABLE_WORKFLOW_STATUSES = new Set(['errored', 'terminated']);
+
+type CrowdReportDispatchScheduledEnv = Env & {
+  CROWD_REPORT_DISPATCH_GITHUB_TOKEN?: string;
+  CROWD_REPORT_DISPATCH_GITHUB_OWNER?: string;
+  CROWD_REPORT_DISPATCH_GITHUB_REPO?: string;
+  CROWD_REPORT_DISPATCH_GITHUB_EVENT_TYPE?: string;
+  CROWD_REPORT_DISPATCH_LIMIT?: string;
+};
 
 function scheduledPullWorkflowId(scheduledTime: number) {
   const slot = Math.floor(scheduledTime / SCHEDULED_PULL_SLOT_MS);
@@ -47,6 +58,14 @@ function isMissingWorkflowInstanceError(error: unknown) {
     code === 'not_found' ||
     /not\s*found|unknown instance|does not exist/i.test(message)
   );
+}
+
+function getScheduledCrowdReportDispatchLimit(value: string | undefined) {
+  if (!value) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
 }
 
 async function hasActiveScheduledPullWorkflow(
@@ -132,6 +151,7 @@ export async function handleScheduledWorkflows(
 ) {
   if (SCHEDULED_PULL_CRONS.has(event.cron)) {
     await handleScheduledPullWorkflow(event, env, ctx);
+    handleScheduledCrowdReportDispatch(event, env, ctx);
     return;
   }
 
@@ -141,6 +161,52 @@ export async function handleScheduledWorkflows(
   }
 
   console.warn(`Ignoring unknown scheduled cron trigger: ${event.cron}`);
+}
+
+function handleScheduledCrowdReportDispatch(
+  event: ScheduledController,
+  env: Env,
+  ctx: ExecutionContext,
+) {
+  const runtimeEnv = env as CrowdReportDispatchScheduledEnv;
+  const token = runtimeEnv.CROWD_REPORT_DISPATCH_GITHUB_TOKEN;
+  if (!token) {
+    return;
+  }
+
+  const rootUrl = runtimeEnv.VITE_ROOT_URL;
+  if (!rootUrl) {
+    console.warn(
+      'Skipping scheduled crowd report dispatch; VITE_ROOT_URL is missing',
+    );
+    return;
+  }
+
+  ctx.waitUntil(
+    dispatchPendingCrowdReports(getDb(), {
+      rootUrl,
+      token,
+      limit: getScheduledCrowdReportDispatchLimit(
+        runtimeEnv.CROWD_REPORT_DISPATCH_LIMIT,
+      ),
+      owner: runtimeEnv.CROWD_REPORT_DISPATCH_GITHUB_OWNER,
+      repo: runtimeEnv.CROWD_REPORT_DISPATCH_GITHUB_REPO,
+      eventType: runtimeEnv.CROWD_REPORT_DISPATCH_GITHUB_EVENT_TYPE,
+    })
+      .then((result) => {
+        if (result.count === 0) {
+          return;
+        }
+        console.log('Scheduled crowd report dispatch complete', {
+          dispatched: result.dispatched,
+          failed: result.failed,
+        });
+      })
+      .catch((error) => {
+        console.error('Scheduled crowd report dispatch failed', { error });
+        event.noRetry();
+      }),
+  );
 }
 
 async function handleScheduledPullWorkflow(

--- a/docs/DATA_PIPELINE.md
+++ b/docs/DATA_PIPELINE.md
@@ -23,6 +23,27 @@ weekly cron trigger for this workflow; use
 `/internal/api/tasks/public-holidays` for an immediate manual refresh after an
 out-of-cycle update.
 
+## Crowd Report Dispatch
+
+Accepted crowdsourced reports and accepted report clusters stay site-local until
+the scheduled dispatch job or an operator invokes the dispatch path. The
+`/internal/api/tasks/crowd-report-dispatch` endpoint builds an
+`@mrtdown/ingest-contracts` `crowd-report` payload, posts it to the
+`mrtdown-data` `repository_dispatch` ingest workflow, and records dispatch
+success or failure on the site-local report rows.
+
+Configure `CROWD_REPORT_DISPATCH_GITHUB_TOKEN` as a deployed secret. Optional
+overrides are `CROWD_REPORT_DISPATCH_GITHUB_OWNER`,
+`CROWD_REPORT_DISPATCH_GITHUB_REPO`, and
+`CROWD_REPORT_DISPATCH_GITHUB_EVENT_TYPE`. The canonical evidence source URL is
+built from `VITE_ROOT_URL`. Send `{ "dryRun": true }` to the endpoint to inspect
+pending payloads without calling GitHub or mutating report state.
+
+The existing hourly scheduled cron also invokes the same dispatch path when
+`CROWD_REPORT_DISPATCH_GITHUB_TOKEN` is configured. Use
+`CROWD_REPORT_DISPATCH_LIMIT` to tune the maximum number of dispatch candidates
+processed per scheduled run.
+
 ## Staging Tables
 
 Staging tables are named with a `_next` suffix. They are the durable handoff between workflow steps and avoid returning large parsed payloads between Cloudflare Workflow steps.

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -398,6 +398,13 @@ Exit criteria:
   duplicate reports increment those clusters, clusters become public only after
   at least three reports, and home/line/station pages render accepted community
   signals separately from canonical advisories.
+- 2026-05-27: Started Phase 5 canonical ingest dispatch in `mrtdown-site` with
+  an internal crowd-report dispatch task, local ingest-contract payload
+  validation, GitHub `repository_dispatch` posting, dry-run support, and
+  dispatch result persistence on site-local report rows.
+- 2026-05-27: Added periodic Phase 5 dispatch from the existing hourly
+  Cloudflare scheduled cron when crowd-report GitHub dispatch credentials are
+  configured.
 
 ## Decision Log
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "verify:strict": "npm run typecheck && npm run lint && npm run format:check && npm run db:generate:check && npm run test:run",
     "dev:pull": "curl -i -X POST http://localhost:3000/internal/api/tasks/pull",
     "dev:public-holidays": "curl -i -X POST http://localhost:3000/internal/api/tasks/public-holidays",
+    "dev:crowd-report-dispatch": "curl -i -X POST http://localhost:3000/internal/api/tasks/crowd-report-dispatch",
     "db:reset": "tsx app/scripts/resetDatabase.ts",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",


### PR DESCRIPTION
## Summary

- Add a shared crowd-report dispatch runner that builds `@mrtdown/ingest-contracts` `crowd-report` payloads and posts them to the `mrtdown-data` `repository_dispatch` ingest workflow.
- Add `/internal/api/tasks/crowd-report-dispatch` for operator-triggered dispatch and dry-run payload inspection.
- Invoke the same dispatch runner from the existing hourly Cloudflare scheduled cron when `CROWD_REPORT_DISPATCH_GITHUB_TOKEN` is configured.
- Dispatch accepted, undispatched clusters first, with legacy unclustered accepted reports as a fallback, and persist dispatch success or failure on site-local report rows.
- Guard dispatch with a per-candidate transactional advisory lock and eligibility recheck to avoid duplicate sends from concurrent invocations.
- Mark all current accepted/duplicate rows in a dispatched cluster so late-arriving duplicate rows are not stranded after the cluster is marked dispatched.
- Add a timeout around GitHub `repository_dispatch` requests so scheduled or manual dispatch cannot hang indefinitely.
- Use `VITE_ROOT_URL` for canonical evidence source URLs and document dispatch configuration, including `CROWD_REPORT_DISPATCH_LIMIT`.

## Validation

- `npm run verify`

Note: verification was run with approved sandbox escalation because `tsx` needs to create its IPC pipe under `/var` during `db:generate:check`.