### PR TITLE
perf: shrink profile route payloads

### DIFF
--- a/app/util/db.queries.test.ts
+++ b/app/util/db.queries.test.ts
@@ -322,6 +322,10 @@ describe('selectIncludedEntities', () => {
   });
 
   it('keeps explicitly requested stations and their membership lines', () => {
+    const station = {
+      ...TEST_STATION,
+      landmarkIds: ['hillion'],
+    };
     const included = selectIncludedEntities(
       {
         lines: {
@@ -329,24 +333,92 @@ describe('selectIncludedEntities', () => {
           [TEST_FEEDER_LINE.id]: TEST_FEEDER_LINE,
         },
         stations: {
-          [TEST_STATION.id]: TEST_STATION,
+          [station.id]: station,
         },
         operators: {},
+        towns: {
+          'bukit-panjang': {
+            id: 'bukit-panjang',
+            name: {
+              'en-SG': 'Bukit Panjang',
+              'zh-Hans': null,
+              ms: null,
+              ta: null,
+            },
+          },
+        },
+        landmarks: {
+          hillion: {
+            id: 'hillion',
+            name: {
+              'en-SG': 'Hillion Mall',
+              'zh-Hans': null,
+              ms: null,
+              ta: null,
+            },
+          },
+        },
+      },
+      {},
+      {
+        issueIds: [],
+        stationIds: [station.id],
+        includeStationDetailEntities: true,
+        includeStationMembershipLines: true,
+      },
+    );
+
+    expect(Object.keys(included.stations)).toEqual([station.id]);
+    expect(Object.keys(included.lines).sort()).toEqual(
+      [TEST_FEEDER_LINE.id, TEST_LINE.id].sort(),
+    );
+    expect(Object.keys(included.towns)).toEqual(['bukit-panjang']);
+    expect(Object.keys(included.landmarks)).toEqual(['hillion']);
+    expect(included.issues).toEqual({});
+  });
+
+  it('keeps operators for requested lines when requested', () => {
+    const line = {
+      ...TEST_LINE,
+      operators: [
+        {
+          operatorId: 'SMRT',
+          startedAt: '1999-11-06',
+          endedAt: null,
+        },
+      ],
+    };
+    const included = selectIncludedEntities(
+      {
+        lines: {
+          [line.id]: line,
+        },
+        stations: {},
+        operators: {
+          SMRT: {
+            id: 'SMRT',
+            name: {
+              'en-SG': 'SMRT',
+              'zh-Hans': null,
+              ms: null,
+              ta: null,
+            },
+            foundedAt: '1987-08-06',
+            url: null,
+          },
+        },
         towns: {},
         landmarks: {},
       },
       {},
       {
         issueIds: [],
-        stationIds: [TEST_STATION.id],
-        includeStationMembershipLines: true,
+        lineIds: [line.id],
+        includeLineOperators: true,
       },
     );
 
-    expect(Object.keys(included.stations)).toEqual([TEST_STATION.id]);
-    expect(Object.keys(included.lines).sort()).toEqual(
-      [TEST_FEEDER_LINE.id, TEST_LINE.id].sort(),
-    );
-    expect(included.issues).toEqual({});
+    expect(Object.keys(included.lines)).toEqual([line.id]);
+    expect(Object.keys(included.operators)).toEqual(['SMRT']);
   });
 });

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -1677,6 +1677,7 @@ async function getIncludedForIssueIds(issueIds: readonly string[]) {
   const dataset = await buildDataset(nowSg(), undefined, issueIds);
   return selectIncludedEntities(dataset.included, dataset.allIssues, {
     issueIds,
+    includeStationMembershipLines: true,
   });
 }
 
@@ -3323,6 +3324,7 @@ export async function getIssueData(issueId: string) {
     },
     included: selectIncludedEntities(dataset.included, dataset.allIssues, {
       issueIds: [issueId],
+      includeStationMembershipLines: true,
     }),
   };
 }
@@ -3374,6 +3376,9 @@ export async function getStationProfileData(
     },
     included: selectIncludedEntities(dataset.included, dataset.allIssues, {
       issueIds: issueIdsRecent,
+      lineIds: [
+        ...new Set(communitySignals.flatMap((signal) => signal.lineIds)),
+      ],
       stationIds: [
         stationId,
         ...new Set(communitySignals.flatMap((signal) => signal.stationIds)),
@@ -3516,6 +3521,7 @@ export async function getOperatorProfileData(operatorId: string, days: number) {
       issueIds: profile.issueIdsRecent,
       lineIds: profile.lineIds,
       operatorIds: [operatorId],
+      includeStationMembershipLines: true,
     }),
   };
 }
@@ -3574,6 +3580,7 @@ export async function getHistoryYearSummaryData(year: number) {
       },
       included: selectIncludedEntities(dataset.included, dataset.allIssues, {
         issueIds: issues.map((issue) => issue.id),
+        includeStationMembershipLines: true,
       }),
     };
   }
