### PR TITLE
perf: reduce home payload reloads

### DIFF
--- a/app/constants.ts
+++ b/app/constants.ts
@@ -9,6 +9,7 @@ import type { LineSummaryStatus } from './types';
 
 export const LANGUAGES_NON_DEFAULT = ['zh-Hans', 'ms', 'ta'];
 export const LANGUAGES = ['en-SG', ...LANGUAGES_NON_DEFAULT];
+export const HOME_OVERVIEW_INITIAL_DATE_COUNT = 30;
 
 export const LineSummaryStatusLabels: Record<
   LineSummaryStatus,

--- a/app/routes/{-$lang}/index.tsx
+++ b/app/routes/{-$lang}/index.tsx
@@ -1,15 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
 import { createFileRoute, Link, notFound } from '@tanstack/react-router';
 import { DateTime } from 'luxon';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { createIntl, FormattedMessage } from 'react-intl';
-import { z } from 'zod';
 import { LineSummaryBlock } from '~/components/LineSummaryBlock';
 import { CommunitySignalsSection } from '~/components/CommunitySignalsSection';
-import { LANGUAGES } from '~/constants';
+import { HOME_OVERVIEW_INITIAL_DATE_COUNT, LANGUAGES } from '~/constants';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
 import { useCrowdReportsFeatureEnabled } from '~/contexts/CrowdReportsFeature';
 import { getDateCountForViewport } from '~/helpers/getDateCountForViewport';
-import { useViewport, ViewportSchema } from '~/hooks/useViewport';
+import { useViewport } from '~/hooks/useViewport';
 import { getOverviewFn } from '~/util/overview.functions';
 import { CurrentAdvisoriesSection } from '../../components/CurrentAdvisoriesSection';
 import { countOperationalLineSummaries } from '../../components/CurrentAdvisoriesSection/helpers';
@@ -17,34 +17,26 @@ import { assert } from '../../util/assert';
 import { HomeLineSummariesSkeleton } from './components/HomeLineSummariesSkeleton';
 import { sortLineSummariesWithFutureServiceLast } from './helpers/sortLineSummaries';
 
