### PR TITLE
feat: harden crowd report cluster thresholds

### DIFF
--- a/app/util/crowdReportDispatch.ts
+++ b/app/util/crowdReportDispatch.ts
@@ -7,6 +7,7 @@ import {
 import { and, desc, eq, inArray, isNull, or, sql } from 'drizzle-orm';
 import { DateTime } from 'luxon';
 import {
+  crowdReportAbuseEventsTable,
   crowdReportClusterLinesTable,
   crowdReportClustersTable,
   crowdReportClusterStationsTable,
@@ -20,6 +21,7 @@ const DEFAULT_DISPATCH_REPO = 'mrtdown-data';
 const DEFAULT_DISPATCH_EVENT_TYPE = 'ingest';
 const DEFAULT_DISPATCH_LIMIT = 10;
 const DEFAULT_DISPATCH_TIMEOUT_MS = 15_000;
+const DEFAULT_DISPATCH_MIN_DISTINCT_IP_HASHES = 2;
 const MAX_DISPATCH_LIMIT = 50;
 
 type AppDb = ReturnType<typeof import('~/db').getDb>;
@@ -104,6 +106,16 @@ function hasCrowdReportClusterScope() {
     sql`exists (select 1 from ${crowdReportClusterLinesTable} where ${crowdReportClusterLinesTable.cluster_id} = ${crowdReportClustersTable.id})`,
     sql`exists (select 1 from ${crowdReportClusterStationsTable} where ${crowdReportClusterStationsTable.cluster_id} = ${crowdReportClustersTable.id})`,
   );
+}
+
+function hasCrowdReportClusterSourceDiversity() {
+  return sql`(
+    select count(distinct ${crowdReportAbuseEventsTable.ip_hash})
+    from ${crowdReportAbuseEventsTable}
+    inner join ${crowdReportsTable}
+      on ${crowdReportsTable.id} = ${crowdReportAbuseEventsTable.report_id}
+    where ${crowdReportsTable.cluster_id} = ${crowdReportClustersTable.id}
+  ) >= ${DEFAULT_DISPATCH_MIN_DISTINCT_IP_HASHES}`;
 }
 
 export function buildCrowdReportSourceUrl(
@@ -238,6 +250,7 @@ async function getDispatchableCrowdReportClusterCandidates(
         eq(crowdReportClustersTable.status, 'accepted'),
         isNull(crowdReportClustersTable.dispatched_at),
         hasCrowdReportClusterScope(),
+        hasCrowdReportClusterSourceDiversity(),
       ),
     )
     .orderBy(desc(crowdReportClustersTable.window_end_at))
@@ -571,6 +584,7 @@ async function isCrowdReportDispatchCandidateEligible(
           eq(crowdReportClustersTable.status, 'accepted'),
           isNull(crowdReportClustersTable.dispatched_at),
           hasCrowdReportClusterScope(),
+          hasCrowdReportClusterSourceDiversity(),
         ),
       )
       .limit(1);

--- a/app/util/crowdReports.test.ts
+++ b/app/util/crowdReports.test.ts
@@ -776,6 +776,34 @@ describe('automoderateCrowdReport', () => {
     expect(fake.executes).toHaveLength(1);
   });
 