@@ -3680,6 +3687,7 @@ export async function getHistoryYearMonthData(year: number, month: number) {
       },
       included: selectIncludedEntities(dataset.included, dataset.allIssues, {
         issueIds: issues.map((issue) => issue.id),
+        includeStationMembershipLines: true,
       }),
     };
   }
@@ -3744,6 +3752,7 @@ export async function getHistoryDayData(
       },
       included: selectIncludedEntities(dataset.included, dataset.allIssues, {
         issueIds,
+        includeStationMembershipLines: true,
       }),
     };
   }

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -1675,25 +1675,21 @@ async function getBaseDataset() {
 
 async function getIncludedForIssueIds(issueIds: readonly string[]) {
   const dataset = await buildDataset(nowSg(), undefined, issueIds);
-  return withIssues(dataset.included, dataset.allIssues, issueIds);
-}
-
-function withIssues(
-  baseIncluded: BaseIncludedEntities,
-  allIssues: Record<string, IssueWithOperationalEffects>,
-  issueIds?: readonly string[],
-): IncludedEntities {
-  return {
-    ...baseIncluded,
-    issues: stripOperationalEffects(selectIssues(allIssues, issueIds)),
-  };
+  return selectIncludedEntities(dataset.included, dataset.allIssues, {
+    issueIds,
+  });
 }
 
 type IncludedEntitySelection = {
   issueIds?: readonly string[];
   lineIds?: readonly string[];
+  operatorIds?: readonly string[];
   stationIds?: readonly string[];
+  townIds?: readonly string[];
+  landmarkIds?: readonly string[];
   includeIssueEntities?: boolean;
+  includeLineOperators?: boolean;
+  includeStationDetailEntities?: boolean;
   includeStationMembershipLines?: boolean;
 };
 
@@ -1732,7 +1728,10 @@ export function selectIncludedEntities(
 ): IncludedEntities {
   const selectedIssuesWithEffects = selectIssues(allIssues, selection.issueIds);
   const lineIds = new Set(selection.lineIds ?? []);
+  const operatorIds = new Set(selection.operatorIds ?? []);
   const stationIds = new Set(selection.stationIds ?? []);
+  const townIds = new Set(selection.townIds ?? []);
+  const landmarkIds = new Set(selection.landmarkIds ?? []);
 
   if (selection.includeIssueEntities !== false) {
     for (const issue of Object.values(selectedIssuesWithEffects)) {
@@ -1757,6 +1756,28 @@ export function selectIncludedEntities(
     }
   }
 
+  if (selection.includeLineOperators === true) {
+    for (const lineId of lineIds) {
+      const line = baseIncluded.lines[lineId];
+      for (const operator of line?.operators ?? []) {
+        operatorIds.add(operator.operatorId);
+      }
+    }
+  }
+
+  if (selection.includeStationDetailEntities === true) {
+    for (const stationId of stationIds) {
+      const station = baseIncluded.stations[stationId];
+      if (station == null) {
+        continue;
+      }
+      townIds.add(station.townId);
+      for (const landmarkId of station.landmarkIds) {
+        landmarkIds.add(landmarkId);
+      }
+    }
+  }
+
   return {
     lines: Object.fromEntries(
       [...lineIds]
@@ -1769,9 +1790,21 @@ export function selectIncludedEntities(
         .map((stationId) => [stationId, baseIncluded.stations[stationId]]),
     ),
     issues: stripOperationalEffects(selectedIssuesWithEffects),
-    landmarks: {},
-    towns: {},
-    operators: {},
+    landmarks: Object.fromEntries(
+      [...landmarkIds]
+        .filter((landmarkId) => baseIncluded.landmarks[landmarkId] != null)
+        .map((landmarkId) => [landmarkId, baseIncluded.landmarks[landmarkId]]),
+    ),
+    towns: Object.fromEntries(
+      [...townIds]
+        .filter((townId) => baseIncluded.towns[townId] != null)
+        .map((townId) => [townId, baseIncluded.towns[townId]]),
+    ),
+    operators: Object.fromEntries(
+      [...operatorIds]
+        .filter((operatorId) => baseIncluded.operators[operatorId] != null)
+        .map((operatorId) => [operatorId, baseIncluded.operators[operatorId]]),
+    ),
   };
 }
 
@@ -3239,16 +3272,23 @@ export async function getLineProfileData(
     stationIdsInterchanges,
     communitySignals: await getPageCommunitySignals(options, { lineId }),
   };
+  const profileIssueIds = [
+    ...new Set(
+      [...issueIdsRecent, profile.issueIdNextMaintenance].filter(
+        (value): value is string => value != null,
+      ),
+    ),
+  ];
 
   return {
     data: profile,
-    included: withIssues(dataset.included, dataset.allIssues, [
-      ...new Set(
-        [...issueIdsRecent, profile.issueIdNextMaintenance].filter(
-          (value): value is string => value != null,
-        ),
-      ),
-    ]),
+    included: selectIncludedEntities(dataset.included, dataset.allIssues, {
+      issueIds: profileIssueIds,
+      lineIds: [lineId],
+      stationIds: Object.keys(dataset.included.stations),
+      operatorIds: line.operators.map((operator) => operator.operatorId),
+      includeStationMembershipLines: true,
+    }),
   };
 }
 
@@ -3281,7 +3321,9 @@ export async function getIssueData(issueId: string) {
         createdAt: evidence.ts,
       })),
     },
