### PR TITLE
perf: shrink statistics included payload

### DIFF
--- a/app/util/db.queries.test.ts
+++ b/app/util/db.queries.test.ts
@@ -1,7 +1,7 @@
 import { DateTime } from 'luxon';
 import { describe, expect, it } from 'vitest';
-import type { Issue, Line } from '~/types';
-import { buildLineSummary } from './db.queries';
+import type { Issue, Line, Station } from '~/types';
+import { buildLineSummary, selectIncludedEntities } from './db.queries';
 
 const REFERENCE_NOW = DateTime.fromISO('2026-02-23T23:59:00', {
   zone: 'Asia/Singapore',
@@ -23,6 +23,58 @@ const TEST_LINE: Line = {
     weekends: { start: '05:30', end: '23:30' },
   },
   operators: [],
+};
+
+const TEST_FEEDER_LINE: Line = {
+  id: 'DTL',
+  name: {
+    'en-SG': 'Downtown Line',
+    'zh-Hans': null,
+    ms: null,
+    ta: null,
+  },
+  type: 'mrt.high',
+  color: '#005ec4',
+  startedAt: '2015-12-27',
+  operatingHours: {
+    weekdays: { start: '05:30', end: '23:30' },
+    weekends: { start: '05:30', end: '23:30' },
+  },
+  operators: [],
+};
+
+const TEST_STATION: Station = {
+  id: 'BP6',
+  name: {
+    'en-SG': 'Bukit Panjang',
+    'zh-Hans': null,
+    ms: null,
+    ta: null,
+  },
+  geo: {
+    latitude: 1.379,
+    longitude: 103.761,
+  },
+  townId: 'bukit-panjang',
+  landmarkIds: [],
+  memberships: [
+    {
+      branchId: TEST_LINE.id,
+      code: 'BP6',
+      lineId: TEST_LINE.id,
+      sequenceOrder: 6,
+      startedAt: '1999-11-06',
+      structureType: 'elevated',
+    },
+    {
+      branchId: TEST_FEEDER_LINE.id,
+      code: 'DT1',
+      lineId: TEST_FEEDER_LINE.id,
+      sequenceOrder: 1,
+      startedAt: '2015-12-27',
+      structureType: 'underground',
+    },
+  ],
 };
 
 function buildIssue(
@@ -169,5 +221,77 @@ describe('buildLineSummary', () => {
     );
 
     expect(summary.status).toBe('closed_for_day');
+  });
+});
+
+describe('selectIncludedEntities', () => {
+  it('keeps only explicitly needed entities plus issue branch dependencies', () => {
+    const issue = buildIssue('disruption-1', 'disruption', [
+      {
+        startAt: '2026-02-23T05:30:00+08:00',
+        endAt: '2026-02-23T06:30:00+08:00',
+        status: 'ended',
+      },
+    ]);
+    issue.branchesAffected = [
+      {
+        lineId: TEST_LINE.id,
+        branchId: TEST_LINE.id,
+        stationIds: [TEST_STATION.id],
+      },
+    ];
+
+    const included = selectIncludedEntities(
+      {
+        lines: {
+          [TEST_LINE.id]: TEST_LINE,
+          [TEST_FEEDER_LINE.id]: TEST_FEEDER_LINE,
+        },
+        stations: {
+          [TEST_STATION.id]: TEST_STATION,
+        },
+        operators: {
+          SMRT: {
+            id: 'SMRT',
+            name: {
+              'en-SG': 'SMRT',
+              'zh-Hans': null,
+              ms: null,
+              ta: null,
+            },
+            foundedAt: '1987-08-06',
+            url: null,
+          },
+        },
+        towns: {
+          'bukit-panjang': {
+            id: 'bukit-panjang',
+            name: {
+              'en-SG': 'Bukit Panjang',
+              'zh-Hans': null,
+              ms: null,
+              ta: null,
+            },
+          },
+        },
+        landmarks: {},
+      },
+      { [issue.id]: issue },
+      {
+        issueIds: [issue.id],
+        includeStationMembershipLines: true,
+      },
+    );
+
+    expect(Object.keys(included.issues)).toEqual([issue.id]);
+    expect(Object.keys(included.stations)).toEqual([TEST_STATION.id]);
+    expect(Object.keys(included.lines).sort()).toEqual(
+      [TEST_FEEDER_LINE.id, TEST_LINE.id].sort(),
+    );
+    expect(included.operators).toEqual({});
+    expect(included.towns).toEqual({});
+    expect(included.landmarks).toEqual({});
+    expect(included.issues[issue.id]).not.toHaveProperty('serviceEffectKinds');
+    expect(included.issues[issue.id]).not.toHaveProperty('facilityEffectKinds');
   });
 });

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -1683,17 +1683,38 @@ function withIssues(
   allIssues: Record<string, IssueWithOperationalEffects>,
   issueIds?: readonly string[],
 ): IncludedEntities {
-  const selectedIssuesWithEffects =
-    issueIds == null
-      ? allIssues
-      : Object.fromEntries(
-          issueIds
-            .filter((issueId) => allIssues[issueId] != null)
-            .map((issueId) => [issueId, allIssues[issueId]]),
-        );
+  return {
+    ...baseIncluded,
+    issues: stripOperationalEffects(selectIssues(allIssues, issueIds)),
+  };
+}
 
