### PR TITLE
feat: automate crowd report rejection policy

### DIFF
--- a/app/util/crowdReports.test.ts
+++ b/app/util/crowdReports.test.ts
@@ -12,6 +12,7 @@ import {
   crowdReportStationsTable,
 } from '~/db/schema';
 import {
+  assessCrowdReportAutomationPolicy,
   automoderateCrowdReport,
   CrowdReportRateLimitError,
   getCrowdReportRateLimitBucketStart,
@@ -157,7 +158,7 @@ function makeFakeAutomoderationDb(
   selectResults: unknown[][],
   updatedReport: {
     id: string;
-    status: 'accepted' | 'duplicate';
+    status: 'accepted' | 'duplicate' | 'rejected';
     duplicateOfId: string | null;
   },
 ) {
@@ -373,6 +374,57 @@ describe('validateCrowdReportSubmission', () => {
     if (!result.success) {
       expect(result.issues).toContain('observedAt cannot be more than 24h old');
     }
+  });
+});
+
+describe('assessCrowdReportAutomationPolicy', () => {
+  it('rejects obvious test or filler reports', () => {
+    expect(
+      assessCrowdReportAutomationPolicy(
+        {
+          ...VALID_SUBMISSION,
+          text: 'test 123',
+        },
+        NOW,
+      ),
+    ).toEqual({
+      action: 'reject',
+      reason:
+        'Report rejected by automated moderation: obvious test or filler text',
+    });
+
+    expect(
+      assessCrowdReportAutomationPolicy(
+        {
+          ...VALID_SUBMISSION,
+          text: 'aaaa aaaa aaaa',
+        },
+        NOW,
+      ),
+    ).toMatchObject({ action: 'reject' });
+  });
+
+  it('rejects stale resolved reports', () => {
+    expect(
+      assessCrowdReportAutomationPolicy(
+        {
+          ...VALID_SUBMISSION,
+          observedAt: '2026-05-24T05:30:00.000+08:00',
+          isStillHappening: false,
+        },
+        NOW,
+      ),
+    ).toEqual({
+      action: 'reject',
+      reason:
+        'Report rejected by automated moderation: resolved report is more than 6h old',
+    });
+  });
+
+  it('keeps structured current reports eligible for acceptance', () => {
+    expect(assessCrowdReportAutomationPolicy(VALID_SUBMISSION, NOW)).toEqual({
+      action: 'accept',
+    });
   });
 });
 
@@ -669,6 +721,54 @@ describe('automoderateCrowdReport', () => {
         cluster_id: 'event-1',
       },
     });
+    expect(fake.executes).toHaveLength(1);
+  });
+
+  it('rejects low-quality reports before duplicate detection and clustering', async () => {
+    const fake = makeFakeAutomoderationDb([], {
+      id: 'report-1',
+      status: 'rejected',
+      duplicateOfId: null,
+    });
+
+    await expect(
+      automoderateCrowdReport(
+        fake.db as never,
+        'report-1',
+        {
+          ...VALID_SUBMISSION,
+          text: 'testing',
+        },
+        {
+          idFactory: () => 'event-1',
+          now: NOW,
+        },
+      ),
+    ).resolves.toEqual({
+      id: 'report-1',
+      status: 'rejected',
+      duplicateOfId: null,
+    });
+
+    expect(fake.updates[0]).toMatchObject({
+      table: crowdReportsTable,
+      values: {
+        status: 'rejected',
+        duplicate_of_id: null,
+      },
+    });
+    expect(fake.inserts).toEqual([
+      {
+        table: crowdReportModerationEventsTable,
+        values: {
+          id: 'event-1',
+          report_id: 'report-1',
+          actor: 'system',
+          action: 'automated_rejected',
+          note: 'Report rejected by automated moderation: obvious test or filler text',
+        },
+      },
+    ]);
     expect(fake.executes).toHaveLength(1);
   });
 

--- a/app/util/crowdReports.ts
+++ b/app/util/crowdReports.ts
@@ -28,6 +28,7 @@ const DEFAULT_CLUSTER_WINDOW_MINUTES = 10;
 const DEFAULT_PUBLIC_SIGNAL_MIN_REPORTS = 3;
 const DEFAULT_PUBLIC_SIGNAL_MAX_AGE_MINUTES = 90;
 const DEFAULT_PUBLIC_SIGNAL_LIMIT = 20;
+const AUTO_REJECT_RESOLVED_STALE_HOURS = 6;
 const DUPLICATE_CANDIDATE_PAGE_SIZE = 100;
 export const MAX_CROWD_REPORT_REQUEST_BYTES = 10_000;
 