-    included: withIssues(dataset.included, dataset.allIssues, [issueId]),
+    included: selectIncludedEntities(dataset.included, dataset.allIssues, {
+      issueIds: [issueId],
+    }),
   };
 }
 
@@ -3318,6 +3360,9 @@ export async function getStationProfileData(
     issues.map((issue) => issue.id),
     dataset.allIssues,
   ).slice(0, 15);
+  const communitySignals = await getPageCommunitySignals(options, {
+    stationId,
+  });
 
   return {
     data: {
@@ -3325,9 +3370,17 @@ export async function getStationProfileData(
       status,
       issueIdsRecent,
       issueCountByType: pickIssueTypes(issues),
-      communitySignals: await getPageCommunitySignals(options, { stationId }),
+      communitySignals,
     },
-    included: withIssues(dataset.included, dataset.allIssues, issueIdsRecent),
+    included: selectIncludedEntities(dataset.included, dataset.allIssues, {
+      issueIds: issueIdsRecent,
+      stationIds: [
+        stationId,
+        ...new Set(communitySignals.flatMap((signal) => signal.stationIds)),
+      ],
+      includeStationDetailEntities: true,
+      includeStationMembershipLines: true,
+    }),
   };
 }
 
@@ -3459,11 +3512,11 @@ export async function getOperatorProfileData(operatorId: string, days: number) {
 
   return {
     data: profile,
-    included: withIssues(
-      dataset.included,
-      dataset.allIssues,
-      profile.issueIdsRecent,
-    ),
+    included: selectIncludedEntities(dataset.included, dataset.allIssues, {
+      issueIds: profile.issueIdsRecent,
+      lineIds: profile.lineIds,
+      operatorIds: [operatorId],
+    }),
   };
 }
 
@@ -3519,11 +3572,9 @@ export async function getHistoryYearSummaryData(year: number) {
         endAt: isoDate(yearEnd.minus({ day: 1 })),
         summaryByMonth,
       },
-      included: withIssues(
-        dataset.included,
-        dataset.allIssues,
-        issues.map((issue) => issue.id),
-      ),
+      included: selectIncludedEntities(dataset.included, dataset.allIssues, {
+        issueIds: issues.map((issue) => issue.id),
+      }),
     };
   }
   const issueIds = [...new Set(factRows.map((row) => row.issue_id))];
@@ -3627,11 +3678,9 @@ export async function getHistoryYearMonthData(year: number, month: number) {
             issueIds,
           })),
       },
-      included: withIssues(
-        dataset.included,
-        dataset.allIssues,
-        issues.map((issue) => issue.id),
-      ),
+      included: selectIncludedEntities(dataset.included, dataset.allIssues, {
+        issueIds: issues.map((issue) => issue.id),
+      }),
     };
   }
   const issueIds = [...new Set(factRows.map((row) => row.issue_id))];
@@ -3693,7 +3742,9 @@ export async function getHistoryDayData(
         endAt: isoDate(date),
         issueIds,
       },
-      included: withIssues(dataset.included, dataset.allIssues, issueIds),
+      included: selectIncludedEntities(dataset.included, dataset.allIssues, {
+        issueIds,
+      }),
     };
   }
   const issueIds = [...new Set(factRows.map((row) => row.issue_id))].sort(

--- a/docs/plans/active/production-performance.md
+++ b/docs/plans/active/production-performance.md
@@ -291,6 +291,11 @@ underlying compute and payload costs so uncached requests are also fast.
   mobile-sized 30-day window, then fetches the existing viewport-sized 60/90-day
   windows client-side for larger screens without navigating to a `viewport`
   search parameter.
+- 2026-05-27: Extended Phase 2 payload reduction beyond home/statistics. Line,
+  station, operator, issue, and history loaders now use the explicit
+  included-entity selector instead of spreading the full base included graph
+  into each response. The selector can now opt into route-local operators,
+  station towns, and station landmarks for pages that actually render them.
 
 ## Validation
 


### PR DESCRIPTION
## Summary

- extend the included-entity selector so routes can opt into only the operators, station towns, and landmarks they render
- switch line, station, operator, issue, and history loaders away from broad base included graph serialization
- update the production performance plan progress notes and selector coverage

## Validation

- `npm run verify` passed after rerunning outside the sandbox so `tsx` could create its IPC pipe for the migration drift check
- full verification covered typecheck, lint, format check, migration drift check, and 115 tests

## Notes

The first sandboxed `npm run verify` attempt failed at `db:generate:check` with `listen EPERM` on the `tsx` IPC pipe under `/var/folders`; the escalated rerun completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test coverage for entity selection and related data retrieval.

* **Refactor**
  * Updated data retrieval across multiple endpoints to support more granular selection of associated entities (operators, towns, landmarks) in API responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-site/pull/136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->