### PR TITLE
feat: reduce crowd report spam surface

### DIFF
--- a/app/routes/{-$lang}/report.tsx
+++ b/app/routes/{-$lang}/report.tsx
@@ -367,6 +367,9 @@ function ReportPage() {
     selectedLineIds.length === 1
       ? (lineDirections[selectedLineIds[0]] ?? [])
       : [];
+  const requiresDescription =
+    effect === 'unknown' ||
+    (selectedLineIds.length > 0 && directionChoice === 'other');
   const stationSearchResults = useMemo(() => {
     const query = stationSearch.trim().toLocaleLowerCase();
     if (!query) {
@@ -428,6 +431,19 @@ function ReportPage() {
     selectedLineDirectionOptions,
     selectedLineIds.length,
   ]);
+
+  useEffect(() => {
+    if (requiresDescription || fieldErrors.description == null) {
+      return;
+    }
+
+    setClientError(null);
+    setFieldErrors((current) => {
+      const next = { ...current };
+      delete next.description;
+      return next;
+    });
+  }, [fieldErrors.description, requiresDescription]);
 
   const clearFieldError = (field: FieldErrorKey) => {
     setClientError(null);
@@ -657,12 +673,8 @@ function ReportPage() {
     }
 
     const directionText = getDirectionText();
-    const trimmedText = text.trim();
-    if (
-      (effect === 'unknown' ||
-        (selectedLineIds.length > 0 && directionChoice === 'other')) &&
-      trimmedText.length < 8
-    ) {
+    const trimmedText = requiresDescription ? text.trim() : '';
+    if (requiresDescription && trimmedText.length < 8) {
       const message = intl.formatMessage({
         id: 'report.error.description_required_for_ambiguous_report',
         defaultMessage:
@@ -673,14 +685,6 @@ function ReportPage() {
         message,
         'description_required_for_ambiguous_report',
       );
-      return;
-    }
-    if (trimmedText.length > 0 && trimmedText.length < 8) {
-      const message = intl.formatMessage({
-        id: 'report.error.description_too_short',
-        defaultMessage: 'Add a little more detail, or leave the note blank.',
-      });
-      showFieldError('description', message, 'description_too_short');
       return;
     }
     const reportText = trimmedText || buildFallbackText();
@@ -1292,48 +1296,44 @@ function ReportPage() {
           </section>
         )}
 
-        <label className="flex flex-col gap-2">
-          <span className="font-semibold text-gray-800 text-sm dark:text-gray-100">
-            <FormattedMessage
-              id="report.description"
-              defaultMessage="Anything else?"
-            />
-            <span className="ms-2 font-normal text-gray-500 text-xs dark:text-gray-400">
+        {requiresDescription && (
+          <label className="flex flex-col gap-2">
+            <span className="font-semibold text-gray-800 text-sm dark:text-gray-100">
               <FormattedMessage
-                id="report.optional"
-                defaultMessage="Optional"
+                id="report.description"
+                defaultMessage="Anything else?"
               />
             </span>
-          </span>
-          <textarea
-            ref={descriptionRef}
-            value={text}
-            onChange={(event) => {
-              clearFieldError('description');
-              setText(event.target.value);
-            }}
-            maxLength={1000}
-            rows={5}
-            aria-invalid={fieldErrors.description != null}
-            aria-describedby={
-              fieldErrors.description ? 'report-description-error' : undefined
-            }
-            placeholder={intl.formatMessage({
-              id: 'report.description_placeholder',
-              defaultMessage:
-                'Add details that the choices above do not capture.',
-            })}
-            className="resize-y rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 text-sm shadow-sm focus:border-accent-light focus:outline-none focus:ring-2 focus:ring-accent-light/30 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
-          />
-          {fieldErrors.description != null && (
-            <p
-              className="text-red-700 text-sm dark:text-red-300"
-              id="report-description-error"
-            >
-              {fieldErrors.description}
-            </p>
-          )}
-        </label>
+            <textarea
+              ref={descriptionRef}
+              value={text}
+              onChange={(event) => {
+                clearFieldError('description');
+                setText(event.target.value);
+              }}
+              maxLength={1000}
+              rows={4}
+              aria-invalid={fieldErrors.description != null}
+              aria-describedby={
+                fieldErrors.description ? 'report-description-error' : undefined
+              }
+              placeholder={intl.formatMessage({
+                id: 'report.description_placeholder',
+                defaultMessage:
+                  'Add details that the choices above do not capture.',
+              })}
+              className="resize-y rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 text-sm shadow-sm focus:border-accent-light focus:outline-none focus:ring-2 focus:ring-accent-light/30 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
+            />
+            {fieldErrors.description != null && (
+              <p
+                className="text-red-700 text-sm dark:text-red-300"
+                id="report-description-error"
+              >
+                {fieldErrors.description}
+              </p>
+            )}
+          </label>
+        )}
 
         <details className="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900">
           <summary className="cursor-pointer font-medium text-gray-700 text-sm dark:text-gray-200">

--- a/app/util/crowdReports.test.ts
+++ b/app/util/crowdReports.test.ts
@@ -402,6 +402,58 @@ describe('assessCrowdReportAutomationPolicy', () => {
         NOW,
       ),
     ).toMatchObject({ action: 'reject' });
+
+    expect(
+      assessCrowdReportAutomationPolicy(
+        {
+          ...VALID_SUBMISSION,
+          text: '!!!!!!!!',
+        },
+        NOW,
+      ),
+    ).toMatchObject({ action: 'reject' });
+  });
+
+  it('rejects obvious spam or solicitation reports', () => {
+    expect(
+      assessCrowdReportAutomationPolicy(
+        {
+          ...VALID_SUBMISSION,
+          text: 'Buy now at https://spam.example for free money.',
+        },
+        NOW,
+      ),
+    ).toEqual({
+      action: 'reject',
+      reason:
+        'Report rejected by automated moderation: spam or solicitation text',
+    });
+
+    expect(
+      assessCrowdReportAutomationPolicy(
+        {
+          ...VALID_SUBMISSION,
+          text: 'Whatsapp 9000 1234 for casino promo code.',
+        },
+        NOW,
+      ),
+    ).toMatchObject({ action: 'reject' });
+  });
+
+  it('rejects obvious non-transit chatter reports', () => {
+    expect(
+      assessCrowdReportAutomationPolicy(
+        {
+          ...VALID_SUBMISSION,
+          text: 'Good morning',
+        },
+        NOW,
+      ),
+    ).toEqual({
+      action: 'reject',
+      reason:
+        'Report rejected by automated moderation: obvious non-transit text',
+    });
   });
 
   it('rejects stale resolved reports', () => {

--- a/app/util/crowdReports.ts
+++ b/app/util/crowdReports.ts
@@ -208,6 +208,10 @@ function normalizePolicyText(value: string) {
 
 function isRepeatedFillerText(value: string) {
   const compact = value.replace(/[\s\p{P}\p{S}]/gu, '');
+  if (!/[\p{L}\p{N}]/u.test(value) || /^\p{N}+$/u.test(compact)) {
+    return true;
+  }
+
   if (compact.length >= 8 && new Set([...compact]).size <= 2) {
     return true;
   }
@@ -235,6 +239,50 @@ function isObviousTestReportText(value: string) {
   );
 }
 
+function isObviousSpamOrSolicitationText(value: string) {
+  if (
+    /(?:https?:\/\/|www\.)\S+/u.test(value) ||
+    /\b[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}\b/u.test(value)
+  ) {
+    return true;
+  }
+
+  if (
+    /\b(?:buy now|casino|crypto|forex|free money|loan|promo code|seo|work from home)\b/u.test(
+      value,
+    )
+  ) {
+    return true;
+  }
+
+  return (
+    /\b(?:call|sms|telegram|text|whatsapp)\b/u.test(value) &&
+    /(?:\+?\d[\s-]?){8,}/u.test(value)
+  );
+}
+
+function isObviousNonTransitChatterText(value: string) {
+  if (
+    [
+      'good afternoon',
+      'good evening',
+      'good morning',
+      'good night',
+      'how are you',
+      'i am bored',
+      'weather today',
+      'what is the weather',
+      'where to eat',
+    ].includes(value)
+  ) {
+    return true;
+  }
+
+  return /\b(?:food delivery|homework help|movie tickets|taxi booking)\b/u.test(
+    value,
+  );
+}
+
 export function assessCrowdReportAutomationPolicy(
   submission: CrowdReportSubmission,
   now = DateTime.now().setZone(SG_TIMEZONE),
@@ -248,6 +296,22 @@ export function assessCrowdReportAutomationPolicy(
       action: 'reject',
       reason:
         'Report rejected by automated moderation: obvious test or filler text',
+    };
+  }
+
+  if (isObviousSpamOrSolicitationText(normalizedText)) {
+    return {
+      action: 'reject',
+      reason:
+        'Report rejected by automated moderation: spam or solicitation text',
+    };
+  }
+
+  if (isObviousNonTransitChatterText(normalizedText)) {
+    return {
+      action: 'reject',
+      reason:
+        'Report rejected by automated moderation: obvious non-transit text',
     };
   }
 

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -409,6 +409,13 @@ Exit criteria:
   deterministic auto-rejection for obvious test/filler reports and resolved
   reports that are already several hours stale, while keeping accepted reports
   non-canonical until clustering, dispatch, and data-side review.
+- 2026-05-27: Continued Phase 6 automation policy with deterministic rejection
+  for punctuation-only, numeric-only, contact-solicitation, spam-link, and
+  obvious non-transit chatter submissions.
+- 2026-05-27: Reduced spam incentive in the public report form by hiding
+  free-text details by default; standard structured reports now submit
+  generated summary text, while ambiguous `unknown` or `Other` direction
+  reports still require a short note.
 
 ## Decision Log
 

--- a/lang/en-SG.json
+++ b/lang/en-SG.json
@@ -212,7 +212,6 @@
   "report.effect.skipped_stop": "Train skipped stop",
   "report.effect.unknown": "Not sure",
   "report.error.description_required_for_ambiguous_report": "Add a short note so reviewers can understand the report.",
-  "report.error.description_too_short": "Add a little more detail, or leave the note blank.",
   "report.error.direction_other_required": "Add the direction or destination.",
   "report.error.effect_required": "Choose what is happening.",
   "report.error.line_required": "Select the affected line.",


### PR DESCRIPTION
## Summary

- Hide the public report free-text field by default and keep ordinary submissions structured-only with generated summary text.
- Require the details field only for ambiguous `unknown` effects or `Other` direction reports.
- Keep low-effort deterministic filters for obvious filler, spam links/contact solicitations, and non-transit chatter.
- Update the crowdsourced reports plan and extracted messages.

## Spam Incentive Notes

Public community signals do not render raw report text. They show only aggregate effect, report count, affected lines/stations, and update time. Report text stays site-local unless it later survives dispatch and data-side review as canonical evidence.

## Validation

- `npm run i18n:extract`
- `npm run verify` passed outside the sandbox.
- Browser QA on `http://localhost:3001/report`: ordinary structured delay reports do not show the details textarea; `Not sure` effect reveals the textarea.

The sandboxed `npm run verify` attempt reached typecheck, lint, and format, then failed at `db:generate:check` because `tsx` could not bind its IPC pipe under `/var/folders`; the escalated rerun passed.