-const SearchParamsSchema = z.object({
-  viewport: ViewportSchema.optional(),
-});
-
 export const Route = createFileRoute('/{-$lang}/')({
   component: HomePage,
   pendingComponent: HomePagePending,
   pendingMs: 0,
   pendingMinMs: 0,
 
-  validateSearch: SearchParamsSchema,
-  loaderDeps({ search }) {
-    return { viewport: search.viewport ?? 'xs' };
-  },
-  async loader({ deps, params }) {
+  async loader({ params }) {
     const lang = params.lang ?? 'en-SG';
     if (!LANGUAGES.includes(lang)) {
       throw notFound();
     }
 
-    const viewport = deps.viewport ?? 'xs';
-    const dateCount = getDateCountForViewport(viewport);
     const { data, included } = await getOverviewFn({
-      data: {
-        viewport,
-      },
+      data: { days: HOME_OVERVIEW_INITIAL_DATE_COUNT },
     });
-    return { overview: data, included, dateCount };
+    return {
+      overview: data,
+      included,
+      dateCount: HOME_OVERVIEW_INITIAL_DATE_COUNT,
+    };
   },
   async head(ctx) {
     const lang = ctx.params.lang ?? 'en-SG';
@@ -123,43 +115,26 @@ export const Route = createFileRoute('/{-$lang}/')({
 
 function HomePage() {
   const loaderData = Route.useLoaderData();
-  const { viewport } = Route.useSearch();
-  const { overview, included, dateCount } = loaderData;
+  const measuredViewport = useViewport();
+  const desiredDateCount = getDateCountForViewport(measuredViewport);
+  const expandedOverviewQuery = useQuery({
+    queryKey: ['home-overview', desiredDateCount],
+    queryFn: () => getOverviewFn({ data: { days: desiredDateCount } }),
+    enabled: desiredDateCount > loaderData.dateCount,
+    staleTime: 60_000,
+  });
+  const activeData =
+    desiredDateCount > loaderData.dateCount &&
+    expandedOverviewQuery.data != null
+      ? {
+          overview: expandedOverviewQuery.data.data,
+          included: expandedOverviewQuery.data.included,
+          dateCount: desiredDateCount,
+        }
+      : loaderData;
+  const { overview, included, dateCount } = activeData;
   const { issues } = included;
   const crowdReportsEnabled = useCrowdReportsFeatureEnabled();
-
-  const navigate = Route.useNavigate();
-
-  const measuredViewport = useViewport();
-  const measuredDateCount = useMemo(
-    () => getDateCountForViewport(measuredViewport),
-    [measuredViewport],
-  );
-  const measuredDateKeys = useMemo(() => {
-    const dateRangeEnd = DateTime.now()
-      .startOf('hour')
-      .setZone('Asia/Singapore');
-    return Array.from({ length: measuredDateCount }, (_, daysAgo) => {
-      return (
-        dateRangeEnd
-          .minus({ days: measuredDateCount - daysAgo - 1 })
-          .toISODate() ?? `date-${daysAgo}`
-      );
-    });
-  }, [measuredDateCount]);
-  const isLineSummaryViewportPending = dateCount !== measuredDateCount;
-
-  useEffect(() => {
-    if (viewport === measuredViewport) {
-      return;
-    }
-    navigate({
-      search: {
-        viewport: measuredViewport,
-      },
-      replace: true,
-    });
-  }, [viewport, measuredViewport, navigate]);
 
   const dateTimes = useMemo(() => {
     const dateRangeEnd = DateTime.now()
@@ -246,26 +221,17 @@ function HomePage() {
           </section>
         )}
 
-        {isLineSummaryViewportPending ? (
-          <HomeLineSummariesSkeleton
-            dateKeys={measuredDateKeys}
-            lineIds={sortedLineSummaries.map((lineSummary) => {
-              return lineSummary.lineId;
-            })}
-          />
-        ) : (
-          <div className="rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
-            <div className="flex flex-col gap-y-4 px-2 py-2 sm:gap-y-6 sm:px-3 sm:py-4">
-              {sortedLineSummaries.map((lineSummary) => (
-                <LineSummaryBlock
-                  key={lineSummary.lineId}
-                  data={lineSummary}
-                  dateTimes={dateTimes}
-                />
-              ))}
-            </div>
+        <div className="rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <div className="flex flex-col gap-y-4 px-2 py-2 sm:gap-y-6 sm:px-3 sm:py-4">
+            {sortedLineSummaries.map((lineSummary) => (
+              <LineSummaryBlock
+                key={lineSummary.lineId}
+                data={lineSummary}
+                dateTimes={dateTimes}
+              />
+            ))}
           </div>
-        )}
+        </div>
 
         <div className="rounded-2xl border border-gray-200 bg-gray-50 p-6 dark:border-gray-700 dark:bg-gray-800/50">
           <h3 className="mb-4 text-center font-semibold text-gray-700 text-sm dark:text-gray-300">

--- a/app/util/db.queries.test.ts
+++ b/app/util/db.queries.test.ts
@@ -320,4 +320,33 @@ describe('selectIncludedEntities', () => {
     expect(included.issues).toEqual({});
     expect(included.stations).toEqual({});
   });
+
+  it('keeps explicitly requested stations and their membership lines', () => {
+    const included = selectIncludedEntities(
+      {
+        lines: {
+          [TEST_LINE.id]: TEST_LINE,
+          [TEST_FEEDER_LINE.id]: TEST_FEEDER_LINE,
+        },
+        stations: {
+          [TEST_STATION.id]: TEST_STATION,
+        },
+        operators: {},
+        towns: {},
+        landmarks: {},
+      },
+      {},
+      {
+        issueIds: [],
+        stationIds: [TEST_STATION.id],
+        includeStationMembershipLines: true,
+      },
+    );
+
+    expect(Object.keys(included.stations)).toEqual([TEST_STATION.id]);
+    expect(Object.keys(included.lines).sort()).toEqual(
+      [TEST_FEEDER_LINE.id, TEST_LINE.id].sort(),
+    );
+    expect(included.issues).toEqual({});
+  });
 });

--- a/app/util/db.queries.test.ts
+++ b/app/util/db.queries.test.ts
@@ -294,4 +294,30 @@ describe('selectIncludedEntities', () => {
     expect(included.issues[issue.id]).not.toHaveProperty('serviceEffectKinds');
     expect(included.issues[issue.id]).not.toHaveProperty('facilityEffectKinds');
   });
+
+  it('keeps explicitly requested lines when no selected issue references them', () => {
+    const included = selectIncludedEntities(
+      {
+        lines: {
+          [TEST_LINE.id]: TEST_LINE,
+          [TEST_FEEDER_LINE.id]: TEST_FEEDER_LINE,
+        },
+        stations: {
+          [TEST_STATION.id]: TEST_STATION,
+        },
+        operators: {},
+        towns: {},
+        landmarks: {},
+      },
+      {},
+      {
+        issueIds: [],
+        lineIds: [TEST_LINE.id],
+      },
+    );
+
+    expect(Object.keys(included.lines)).toEqual([TEST_LINE.id]);
+    expect(included.issues).toEqual({});
+    expect(included.stations).toEqual({});
+  });
 });

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -3117,12 +3117,18 @@ export async function getOverviewData(
         ),
       ]),
     ];
+    const overviewCommunitySignalStationIds = [
+      ...new Set(
+        overview.communitySignals.flatMap((signal) => signal.stationIds),
+      ),
+    ];
 
     return {
       data: overview,
       included: selectIncludedEntities(dataset.included, dataset.allIssues, {
         issueIds: overviewIssueIds,
         lineIds: overview.lineSummaries.map((summary) => summary.lineId),
+        stationIds: overviewCommunitySignalStationIds,
         includeStationMembershipLines: true,
       }),
     };

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -3120,11 +3120,11 @@ export async function getOverviewData(
 
     return {
       data: overview,
-      included: withIssues(
-        dataset.included,
-        dataset.allIssues,
-        overviewIssueIds,
-      ),
+      included: selectIncludedEntities(dataset.included, dataset.allIssues, {
+        issueIds: overviewIssueIds,
+        lineIds: overview.lineSummaries.map((summary) => summary.lineId),
+        includeStationMembershipLines: true,
+      }),
     };
   });
 }