-  const selectedIssues = Object.fromEntries(
-    Object.entries(selectedIssuesWithEffects).map(([issueId, issue]) => {
+type IncludedEntitySelection = {
+  issueIds?: readonly string[];
+  lineIds?: readonly string[];
+  stationIds?: readonly string[];
+  includeIssueEntities?: boolean;
+  includeStationMembershipLines?: boolean;
+};
+
+function selectIssues(
+  allIssues: Record<string, IssueWithOperationalEffects>,
+  issueIds?: readonly string[],
+) {
+  return issueIds == null
+    ? allIssues
+    : Object.fromEntries(
+        issueIds
+          .filter((issueId) => allIssues[issueId] != null)
+          .map((issueId) => [issueId, allIssues[issueId]]),
+      );
+}
+
+function stripOperationalEffects(
+  issues: Record<string, IssueWithOperationalEffects>,
+): Record<string, Issue> {
+  return Object.fromEntries(
+    Object.entries(issues).map(([issueId, issue]) => {
       const {
         serviceEffectKinds: _serviceEffectKinds,
         facilityEffectKinds: _facilityEffectKinds,
@@ -1702,10 +1723,55 @@ function withIssues(
       return [issueId, publicIssue];
     }),
   ) as Record<string, Issue>;
+}
+
+export function selectIncludedEntities(
+  baseIncluded: BaseIncludedEntities,
+  allIssues: Record<string, IssueWithOperationalEffects>,
+  selection: IncludedEntitySelection,
+): IncludedEntities {
+  const selectedIssuesWithEffects = selectIssues(allIssues, selection.issueIds);
+  const lineIds = new Set(selection.lineIds ?? []);
+  const stationIds = new Set(selection.stationIds ?? []);
+
+  if (selection.includeIssueEntities !== false) {
+    for (const issue of Object.values(selectedIssuesWithEffects)) {
+      for (const lineId of issue.lineIds) {
+        lineIds.add(lineId);
+      }
+      for (const branch of issue.branchesAffected) {
+        lineIds.add(branch.lineId);
+        for (const stationId of branch.stationIds) {
+          stationIds.add(stationId);
+        }
+      }
+    }
+  }
+
+  if (selection.includeStationMembershipLines === true) {
+    for (const stationId of stationIds) {
+      const station = baseIncluded.stations[stationId];
+      for (const membership of station?.memberships ?? []) {
+        lineIds.add(membership.lineId);
+      }
+    }
+  }
 
   return {
-    ...baseIncluded,
-    issues: selectedIssues,
+    lines: Object.fromEntries(
+      [...lineIds]
+        .filter((lineId) => baseIncluded.lines[lineId] != null)
+        .map((lineId) => [lineId, baseIncluded.lines[lineId]]),
+    ),
+    stations: Object.fromEntries(
+      [...stationIds]
+        .filter((stationId) => baseIncluded.stations[stationId] != null)
+        .map((stationId) => [stationId, baseIncluded.stations[stationId]]),
+    ),
+    issues: stripOperationalEffects(selectedIssuesWithEffects),
+    landmarks: {},
+    towns: {},
+    operators: {},
   };
 }
 
@@ -3758,17 +3824,23 @@ export async function getStatisticsData() {
             ),
     );
 
-    const chartTotalIssueCountByStation = timeSyncServerSpan(
-      'statistics_station_chart',
-      () => ({
-        title: 'Issue Count by Station',
-        data: stationIssueCounts
+    const topStationIssueCounts = timeSyncServerSpan(
+      'statistics_top_station_counts',
+      () =>
+        stationIssueCounts
           .sort(
             (a, b) =>
               (b.payload.totalIssues as number) -
               (a.payload.totalIssues as number),
           )
           .slice(0, 15),
+    );
+
+    const chartTotalIssueCountByStation = timeSyncServerSpan(
+      'statistics_station_chart',
+      () => ({
+        title: 'Issue Count by Station',
+        data: topStationIssueCounts,
       }),
     );
 
@@ -3811,10 +3883,13 @@ export async function getStatisticsData() {
 
     return {
       data: statistics,
-      included: withIssues(
-        dataset.included,
-        dataset.allIssues,
-        longestDisruptions,
+      included: timeSyncServerSpan('statistics_included', () =>
+        selectIncludedEntities(dataset.included, dataset.allIssues, {
+          issueIds: longestDisruptions,
+          lineIds: chartTotalIssueCountByLine.data.map((entry) => entry.name),
+          stationIds: topStationIssueCounts.map((entry) => entry.name),
+          includeStationMembershipLines: true,
+        }),
       ),
     };
   });

--- a/docs/plans/active/production-performance.md
+++ b/docs/plans/active/production-performance.md
@@ -277,6 +277,13 @@ underlying compute and payload costs so uncached requests are also fast.
   `Set-Cookie`, private/no-store opt-outs, and client no-cache requests are
   excluded. Added focused route-matching and cache-key tests in
   `app/util/publicHtmlCache.test.ts`.
+- 2026-05-27: Started Phase 2 payload reduction for `/statistics`. The
+  statistics loader now returns an explicit included-entity subset: all lines
+  needed by the line chart, the top station-chart stations, the longest
+  disruption issues, and the line/station dependencies those issue cards need.
+  It no longer serializes the full operators, towns, landmarks, or station
+  dictionaries for the statistics route. Added focused selector coverage in
+  `app/util/db.queries.test.ts`.
 
 ## Validation
 


### PR DESCRIPTION
## Summary

- Add an explicit included-entity selector for route payload pruning.
- Use the selector on `/statistics` so the route serializes only the line chart lines, top station chart stations, longest disruption issues, and issue-card line/station dependencies.
- Record the Phase 2 performance-plan progress note.

## Impact

This reduces the serialized statistics route payload by dropping the full operators, towns, landmarks, and station dictionaries from that route while preserving the data needed by chart labels and longest-disruption issue cards.

## Validation

- `npm run verify`

Note: the first sandboxed verification attempt failed because `tsx` could not create its IPC pipe under `/var/folders`; rerunning `npm run verify` outside the sandbox completed successfully.