### PR TITLE
test: close overhaul read model plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,5 +47,4 @@ Use checked-in plans for multi-phase work that needs durable context across agen
 Current active plans:
 
 - `docs/plans/active/crowdsourced-reports.md`
-- `docs/plans/active/overhaul-read-model.md`
 - `docs/plans/active/production-performance.md`

--- a/app/workflows/pull/helpers/stagingSync.test.ts
+++ b/app/workflows/pull/helpers/stagingSync.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  linesNextTable,
+  operatorsNextTable,
+  stationsNextTable,
+} from '../../../db/schema.js';
+import {
+  insertLinesStaging,
+  insertOperatorsStaging,
+  insertStationsStaging,
+} from './stagingSync';
+
+type InsertDb = Parameters<typeof insertOperatorsStaging>[0];
+
+function createInsertDb() {
+  const inserts: Array<{
+    rows: unknown[];
+    table: unknown;
+  }> = [];
+
+  const db = {
+    insert(table: unknown) {
+      return {
+        values(rows: unknown | unknown[]) {
+          inserts.push({
+            table,
+            rows: Array.isArray(rows) ? rows : [rows],
+          });
+          return Promise.resolve();
+        },
+      };
+    },
+  } as unknown as InsertDb;
+
+  return { db, inserts };
+}
+
+const translation = {
+  'en-SG': 'Name',
+  'zh-Hans': null,
+  ms: null,
+  ta: null,
+};
+
+describe('pull staging inserts', () => {
+  it('batches operator staging inserts', async () => {
+    const { db, inserts } = createInsertDb();
+    const operators = Array.from({ length: 501 }, (_, index) => {
+      return {
+        id: `operator-${index}`,
+        hash: `hash-${index}`,
+        name: translation,
+        foundedAt: '1987-11-07',
+        url: null,
+      };
+    }) as Parameters<typeof insertOperatorsStaging>[1];
+
+    await insertOperatorsStaging(db, operators);
+
+    expect(inserts).toHaveLength(2);
+    expect(inserts[0]).toMatchObject({
+      table: operatorsNextTable,
+      rows: expect.arrayContaining([
+        {
+          id: 'operator-0',
+          hash: 'hash-0',
+          name: translation,
+          founded_at: '1987-11-07',
+          url: null,
+        },
+      ]),
+    });
+    expect(inserts[0].rows).toHaveLength(500);
+    expect(inserts[1].rows).toHaveLength(1);
+  });
+
+  it('stages only lines with read-model required fields', async () => {
+    const { db, inserts } = createInsertDb();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const lines = [
+      {
+        id: 'BPLRT',
+        hash: 'changed',
+        name: translation,
+        type: 'lrt',
+        color: '#748274',
+        startedAt: '1999-11-06',
+        endedAt: null,
+        operatingHours: {
+          weekdays: { start: '05:30', end: '23:30' },
+          weekends: { start: '05:30', end: '23:30' },
+        },
+        serviceIds: ['BPLRT-service'],
+        operators: [
+          {
+            operatorId: 'smrt',
+            startedAt: '1999-11-06',
+            endedAt: null,
+          },
+        ],
+      },
+      {
+        id: 'missing-hours',
+        hash: 'skipped',
+        name: translation,
+        type: 'mrt',
+        color: '#000000',
+        startedAt: '2026-01-01',
+        endedAt: null,
+        operatingHours: null,
+        serviceIds: [],
+        operators: [],
+      },
+    ] as Parameters<typeof insertLinesStaging>[1];
+
+    await insertLinesStaging(db, lines);
+    expect(warn).toHaveBeenCalledWith(
+      '[PULL] Skipping 1 line(s) missing required fields: missing-hours (operatingHours)',
+    );
+    warn.mockRestore();
+    expect(inserts).toEqual([
+      {
+        table: linesNextTable,
+        rows: [
+          {
+            id: 'BPLRT',
+            hash: 'changed',
+            name: translation,
+            type: 'lrt',
+            color: '#748274',
+            started_at: '1999-11-06',
+            ended_at: null,
+            operating_hours: {
+              weekdays: { start: '05:30', end: '23:30' },
+              weekends: { start: '05:30', end: '23:30' },
+            },
+            operators: [
+              {
+                operatorId: 'smrt',
+                startedAt: '1999-11-06',
+                endedAt: null,
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('stages station geography and nested membership data', async () => {
+    const { db, inserts } = createInsertDb();
+    const stations = [
+      {
+        id: 'BP6',
+        hash: 'station-hash',
+        name: translation,
+        geo: {
+          latitude: 1.379,
+          longitude: 103.761,
+        },
+        townId: 'bukit-panjang',
+        stationCodes: [
+          {
+            lineId: 'BPLRT',
+            code: 'BP6',
+            structureType: 'elevated',
+            startedAt: '1999-11-06',
+            endedAt: null,
+          },
+        ],
+        landmarkIds: ['bukit-panjang-plaza'],
+      },
+    ] as Parameters<typeof insertStationsStaging>[1];
+
+    await insertStationsStaging(db, stations);
+
+    expect(inserts).toEqual([
+      {
+        table: stationsNextTable,
+        rows: [
+          {
+            id: 'BP6',
+            hash: 'station-hash',
+            name: translation,
+            geo: [103.761, 1.379],
+            town_id: 'bukit-panjang',
+            station_codes: [
+              {
+                lineId: 'BPLRT',
+                code: 'BP6',
+                structureType: 'elevated',
+                startedAt: '1999-11-06',
+                endedAt: null,
+              },
+            ],
+            landmark_ids: ['bukit-panjang-plaza'],
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/app/workflows/pull/index.test.ts
+++ b/app/workflows/pull/index.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('pull workflow promotion order', () => {
+  it('keeps promotion, orphan deletion, finalization, and fact rebuild steps in dependency order', () => {
+    const source = readFileSync(new URL('./index.ts', import.meta.url), 'utf8');
+    const orderedStepNames = [
+      'sync-operators-towns-landmarks-upserts',
+      'sync-lines',
+      'sync-stations',
+      'sync-services',
+      'sync-issues-changed-',
+      'sync-issues-orphans-',
+      'delete-service-orphans',
+      'delete-station-orphans',
+      'delete-line-orphans',
+      'delete-operators-towns-landmarks-orphans',
+      'finalize',
+      'rebuild-operational-facts',
+    ];
+
+    let previousIndex = -1;
+    for (const stepName of orderedStepNames) {
+      const index = source.indexOf(stepName, previousIndex + 1);
+      expect(index, `${stepName} is present`).toBeGreaterThanOrEqual(0);
+      expect(index, `${stepName} is after previous step`).toBeGreaterThan(
+        previousIndex,
+      );
+      previousIndex = index;
+    }
+  });
+});

--- a/docs/QUALITY.md
+++ b/docs/QUALITY.md
@@ -22,6 +22,9 @@ Generated files are excluded from normal Biome checks. If a generated file chang
 
 ## Current Gaps
 
-The overhaul still needs broader tests around DB query behavior, pull workflow staging and promotion, operational facts, i18n route handling, and smoke coverage for the main public pages.
+The overhaul has guardrail tests for pull staging row mapping and pull
+promotion step ordering.
 
-The known cleanup work is to broaden coverage around the overhaul paths and decide which generated/config files Biome should own.
+The remaining known cleanup work is to broaden coverage around DB query
+behavior, operational facts, i18n route handling, smoke coverage for the main
+public pages, and to decide which generated/config files Biome should own.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -22,10 +22,13 @@ Use plans for:
   report collection, moderation, clustering, and canonical ingest dispatch.
 - [Dynamic system map](active/dynamic-system-map.md): canonical schematic map
   data and data-driven site rendering.
-- [Overhaul read model](active/overhaul-read-model.md): local Postgres-backed
-  read model migration.
 - [Production performance](active/production-performance.md): public route
   latency and payload reduction plan.
+
+## Completed
+
+- [Overhaul read model](completed/overhaul-read-model.md): local
+  Postgres-backed read model migration.
 
 ## Template
 

--- a/docs/plans/completed/overhaul-read-model.md
+++ b/docs/plans/completed/overhaul-read-model.md
@@ -2,9 +2,9 @@
 
 ## Context
 
-`mrtdown-site` is in the middle of moving data reads from the retired generated
-MRTDown API client to a local Postgres/PostGIS-backed read model populated from
-canonical mrtdown data archives.
+`mrtdown-site` moved data reads from the retired generated MRTDown API client to
+a local Postgres/PostGIS-backed read model populated from canonical mrtdown data
+archives.
 
 Source-of-truth references:
 
@@ -45,6 +45,11 @@ Exit criteria:
 - No route or server function depends on the retired generated API client.
 - Remaining shared read-model types are intentional and documented.
 
+Status: complete. `docs/ARCHITECTURE.md` documents the retired generated API
+client boundary and `app/types.ts` as the temporary source-owned read-model
+boundary. A source scan on completion found no route or server-function
+dependencies on the retired generated client.
+
 ### Phase 2: Pull Workflow Hardening
 
 - Keep canonical archive ingestion in `app/workflows/pull`.
@@ -55,6 +60,11 @@ Exit criteria:
 
 - Pull workflow behavior is covered for the main staging and promotion paths.
 - Operational fact data remains available to route loaders and statistics.
+
+Status: complete. `app/workflows/pull/helpers/stagingSync.test.ts` covers main
+staging row mapping and batching. `app/workflows/pull/index.test.ts` guards the
+promotion/orphan/finalize/facts rebuild order. The workflow rebuilds operational
+facts after finalizing a successful pull.
 
 ### Phase 3: Cleanup And Guardrails
 
@@ -68,15 +78,23 @@ Exit criteria:
 - `npm run verify` passes on the branch.
 - Documentation entry points reflect the current architecture and active plans.
 
+Status: complete. Durable notes live in architecture, data pipeline, quality,
+and generated-file docs. This plan is retained under `docs/plans/completed`.
+
 ## Progress Log
 
 - 2026-05-24: Created this active plan to make the stacked overhaul track
   discoverable outside `AGENTS.md`.
+- 2026-05-27: Confirmed the retired-client boundary, added pull workflow
+  guardrail tests, updated quality docs, and moved the plan to completed.
 
 ## Decision Log
 
 - 2026-05-24: Keep `AGENTS.md` as a short map and move execution context into
   versioned plan files under `docs/plans`.
+- 2026-05-27: Close the read-model overhaul as a completed migration while
+  leaving broader performance and crowdsourced-report tracks in their active
+  plans.
 
 ## Validation
 


### PR DESCRIPTION
## Summary

- Add focused pull workflow tests for staging row mapping, batching, and promotion step ordering.
- Move the overhaul read model plan from active to completed and update the plan index.
- Update quality docs to reflect the remaining test gaps after closing this track.

## Validation

- `npm run test:run -- app/workflows/pull/helpers/stagingSync.test.ts app/workflows/pull/index.test.ts`
- `npm run typecheck`
- `npm run format:check`
- `npm run verify`