--- a/app/util/overview.functions.ts
+++ b/app/util/overview.functions.ts
@@ -1,8 +1,7 @@
 import { env } from 'cloudflare:workers';
 import { createServerFn } from '@tanstack/react-start';
 import z from 'zod';
-import { getDateCountForViewport } from '~/helpers/getDateCountForViewport';
-import { ViewportSchema } from '~/hooks/useViewport';
+import { HOME_OVERVIEW_INITIAL_DATE_COUNT } from '~/constants';
 import {
   type CrowdReportFeatureEnv,
   isCrowdReportsFeatureEnabled,
@@ -11,23 +10,22 @@ import { getOverviewData } from './db.queries';
 import { timeServerSpan } from './serverTiming';
 
 const RequestSchema = z.object({
-  viewport: ViewportSchema.optional(),
+  days: z.union([z.literal(30), z.literal(60), z.literal(90)]).optional(),
 });
 
 export const getOverviewFn = createServerFn({ method: 'GET' })
   .inputValidator((val) => RequestSchema.parse(val))
   .handler(async (val) => {
-    const viewport = val.data.viewport ?? 'xs';
-    const dateCount = getDateCountForViewport(viewport);
+    const days = val.data.days ?? HOME_OVERVIEW_INITIAL_DATE_COUNT;
     return timeServerSpan(
       'overview_loader',
       () =>
-        getOverviewData(dateCount, {
+        getOverviewData(days, {
           includeCommunitySignals: isCrowdReportsFeatureEnabled(
             env as CrowdReportFeatureEnv,
             { isLocalDev: import.meta.env.DEV },
           ),
         }),
-      `viewport=${viewport}`,
+      `days=${days}`,
     );
   });

--- a/docs/plans/active/production-performance.md
+++ b/docs/plans/active/production-performance.md
@@ -284,6 +284,13 @@ underlying compute and payload costs so uncached requests are also fast.
   It no longer serializes the full operators, towns, landmarks, or station
   dictionaries for the statistics route. Added focused selector coverage in
   `app/util/db.queries.test.ts`.
+- 2026-05-27: Advanced Phase 2 for `/` and started Phase 3. The home loader now
+  returns an explicit included-entity subset instead of the full base included
+  graph: rendered line summaries, selected advisory/date-card issues, and the
+  line/station dependencies those issue cards need. The route now SSR-loads the
+  mobile-sized 30-day window, then fetches the existing viewport-sized 60/90-day
+  windows client-side for larger screens without navigating to a `viewport`
+  search parameter.
 
 ## Validation
 


### PR DESCRIPTION
## Summary

- shrink home route included entities to the line, station, and issue records the page actually renders
- SSR-load the mobile-sized 30-day home window, then fetch the existing 60/90-day viewport windows client-side for larger screens
- remove the home route `viewport` search-param navigation after hydration
- update the production performance plan with the Phase 2/3 progress

## Validation

- `npm run verify` passed outside the sandbox
- The sandboxed `npm run verify` run passed typecheck, lint, and format before failing at `db:generate:check` because `tsx` could not open its IPC pipe under `/var/folders` (`listen EPERM`); rerunning outside the sandbox completed successfully

## Notes

This preserves the smaller mobile initial payload while restoring desktop detail without mutating the URL after hydration.