@@ -109,6 +110,7 @@ type PersistCrowdReportTransactionContext = {
 
 type AutomoderateCrowdReportOptions = ClusterCrowdReportOptions & {
   duplicateWindowMinutes?: number;
+  now?: DateTime;
 };
 
 type ClusterCrowdReportOptions = {
@@ -122,6 +124,10 @@ type DuplicateCrowdReport = {
   clusterId: string | null;
   observedAt: string;
 };
+
+type CrowdReportAutomationPolicyResult =
+  | { action: 'accept' }
+  | { action: 'reject'; reason: string };
 
 export type PublicCrowdReportSignal = {
   id: string;
@@ -194,6 +200,73 @@ function getCrowdReportClusterWindow(
     throw new Error('Unable to calculate crowd report cluster window');
   }
   return { windowStartAt, windowEndAt };
+}
+
+function normalizePolicyText(value: string) {
+  return value.trim().toLocaleLowerCase().replace(/\s+/g, ' ');
+}
+
+function isRepeatedFillerText(value: string) {
+  const compact = value.replace(/[\s\p{P}\p{S}]/gu, '');
+  if (compact.length >= 8 && new Set([...compact]).size <= 2) {
+    return true;
+  }
+
+  const tokens = value.split(' ').filter(Boolean);
+  return tokens.length >= 3 && new Set(tokens).size === 1;
+}
+
+function isObviousTestReportText(value: string) {
+  return (
+    [
+      'asdf',
+      'hello',
+      'hi',
+      'lorem ipsum',
+      'n/a',
+      'na',
+      'none',
+      'nothing',
+      'qwerty',
+      'test',
+      'test report',
+      'testing',
+    ].includes(value) || /^test(?:ing)?(?:\s+\d+)?$/.test(value)
+  );
+}
+
+export function assessCrowdReportAutomationPolicy(
+  submission: CrowdReportSubmission,
+  now = DateTime.now().setZone(SG_TIMEZONE),
+): CrowdReportAutomationPolicyResult {
+  const normalizedText = normalizePolicyText(submission.text);
+  if (
+    isObviousTestReportText(normalizedText) ||
+    isRepeatedFillerText(normalizedText)
+  ) {
+    return {
+      action: 'reject',
+      reason:
+        'Report rejected by automated moderation: obvious test or filler text',
+    };
+  }
+
+  const observedAt = DateTime.fromISO(submission.observedAt, {
+    setZone: true,
+  });
+  if (
+    submission.isStillHappening === false &&
+    observedAt.isValid &&
+    observedAt.setZone(SG_TIMEZONE) <
+      now.minus({ hours: AUTO_REJECT_RESOLVED_STALE_HOURS })
+  ) {
+    return {
+      action: 'reject',
+      reason: `Report rejected by automated moderation: resolved report is more than ${AUTO_REJECT_RESOLVED_STALE_HOURS}h old`,
+    };
+  }
+
+  return { action: 'accept' };
 }
 
 export function validateCrowdReportSubmission(
@@ -629,6 +702,7 @@ export async function automoderateCrowdReport(
   const idFactory = options.idFactory ?? (() => crypto.randomUUID());
   const duplicateWindowMinutes =
     options.duplicateWindowMinutes ?? DEFAULT_DUPLICATE_WINDOW_MINUTES;
+  const now = options.now ?? DateTime.now().setZone(SG_TIMEZONE);
 
   return db.transaction((tx) =>
     automoderateCrowdReportInTransaction(
@@ -637,6 +711,7 @@ export async function automoderateCrowdReport(
       submission,
       duplicateWindowMinutes,
       idFactory,
+      now,
       options.clusterWindowMinutes,
       options.publicSignalMinReports,
     ),
@@ -649,12 +724,46 @@ async function automoderateCrowdReportInTransaction(
   submission: CrowdReportSubmission,
   duplicateWindowMinutes: number,
   idFactory: () => string,
+  now: DateTime,
   clusterWindowMinutes = DEFAULT_CLUSTER_WINDOW_MINUTES,
   publicSignalMinReports = DEFAULT_PUBLIC_SIGNAL_MIN_REPORTS,
 ) {
   await tx.execute(
     sql`select pg_advisory_xact_lock(hashtextextended(${buildDuplicateLockKey(submission)}, 0::bigint))`,
   );
+
+  const policy = assessCrowdReportAutomationPolicy(submission, now);
+  if (policy.action === 'reject') {
+    const [updatedReport] = await tx
+      .update(crowdReportsTable)
+      .set({
+        status: 'rejected',
+        duplicate_of_id: null,
+        updated_at: sql`now()`,
+      })
+      .where(eq(crowdReportsTable.id, reportId))
+      .returning({
+        id: crowdReportsTable.id,
+        status: crowdReportsTable.status,
+        duplicateOfId: crowdReportsTable.duplicate_of_id,
+      });
+
+    await tx.insert(crowdReportModerationEventsTable).values({
+      id: idFactory(),
+      report_id: reportId,
+      actor: 'system',
+      action: 'automated_rejected',
+      note: policy.reason,
+    });
+
+    return (
+      updatedReport ?? {
+        id: reportId,
+        status: 'rejected' as const,
+        duplicateOfId: null,
+      }
+    );
+  }
 
   const duplicate = await findDuplicateCrowdReport(
     tx,
@@ -961,6 +1070,7 @@ export async function persistAutomoderatedCrowdReport(
       submission,
       duplicateWindowMinutes,
       idFactory,
+      now,
       options.clusterWindowMinutes,
       options.publicSignalMinReports,
     );

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -405,6 +405,10 @@ Exit criteria:
 - 2026-05-27: Added periodic Phase 5 dispatch from the existing hourly
   Cloudflare scheduled cron when crowd-report GitHub dispatch credentials are
   configured.
+- 2026-05-27: Started Phase 6 automation policy in `mrtdown-site` with
+  deterministic auto-rejection for obvious test/filler reports and resolved
+  reports that are already several hours stale, while keeping accepted reports
+  non-canonical until clustering, dispatch, and data-side review.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- add a deterministic automation-policy pass for crowd report moderation
- auto-reject obvious test/filler submissions and resolved reports older than six hours
- record automated rejection moderation events before duplicate detection or clustering
- update the crowdsourced reports plan log for the Phase 6 slice

## Validation

- `npm run test:run -- app/util/crowdReports.test.ts`
- `npm run verify`