+  it('only accepts a first-report cluster when configured source thresholds are met', async () => {
+    const fake = makeFakeAutomoderationDb([[]], {
+      id: 'report-1',
+      status: 'accepted',
+      duplicateOfId: null,
+    });
+
+    await automoderateCrowdReport(
+      fake.db as never,
+      'report-1',
+      VALID_SUBMISSION,
+      {
+        idFactory: () => 'event-1',
+        publicSignalMinReports: 1,
+        publicSignalMinDistinctIpHashes: 1,
+      },
+    );
+
+    expect(fake.inserts[1]).toMatchObject({
+      table: crowdReportClustersTable,
+      values: {
+        id: 'event-1',
+        report_count: 1,
+        status: 'accepted',
+      },
+    });
+  });
+
   it('rejects low-quality reports before duplicate detection and clustering', async () => {
     const fake = makeFakeAutomoderationDb([], {
       id: 'report-1',

--- a/app/util/crowdReports.ts
+++ b/app/util/crowdReports.ts
@@ -26,6 +26,7 @@ const MAX_REPORT_FUTURE_MINUTES = 15;
 const DEFAULT_DUPLICATE_WINDOW_MINUTES = 10;
 const DEFAULT_CLUSTER_WINDOW_MINUTES = 10;
 const DEFAULT_PUBLIC_SIGNAL_MIN_REPORTS = 3;
+const DEFAULT_PUBLIC_SIGNAL_MIN_DISTINCT_IP_HASHES = 2;
 const DEFAULT_PUBLIC_SIGNAL_MAX_AGE_MINUTES = 90;
 const DEFAULT_PUBLIC_SIGNAL_LIMIT = 20;
 const AUTO_REJECT_RESOLVED_STALE_HOURS = 6;
@@ -116,6 +117,7 @@ type AutomoderateCrowdReportOptions = ClusterCrowdReportOptions & {
 type ClusterCrowdReportOptions = {
   clusterWindowMinutes?: number;
   publicSignalMinReports?: number;
+  publicSignalMinDistinctIpHashes?: number;
   idFactory?: () => string;
 };
 
@@ -200,6 +202,24 @@ function getCrowdReportClusterWindow(
     throw new Error('Unable to calculate crowd report cluster window');
   }
   return { windowStartAt, windowEndAt };
+}
+
+function getCrowdReportClusterDistinctIpHashCountSql(
+  clusterId: string | typeof crowdReportClustersTable.id,
+) {
+  return sql<number>`(
+    select count(distinct ${crowdReportAbuseEventsTable.ip_hash})
+    from ${crowdReportAbuseEventsTable}
+    inner join ${crowdReportsTable}
+      on ${crowdReportsTable.id} = ${crowdReportAbuseEventsTable.report_id}
+    where ${crowdReportsTable.cluster_id} = ${clusterId}
+  )`;
+}
+
+function hasCrowdReportClusterSourceDiversitySql(minDistinctIpHashes: number) {
+  return sql`${getCrowdReportClusterDistinctIpHashCountSql(
+    crowdReportClustersTable.id,
+  )} >= ${minDistinctIpHashes}`;
 }
 
 function normalizePolicyText(value: string) {
@@ -778,6 +798,7 @@ export async function automoderateCrowdReport(
       now,
       options.clusterWindowMinutes,
       options.publicSignalMinReports,
+      options.publicSignalMinDistinctIpHashes,
     ),
   );
 }
@@ -791,6 +812,7 @@ async function automoderateCrowdReportInTransaction(
   now: DateTime,
   clusterWindowMinutes = DEFAULT_CLUSTER_WINDOW_MINUTES,
   publicSignalMinReports = DEFAULT_PUBLIC_SIGNAL_MIN_REPORTS,
+  publicSignalMinDistinctIpHashes = DEFAULT_PUBLIC_SIGNAL_MIN_DISTINCT_IP_HASHES,
 ) {
   await tx.execute(
     sql`select pg_advisory_xact_lock(hashtextextended(${buildDuplicateLockKey(submission)}, 0::bigint))`,
@@ -869,6 +891,7 @@ async function automoderateCrowdReportInTransaction(
     duplicate,
     clusterWindowMinutes,
     publicSignalMinReports,
+    publicSignalMinDistinctIpHashes,
     idFactory,
   );
 
@@ -887,6 +910,8 @@ async function createCrowdReportClusterInTransaction(
   submission: CrowdReportSubmission,
   clusterWindowMinutes: number,
   idFactory: () => string,
+  publicSignalMinReports: number,
+  publicSignalMinDistinctIpHashes: number,
 ) {
   const clusterId = idFactory();
   const { windowStartAt, windowEndAt } = getCrowdReportClusterWindow(
@@ -900,7 +925,10 @@ async function createCrowdReportClusterInTransaction(
     window_start_at: windowStartAt,
     window_end_at: windowEndAt,
     report_count: 1,
-    status: 'pending',
+    status:
+      publicSignalMinReports <= 1 && publicSignalMinDistinctIpHashes <= 1
+        ? 'accepted'
+        : 'pending',
   });
 
   if (submission.lineIds.length > 0) {
@@ -940,6 +968,7 @@ async function clusterModeratedCrowdReportInTransaction(
   duplicate: DuplicateCrowdReport | undefined,
   clusterWindowMinutes: number,
   publicSignalMinReports: number,
+  publicSignalMinDistinctIpHashes: number,
   idFactory: () => string,
 ) {
   if (duplicate == null) {
@@ -949,6 +978,8 @@ async function clusterModeratedCrowdReportInTransaction(
       submission,
       clusterWindowMinutes,
       idFactory,
+      publicSignalMinReports,
+      publicSignalMinDistinctIpHashes,
     );
     return;
   }
@@ -961,6 +992,8 @@ async function clusterModeratedCrowdReportInTransaction(
       { ...submission, observedAt: duplicate.observedAt },
       clusterWindowMinutes,
       idFactory,
+      publicSignalMinReports,
+      publicSignalMinDistinctIpHashes,
     ));
   const { windowStartAt, windowEndAt } = getCrowdReportClusterWindow(
     submission.observedAt,
@@ -980,7 +1013,7 @@ async function clusterModeratedCrowdReportInTransaction(
     .update(crowdReportClustersTable)
     .set({
       report_count: sql`${crowdReportClustersTable.report_count} + 1`,
-      status: sql`case when ${crowdReportClustersTable.status} = 'pending' and ${crowdReportClustersTable.report_count} + 1 >= ${publicSignalMinReports} then 'accepted'::crowd_report_cluster_status else ${crowdReportClustersTable.status} end`,
+      status: sql`case when ${crowdReportClustersTable.status} = 'pending' and ${crowdReportClustersTable.report_count} + 1 >= ${publicSignalMinReports} and ${getCrowdReportClusterDistinctIpHashCountSql(clusterId)} >= ${publicSignalMinDistinctIpHashes} then 'accepted'::crowd_report_cluster_status else ${crowdReportClustersTable.status} end`,
       window_start_at: sql`least(${crowdReportClustersTable.window_start_at}, ${windowStartAt}::timestamptz)`,
       window_end_at: sql`greatest(${crowdReportClustersTable.window_end_at}, ${windowEndAt}::timestamptz)`,
       updated_at: sql`now()`,
@@ -1137,6 +1170,7 @@ export async function persistAutomoderatedCrowdReport(
       now,
       options.clusterWindowMinutes,
       options.publicSignalMinReports,
+      options.publicSignalMinDistinctIpHashes,
     );
   });
 }
@@ -1149,6 +1183,7 @@ export async function getPublicCrowdReportSignals(
     now?: DateTime;
     maxAgeMinutes?: number;
     minReportCount?: number;
+    minDistinctIpHashes?: number;
     limit?: number;
   } = {},
 ): Promise<PublicCrowdReportSignal[]> {
@@ -1179,6 +1214,10 @@ export async function getPublicCrowdReportSignals(
         gte(
           crowdReportClustersTable.report_count,
           options.minReportCount ?? DEFAULT_PUBLIC_SIGNAL_MIN_REPORTS,
+        ),
+        hasCrowdReportClusterSourceDiversitySql(
+          options.minDistinctIpHashes ??
+            DEFAULT_PUBLIC_SIGNAL_MIN_DISTINCT_IP_HASHES,
         ),
         gte(crowdReportClustersTable.window_end_at, activeSince),
         options.lineId

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -416,6 +416,10 @@ Exit criteria:
   free-text details by default; standard structured reports now submit
   generated summary text, while ambiguous `unknown` or `Other` direction
   reports still require a short note.
+- 2026-05-27: Hardened Phase 6 high-confidence cluster automation by requiring
+  public and dispatchable community-report clusters to include multiple
+  site-local reporter IP hashes, reducing the chance that one source can create
+  a public signal or canonical ingest dispatch alone.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Require accepted community-report clusters to meet a distinct site-local reporter IP-hash threshold before they can appear as public signals.
- Apply the same source-diversity eligibility check before dispatching accepted clusters to canonical ingest.
- Add focused test coverage and update the active crowdsourced reports plan log.

## Validation

- `npm run test:run -- app/util/crowdReports.test.ts app/util/crowdReportDispatch.test.ts`
- `npm run typecheck`
- `npm run verify`

Note: the first sandboxed `npm run verify` attempt failed at `npm run db:generate:check` because `tsx` could not create an IPC pipe under `/var/folders` (`listen EPERM`). The same command passed when rerun outside the sandbox.