### PR TITLE
perf: precompute statistics snapshots

### DIFF
--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -878,6 +878,29 @@ export const lineDayFactsTable = pgTable(
   },
 );
 
+// Precomputed public statistics payload. This keeps chart assembly off the SSR
+// request path while preserving a rebuildable fallback.
+export const statisticsSnapshotsTable = pgTable(
+  'statistics_snapshots',
+  {
+    id: text('id').primaryKey(),
+    as_of: timestamp('as_of', {
+      withTimezone: true,
+      mode: 'string',
+    }).notNull(),
+    data: jsonb('data').$type<unknown>().notNull(),
+    ...timestampColumns,
+  },
+  (table) => {
+    return [
+      index('statistics_snapshots_as_of_idx').using(
+        'btree',
+        table.as_of.desc(),
+      ),
+    ];
+  },
+);
+
 export const impactEventServiceScopeTypeEnum = pgEnum(
   'impact_event_service_scope_type',
   enumToPgEnum(ServiceScopeTypeSchema.enum),

--- a/app/routes/internal.api.tasks.facts.ts
+++ b/app/routes/internal.api.tasks.facts.ts
@@ -1,6 +1,9 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { z } from 'zod';
-import { rebuildOperationalFactsRange } from '~/util/db.queries';
+import {
+  rebuildOperationalFactsRange,
+  rebuildStatisticsSnapshot,
+} from '~/util/db.queries';
 import { internalMiddleware } from '~/util/internal.middleware';
 
 const RequestSchema = z.object({
@@ -36,11 +39,13 @@ export const Route = createFileRoute('/internal/api/tasks/facts')({
 
         const { days } = parsed.data;
         const rows = await rebuildOperationalFactsRange(days);
+        const statistics = await rebuildStatisticsSnapshot();
         return Response.json(
           {
             success: true,
             days,
             rows,
+            statistics,
           },
           { status: 200 },
         );

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -45,6 +45,7 @@ import {
   stationCodesTable,
   stationLandmarksTable,
   stationsTable,
+  statisticsSnapshotsTable,
   townsTable,
 } from '~/db/schema';
 import {
@@ -138,6 +139,24 @@ type IssueIntervalBounds = {
 };
 
 type TimeScale = TimeScaleChart['dataTimeScale'];
+
+export type SystemAnalytics = {
+  timeScaleChartsIssueCount: TimeScaleChart[];
+  timeScaleChartsIssueDuration: TimeScaleChart[];
+  chartTotalIssueCountByLine: {
+    title: string;
+    data: ChartEntry[];
+  };
+  chartTotalIssueCountByStation: {
+    title: string;
+    data: ChartEntry[];
+  };
+  chartRollingYearHeatmap: {
+    title: string;
+    data: ChartEntry[];
+  };
+  issueIdsDisruptionLongest: string[];
+};
 
 type StatisticsTimeWindow = {
   title: string;
@@ -2622,11 +2641,15 @@ function isUndefinedTableError(error: unknown) {
   );
 }
 
-async function getIssueDayFactsInRange(start: DateTime, end: DateTime) {
-  const db = await getDefaultDb();
+async function getIssueDayFactsInRange(
+  start: DateTime,
+  end: DateTime,
+  db?: AppDb,
+) {
+  const database = db ?? (await getDefaultDb());
   try {
     return await timeServerSpan('fact_issue_day_query', () =>
-      db
+      database
         .select({
           date: issueDayFactsTable.date,
           issue_id: issueDayFactsTable.issue_id,
@@ -2653,11 +2676,12 @@ async function getIssueDayFactsInRange(start: DateTime, end: DateTime) {
 async function getOperationalFactCoverageDatesInRange(
   start: DateTime,
   end: DateTime,
+  db?: AppDb,
 ) {
-  const db = await getDefaultDb();
+  const database = db ?? (await getDefaultDb());
   try {
     return await timeServerSpan('fact_coverage_query', () =>
-      db
+      database
         .select({
           date: lineDayFactsTable.date,
         })
@@ -3771,9 +3795,73 @@ export async function getHistoryDayData(
   };
 }
 
-export async function getStatisticsData() {
-  return timeServerSpan('statistics_data', async () => {
-    const dataset = await getBaseDataset();
+const STATISTICS_SNAPSHOT_ID = 'latest';
+
+function isSystemAnalytics(value: unknown): value is SystemAnalytics {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    Array.isArray(
+      (value as Partial<SystemAnalytics>).timeScaleChartsIssueCount,
+    ) &&
+    Array.isArray(
+      (value as Partial<SystemAnalytics>).timeScaleChartsIssueDuration,
+    ) &&
+    Array.isArray(
+      (value as Partial<SystemAnalytics>).chartTotalIssueCountByLine?.data,
+    ) &&
+    Array.isArray(
+      (value as Partial<SystemAnalytics>).chartTotalIssueCountByStation?.data,
+    ) &&
+    Array.isArray(
+      (value as Partial<SystemAnalytics>).chartRollingYearHeatmap?.data,
+    ) &&
+    Array.isArray((value as Partial<SystemAnalytics>).issueIdsDisruptionLongest)
+  );
+}
+
+async function getLatestStatisticsSnapshot(db?: AppDb) {
+  const database = db ?? (await getDefaultDb());
+  try {
+    const [snapshot] = await timeServerSpan('statistics_snapshot_query', () =>
+      database
+        .select({
+          data: statisticsSnapshotsTable.data,
+        })
+        .from(statisticsSnapshotsTable)
+        .where(eq(statisticsSnapshotsTable.id, STATISTICS_SNAPSHOT_ID))
+        .limit(1),
+    );
+    return isSystemAnalytics(snapshot?.data) ? snapshot.data : null;
+  } catch (error) {
+    if (isUndefinedTableError(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function getStatisticsIncluded(
+  dataset: BaseDataset,
+  statistics: SystemAnalytics,
+) {
+  return selectIncludedEntities(dataset.included, dataset.allIssues, {
+    issueIds: statistics.issueIdsDisruptionLongest,
+    lineIds: statistics.chartTotalIssueCountByLine.data.map(
+      (entry) => entry.name,
+    ),
+    stationIds: statistics.chartTotalIssueCountByStation.data.map(
+      (entry) => entry.name,
+    ),
+    includeStationMembershipLines: true,
+  });
+}
+
+async function buildStatisticsDataFromDataset(
+  dataset: BaseDataset,
+  db?: AppDb,
+) {
+  return timeServerSpan('statistics_build', async () => {
     const issues = Object.values(dataset.allIssues);
     const rollingYearEnd = nowSg().startOf('day');
     const rollingYearStart = rollingYearEnd.minus({ days: 364 });
@@ -3781,16 +3869,19 @@ export async function getStatisticsData() {
     const issueFactRows = await getIssueDayFactsInRange(
       statisticsFactStart,
       rollingYearEnd,
+      db,
     );
     const rollingYearFactCoverageRows =
       await getOperationalFactCoverageDatesInRange(
         rollingYearStart,
         rollingYearEnd,
+        db,
       );
     const statisticsFactCoverageRows =
       await getOperationalFactCoverageDatesInRange(
         statisticsFactStart,
         rollingYearEnd,
+        db,
       );
     const hasRollingYearIssueFactCoverage = hasFullDateCoverage(
       rollingYearFactCoverageRows,
@@ -3926,7 +4017,7 @@ export async function getStatisticsData() {
       }),
     );
 
-    const statistics = {
+    return {
       timeScaleChartsIssueCount: timeSyncServerSpan(
         'statistics_count_charts',
         () =>
@@ -3945,17 +4036,61 @@ export async function getStatisticsData() {
       chartTotalIssueCountByStation,
       chartRollingYearHeatmap,
       issueIdsDisruptionLongest: longestDisruptions,
-    };
+    } satisfies SystemAnalytics;
+  });
+}
 
+export async function rebuildStatisticsSnapshot(db?: AppDb) {
+  return timeServerSpan('statistics_snapshot_rebuild', async () => {
+    const database = db ?? (await getDefaultDb());
+    const asOf = isoDateTime(nowSg());
+    const dataset = await buildDataset(nowSg(), database);
+    const data = await buildStatisticsDataFromDataset(dataset, database);
+    await timeServerSpan('statistics_snapshot_upsert', () =>
+      database
+        .insert(statisticsSnapshotsTable)
+        .values({
+          id: STATISTICS_SNAPSHOT_ID,
+          as_of: asOf,
+          data,
+        })
+        .onConflictDoUpdate({
+          target: [statisticsSnapshotsTable.id],
+          set: {
+            as_of: asOf,
+            data,
+            updated_at: sql`now()`,
+          },
+        }),
+    );
+    return {
+      asOf,
+      issueIdsDisruptionLongest: data.issueIdsDisruptionLongest,
+    };
+  });
+}
+
+export async function getStatisticsData() {
+  return timeServerSpan('statistics_data', async () => {
+    const snapshot = await getLatestStatisticsSnapshot();
+    if (snapshot != null) {
+      const dataset = await timeServerSpan('statistics_included_dataset', () =>
+        buildDataset(nowSg(), undefined, snapshot.issueIdsDisruptionLongest),
+      );
+      return {
+        data: snapshot,
+        included: timeSyncServerSpan('statistics_included', () =>
+          getStatisticsIncluded(dataset, snapshot),
+        ),
+      };
+    }
+
+    const dataset = await getBaseDataset();
+    const statistics = await buildStatisticsDataFromDataset(dataset);
     return {
       data: statistics,
       included: timeSyncServerSpan('statistics_included', () =>
-        selectIncludedEntities(dataset.included, dataset.allIssues, {
-          issueIds: longestDisruptions,
-          lineIds: chartTotalIssueCountByLine.data.map((entry) => entry.name),
-          stationIds: topStationIssueCounts.map((entry) => entry.name),
-          includeStationMembershipLines: true,
-        }),
+        getStatisticsIncluded(dataset, statistics),
       ),
     };
   });
@@ -3990,8 +4125,4 @@ export type LineBranch = Awaited<
 
 export type OperatorProfile = Awaited<
   ReturnType<typeof getOperatorProfileData>
->['data'];
-
-export type SystemAnalytics = Awaited<
-  ReturnType<typeof getStatisticsData>
 >['data'];

--- a/app/workflows/pull/index.test.ts
+++ b/app/workflows/pull/index.test.ts
@@ -17,6 +17,7 @@ describe('pull workflow promotion order', () => {
       'delete-operators-towns-landmarks-orphans',
       'finalize',
       'rebuild-operational-facts',
+      'rebuild-statistics-snapshot',
     ];
 
     let previousIndex = -1;

--- a/app/workflows/pull/index.ts
+++ b/app/workflows/pull/index.ts
@@ -6,7 +6,10 @@ import {
 import { MRTDownRepository } from '@mrtdown/fs';
 import * as Sentry from '@sentry/cloudflare';
 import { ZipStore } from '~/helpers/ZipStore.js';
-import { rebuildOperationalFactsRange } from '~/util/db.queries.js';
+import {
+  rebuildOperationalFactsRange,
+  rebuildStatisticsSnapshot,
+} from '~/util/db.queries.js';
 import { getDb } from '../../db/index.js';
 import { fetchArchive } from './helpers/fetchArchive.js';
 import { fetchManifest } from './helpers/fetchManifest.js';
@@ -295,6 +298,19 @@ class PullWorkflowBase extends WorkflowEntrypoint<Env, Params> {
     );
 
     console.log(`[PULL] Rebuilt operational facts for ${facts.length} days`);
+
+    const statistics = await step.do(
+      'rebuild-statistics-snapshot',
+      factsStepConfig,
+      async () => {
+        console.log('[PULL] Rebuilding statistics snapshot...');
+        return rebuildStatisticsSnapshot();
+      },
+    );
+
+    console.log(
+      `[PULL] Rebuilt statistics snapshot ${statistics.asOf} with ${statistics.issueIdsDisruptionLongest.length} longest disruptions`,
+    );
     console.log('[PULL] Pull complete', counts);
   }
 }

--- a/docs/plans/active/production-performance.md
+++ b/docs/plans/active/production-performance.md
@@ -300,6 +300,11 @@ underlying compute and payload costs so uncached requests are also fast.
   pages. Operator routes now SSR-load a 30-day baseline and fetch the wider
   60/90-day viewport windows client-side without navigating to a `viewport`
   search parameter, matching the home page pattern.
+- 2026-05-27: Started Phase 4 precomputed statistics. Added a rebuildable
+  `statistics_snapshots` read-model table, refresh it after pull workflow
+  operational facts and manual facts rebuilds, and make the statistics route use
+  the snapshot when available. The existing request-time statistics builder
+  remains as a fallback for development and un-migrated environments.
 
 ## Validation
 

--- a/drizzle/0011_serious_kid_colt.sql
+++ b/drizzle/0011_serious_kid_colt.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "statistics_snapshots" (
+	"id" text PRIMARY KEY NOT NULL,
+	"as_of" timestamp with time zone NOT NULL,
+	"data" jsonb NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "statistics_snapshots_as_of_idx" ON "statistics_snapshots" USING btree ("as_of" DESC NULLS LAST);

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,4109 @@
+{
+  "id": "3a19ee65-1095-4fc0-a785-e3fa8f7a2b9f",
+  "prevId": "26dfcab4-a339-4670-b9c2-954a0ee8e64b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.crowd_report_abuse_events": {
+      "name": "crowd_report_abuse_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent_hash": {
+          "name": "user_agent_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_fingerprint_hash": {
+          "name": "client_fingerprint_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turnstile_token_hash": {
+          "name": "turnstile_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turnstile_outcome": {
+          "name": "turnstile_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate_limit_bucket_start_at": {
+          "name": "rate_limit_bucket_start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crowd_report_abuse_events_report_id_idx": {
+          "name": "crowd_report_abuse_events_report_id_idx",
+          "columns": [
+            {
+              "expression": "report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crowd_report_abuse_events_ip_hash_created_at_idx": {
+          "name": "crowd_report_abuse_events_ip_hash_created_at_idx",
+          "columns": [
+            {
+              "expression": "ip_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crowd_report_abuse_events_report_id_crowd_reports_id_fk": {
+          "name": "crowd_report_abuse_events_report_id_crowd_reports_id_fk",
+          "tableFrom": "crowd_report_abuse_events",
+          "tableTo": "crowd_reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crowd_report_cluster_lines": {
+      "name": "crowd_report_cluster_lines",
+      "schema": "",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "crowd_report_cluster_lines_line_id_idx": {
+          "name": "crowd_report_cluster_lines_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crowd_report_cluster_lines_cluster_id_crowd_report_clusters_id_fk": {
+          "name": "crowd_report_cluster_lines_cluster_id_crowd_report_clusters_id_fk",
+          "tableFrom": "crowd_report_cluster_lines",
+          "tableTo": "crowd_report_clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crowd_report_cluster_lines_line_id_lines_id_fk": {
+          "name": "crowd_report_cluster_lines_line_id_lines_id_fk",
+          "tableFrom": "crowd_report_cluster_lines",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "crowd_report_cluster_lines_cluster_id_line_id_pk": {
+          "name": "crowd_report_cluster_lines_cluster_id_line_id_pk",
+          "columns": [
+            "cluster_id",
+            "line_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crowd_report_cluster_stations": {
+      "name": "crowd_report_cluster_stations",
+      "schema": "",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "crowd_report_cluster_stations_station_id_idx": {
+          "name": "crowd_report_cluster_stations_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crowd_report_cluster_stations_cluster_id_crowd_report_clusters_id_fk": {
+          "name": "crowd_report_cluster_stations_cluster_id_crowd_report_clusters_id_fk",
+          "tableFrom": "crowd_report_cluster_stations",
+          "tableTo": "crowd_report_clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crowd_report_cluster_stations_station_id_stations_id_fk": {
+          "name": "crowd_report_cluster_stations_station_id_stations_id_fk",
+          "tableFrom": "crowd_report_cluster_stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "crowd_report_cluster_stations_cluster_id_station_id_pk": {
+          "name": "crowd_report_cluster_stations_cluster_id_station_id_pk",
+          "columns": [
+            "cluster_id",
+            "station_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crowd_report_clusters": {
+      "name": "crowd_report_clusters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "effect": {
+          "name": "effect",
+          "type": "crowd_report_effect",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "window_start_at": {
+          "name": "window_start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end_at": {
+          "name": "window_end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_count": {
+          "name": "report_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "crowd_report_cluster_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crowd_report_clusters_status_idx": {
+          "name": "crowd_report_clusters_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crowd_report_clusters_window_start_at_idx": {
+          "name": "crowd_report_clusters_window_start_at_idx",
+          "columns": [
+            {
+              "expression": "window_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crowd_report_lines": {
+      "name": "crowd_report_lines",
+      "schema": "",
+      "columns": {
+        "report_id": {
+          "name": "report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "crowd_report_lines_line_id_idx": {
+          "name": "crowd_report_lines_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crowd_report_lines_report_id_crowd_reports_id_fk": {
+          "name": "crowd_report_lines_report_id_crowd_reports_id_fk",
+          "tableFrom": "crowd_report_lines",
+          "tableTo": "crowd_reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crowd_report_lines_line_id_lines_id_fk": {
+          "name": "crowd_report_lines_line_id_lines_id_fk",
+          "tableFrom": "crowd_report_lines",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "crowd_report_lines_report_id_line_id_pk": {
+          "name": "crowd_report_lines_report_id_line_id_pk",
+          "columns": [
+            "report_id",
+            "line_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crowd_report_moderation_events": {
+      "name": "crowd_report_moderation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crowd_report_moderation_events_report_id_idx": {
+          "name": "crowd_report_moderation_events_report_id_idx",
+          "columns": [
+            {
+              "expression": "report_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crowd_report_moderation_events_created_at_idx": {
+          "name": "crowd_report_moderation_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crowd_report_moderation_events_report_id_crowd_reports_id_fk": {
+          "name": "crowd_report_moderation_events_report_id_crowd_reports_id_fk",
+          "tableFrom": "crowd_report_moderation_events",
+          "tableTo": "crowd_reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crowd_report_rate_limits": {
+      "name": "crowd_report_rate_limits",
+      "schema": "",
+      "columns": {
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_start_at": {
+          "name": "bucket_start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submission_count": {
+          "name": "submission_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "client_fingerprint_hash": {
+          "name": "client_fingerprint_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crowd_report_rate_limits_bucket_start_at_idx": {
+          "name": "crowd_report_rate_limits_bucket_start_at_idx",
+          "columns": [
+            {
+              "expression": "bucket_start_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "crowd_report_rate_limits_ip_hash_bucket_start_at_pk": {
+          "name": "crowd_report_rate_limits_ip_hash_bucket_start_at_pk",
+          "columns": [
+            "ip_hash",
+            "bucket_start_at"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crowd_report_stations": {
+      "name": "crowd_report_stations",
+      "schema": "",
+      "columns": {
+        "report_id": {
+          "name": "report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "crowd_report_stations_station_id_idx": {
+          "name": "crowd_report_stations_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crowd_report_stations_report_id_crowd_reports_id_fk": {
+          "name": "crowd_report_stations_report_id_crowd_reports_id_fk",
+          "tableFrom": "crowd_report_stations",
+          "tableTo": "crowd_reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crowd_report_stations_station_id_stations_id_fk": {
+          "name": "crowd_report_stations_station_id_stations_id_fk",
+          "tableFrom": "crowd_report_stations",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "crowd_report_stations_report_id_station_id_pk": {
+          "name": "crowd_report_stations_report_id_station_id_pk",
+          "columns": [
+            "report_id",
+            "station_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crowd_reports": {
+      "name": "crowd_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction_text": {
+          "name": "direction_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effect": {
+          "name": "effect",
+          "type": "crowd_report_effect",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delay_minutes": {
+          "name": "delay_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "still_happening": {
+          "name": "still_happening",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "crowd_report_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duplicate_of_id": {
+          "name": "duplicate_of_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_payload": {
+          "name": "dispatch_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_error": {
+          "name": "dispatch_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crowd_reports_observed_at_idx": {
+          "name": "crowd_reports_observed_at_idx",
+          "columns": [
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crowd_reports_status_idx": {
+          "name": "crowd_reports_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crowd_reports_cluster_id_idx": {
+          "name": "crowd_reports_cluster_id_idx",
+          "columns": [
+            {
+              "expression": "cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crowd_reports_duplicate_of_id_idx": {
+          "name": "crowd_reports_duplicate_of_id_idx",
+          "columns": [
+            {
+              "expression": "duplicate_of_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crowd_reports_cluster_id_crowd_report_clusters_id_fk": {
+          "name": "crowd_reports_cluster_id_crowd_report_clusters_id_fk",
+          "tableFrom": "crowd_reports",
+          "tableTo": "crowd_report_clusters",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "crowd_reports_duplicate_of_id_crowd_reports_id_fk": {
+          "name": "crowd_reports_duplicate_of_id_crowd_reports_id_fk",
+          "tableFrom": "crowd_reports",
+          "tableTo": "crowd_reports",
+          "columnsFrom": [
+            "duplicate_of_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "crowd_reports_delay_minutes_check": {
+          "name": "crowd_reports_delay_minutes_check",
+          "value": "\"crowd_reports\".\"delay_minutes\" is null or (\"crowd_reports\".\"delay_minutes\" >= 0 and \"crowd_reports\".\"delay_minutes\" <= 180)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.evidences": {
+      "name": "evidences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "evidence_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "render": {
+          "name": "render",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "evidences_issue_id_idx": {
+          "name": "evidences_issue_id_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "evidences_ts_idx": {
+          "name": "evidences_ts_idx",
+          "columns": [
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evidences_issue_id_issues_id_fk": {
+          "name": "evidences_issue_id_issues_id_fk",
+          "tableFrom": "evidences",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_basis_evidences": {
+      "name": "impact_event_basis_evidences",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_id": {
+          "name": "evidence_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_basis_evidences_impact_event_id_idx": {
+          "name": "impact_event_basis_evidences_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_basis_evidences_evidence_id_idx": {
+          "name": "impact_event_basis_evidences_evidence_id_idx",
+          "columns": [
+            {
+              "expression": "evidence_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_event_basis_evidences_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_basis_evidences_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_basis_evidences",
+          "tableTo": "impact_events",
+          "columnsFrom": [
+            "impact_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "impact_event_basis_evidences_evidence_id_evidences_id_fk": {
+          "name": "impact_event_basis_evidences_evidence_id_evidences_id_fk",
+          "tableFrom": "impact_event_basis_evidences",
+          "tableTo": "evidences",
+          "columnsFrom": [
+            "evidence_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_basis_evidences_impact_event_id_evidence_id_pk": {
+          "name": "impact_event_basis_evidences_impact_event_id_evidence_id_pk",
+          "columns": [
+            "impact_event_id",
+            "evidence_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_causes": {
+      "name": "impact_event_causes",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "impact_event_cause_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_causes_impact_event_id_idx": {
+          "name": "impact_event_causes_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_event_causes_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_causes_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_causes",
+          "tableTo": "impact_events",
+          "columnsFrom": [
+            "impact_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_causes_impact_event_id_type_pk": {
+          "name": "impact_event_causes_impact_event_id_type_pk",
+          "columns": [
+            "impact_event_id",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_entity_facilities": {
+      "name": "impact_event_entity_facilities",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "affected_entity_facility_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_entity_facilities_impact_event_id_idx": {
+          "name": "impact_event_entity_facilities_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_entity_facilities_station_id_idx": {
+          "name": "impact_event_entity_facilities_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_entity_facilities_line_id_idx": {
+          "name": "impact_event_entity_facilities_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_event_entity_facilities_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_entity_facilities_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_entity_facilities",
+          "tableTo": "impact_events",
+          "columnsFrom": [
+            "impact_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "impact_event_entity_facilities_station_id_stations_id_fk": {
+          "name": "impact_event_entity_facilities_station_id_stations_id_fk",
+          "tableFrom": "impact_event_entity_facilities",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "impact_event_entity_facilities_line_id_lines_id_fk": {
+          "name": "impact_event_entity_facilities_line_id_lines_id_fk",
+          "tableFrom": "impact_event_entity_facilities",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_entity_facilities_impact_event_id_station_id_kind_pk": {
+          "name": "impact_event_entity_facilities_impact_event_id_station_id_kind_pk",
+          "columns": [
+            "impact_event_id",
+            "station_id",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_entity_services": {
+      "name": "impact_event_entity_services",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_entity_services_impact_event_id_idx": {
+          "name": "impact_event_entity_services_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_entity_services_service_id_idx": {
+          "name": "impact_event_entity_services_service_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_event_entity_services_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_entity_services_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_entity_services",
+          "tableTo": "impact_events",
+          "columnsFrom": [
+            "impact_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "impact_event_entity_services_service_id_services_id_fk": {
+          "name": "impact_event_entity_services_service_id_services_id_fk",
+          "tableFrom": "impact_event_entity_services",
+          "tableTo": "services",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_entity_services_impact_event_id_service_id_pk": {
+          "name": "impact_event_entity_services_impact_event_id_service_id_pk",
+          "columns": [
+            "impact_event_id",
+            "service_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_facility_effects": {
+      "name": "impact_event_facility_effects",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "facility_effect_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_facility_effects_impact_event_id_idx": {
+          "name": "impact_event_facility_effects_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_facility_effects_kind_idx": {
+          "name": "impact_event_facility_effects_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_event_facility_effects_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_facility_effects_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_facility_effects",
+          "tableTo": "impact_events",
+          "columnsFrom": [
+            "impact_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_facility_effects_impact_event_id_kind_pk": {
+          "name": "impact_event_facility_effects_impact_event_id_kind_pk",
+          "columns": [
+            "impact_event_id",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_periods": {
+      "name": "impact_event_periods",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_ts": {
+          "name": "start_ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_ts": {
+          "name": "end_ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_periods_start_at_idx": {
+          "name": "impact_event_periods_start_at_idx",
+          "columns": [
+            {
+              "expression": "start_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_periods_end_at_idx": {
+          "name": "impact_event_periods_end_at_idx",
+          "columns": [
+            {
+              "expression": "end_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_event_periods_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_periods_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_periods",
+          "tableTo": "impact_events",
+          "columnsFrom": [
+            "impact_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_periods_impact_event_id_index_pk": {
+          "name": "impact_event_periods_impact_event_id_index_pk",
+          "columns": [
+            "impact_event_id",
+            "index"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_service_effects": {
+      "name": "impact_event_service_effects",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "service_effect_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "interval",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_service_effects_impact_event_id_idx": {
+          "name": "impact_event_service_effects_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_service_effects_kind_idx": {
+          "name": "impact_event_service_effects_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_event_service_effects_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_service_effects_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_service_effects",
+          "tableTo": "impact_events",
+          "columnsFrom": [
+            "impact_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_service_effects_impact_event_id_kind_pk": {
+          "name": "impact_event_service_effects_impact_event_id_kind_pk",
+          "columns": [
+            "impact_event_id",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.impact_event_service_scopes": {
+      "name": "impact_event_service_scopes",
+      "schema": "",
+      "columns": {
+        "impact_event_id": {
+          "name": "impact_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "impact_event_service_scope_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_station_id": {
+          "name": "from_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_station_id": {
+          "name": "to_station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_event_service_scopes_impact_event_id_idx": {
+          "name": "impact_event_service_scopes_impact_event_id_idx",
+          "columns": [
+            {
+              "expression": "impact_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_service_scopes_type_idx": {
+          "name": "impact_event_service_scopes_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_service_scopes_station_id_idx": {
+          "name": "impact_event_service_scopes_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_service_scopes_from_station_id_idx": {
+          "name": "impact_event_service_scopes_from_station_id_idx",
+          "columns": [
+            {
+              "expression": "from_station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "impact_event_service_scopes_to_station_id_idx": {
+          "name": "impact_event_service_scopes_to_station_id_idx",
+          "columns": [
+            {
+              "expression": "to_station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_event_service_scopes_impact_event_id_impact_events_id_fk": {
+          "name": "impact_event_service_scopes_impact_event_id_impact_events_id_fk",
+          "tableFrom": "impact_event_service_scopes",
+          "tableTo": "impact_events",
+          "columnsFrom": [
+            "impact_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "impact_event_service_scopes_station_id_stations_id_fk": {
+          "name": "impact_event_service_scopes_station_id_stations_id_fk",
+          "tableFrom": "impact_event_service_scopes",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "impact_event_service_scopes_from_station_id_stations_id_fk": {
+          "name": "impact_event_service_scopes_from_station_id_stations_id_fk",
+          "tableFrom": "impact_event_service_scopes",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "from_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "impact_event_service_scopes_to_station_id_stations_id_fk": {
+          "name": "impact_event_service_scopes_to_station_id_stations_id_fk",
+          "tableFrom": "impact_event_service_scopes",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "to_station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "impact_event_service_scopes_impact_event_id_index_pk": {
+          "name": "impact_event_service_scopes_impact_event_id_index_pk",
+          "columns": [
+            "impact_event_id",
+            "index"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "impact_event_service_scopes_type_station_shape_check": {
+          "name": "impact_event_service_scopes_type_station_shape_check",
+          "value": "\n          (\n            \"impact_event_service_scopes\".\"type\" = 'service.whole'\n            and \"impact_event_service_scopes\".\"station_id\" is null\n            and \"impact_event_service_scopes\".\"from_station_id\" is null\n            and \"impact_event_service_scopes\".\"to_station_id\" is null\n          )\n          or (\n            \"impact_event_service_scopes\".\"type\" = 'service.point'\n            and \"impact_event_service_scopes\".\"station_id\" is not null\n            and \"impact_event_service_scopes\".\"from_station_id\" is null\n            and \"impact_event_service_scopes\".\"to_station_id\" is null\n          )\n          or (\n            \"impact_event_service_scopes\".\"type\" = 'service.segment'\n            and \"impact_event_service_scopes\".\"station_id\" is null\n            and \"impact_event_service_scopes\".\"from_station_id\" is not null\n            and \"impact_event_service_scopes\".\"to_station_id\" is not null\n          )\n        "
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.impact_events": {
+      "name": "impact_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "impact_events_issue_id_idx": {
+          "name": "impact_events_issue_id_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "impact_events_issue_id_issues_id_fk": {
+          "name": "impact_events_issue_id_issues_id_fk",
+          "tableFrom": "impact_events",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issue_day_facts": {
+      "name": "issue_day_facts",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_type": {
+          "name": "issue_type",
+          "type": "issue_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_anytime": {
+          "name": "active_anytime",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_end_of_day": {
+          "name": "active_end_of_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inferred_interval_count": {
+          "name": "inferred_interval_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_day_facts_issue_id_idx": {
+          "name": "issue_day_facts_issue_id_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_day_facts_date_issue_type_idx": {
+          "name": "issue_day_facts_date_issue_type_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_day_facts_as_of_idx": {
+          "name": "issue_day_facts_as_of_idx",
+          "columns": [
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_day_facts_issue_id_issues_id_fk": {
+          "name": "issue_day_facts_issue_id_issues_id_fk",
+          "tableFrom": "issue_day_facts",
+          "tableTo": "issues",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "issue_day_facts_date_issue_id_pk": {
+          "name": "issue_day_facts_date_issue_id_pk",
+          "columns": [
+            "date",
+            "issue_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues_next": {
+      "name": "issues_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "issue_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_meta": {
+          "name": "title_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidences": {
+          "name": "evidences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impact_events": {
+          "name": "impact_events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.issues": {
+      "name": "issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "issue_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_meta": {
+          "name": "title_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.landmarks_next": {
+      "name": "landmarks_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.landmarks": {
+      "name": "landmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.line_day_facts": {
+      "name": "line_day_facts",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_seconds": {
+          "name": "service_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downtime_disruption_seconds": {
+          "name": "downtime_disruption_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downtime_maintenance_seconds": {
+          "name": "downtime_maintenance_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downtime_infra_seconds": {
+          "name": "downtime_infra_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_count_disruption": {
+          "name": "issue_count_disruption",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_count_maintenance": {
+          "name": "issue_count_maintenance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_count_infra": {
+          "name": "issue_count_infra",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "line_day_facts_line_id_idx": {
+          "name": "line_day_facts_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "line_day_facts_date_idx": {
+          "name": "line_day_facts_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "line_day_facts_as_of_idx": {
+          "name": "line_day_facts_as_of_idx",
+          "columns": [
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "line_day_facts_line_id_lines_id_fk": {
+          "name": "line_day_facts_line_id_lines_id_fk",
+          "tableFrom": "line_day_facts",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "line_day_facts_date_line_id_pk": {
+          "name": "line_day_facts_date_line_id_pk",
+          "columns": [
+            "date",
+            "line_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.line_operators": {
+      "name": "line_operators",
+      "schema": "",
+      "columns": {
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator_id": {
+          "name": "operator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "line_operators_line_id_idx": {
+          "name": "line_operators_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "line_operators_operator_id_idx": {
+          "name": "line_operators_operator_id_idx",
+          "columns": [
+            {
+              "expression": "operator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "line_operators_line_id_lines_id_fk": {
+          "name": "line_operators_line_id_lines_id_fk",
+          "tableFrom": "line_operators",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "line_operators_operator_id_operators_id_fk": {
+          "name": "line_operators_operator_id_operators_id_fk",
+          "tableFrom": "line_operators",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "line_operators_line_id_operator_id_pk": {
+          "name": "line_operators_line_id_operator_id_pk",
+          "columns": [
+            "line_id",
+            "operator_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.line_services": {
+      "name": "line_services",
+      "schema": "",
+      "columns": {
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "line_services_line_id_idx": {
+          "name": "line_services_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "line_services_service_id_idx": {
+          "name": "line_services_service_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "line_services_line_id_lines_id_fk": {
+          "name": "line_services_line_id_lines_id_fk",
+          "tableFrom": "line_services",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "line_services_service_id_services_id_fk": {
+          "name": "line_services_service_id_services_id_fk",
+          "tableFrom": "line_services",
+          "tableTo": "services",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "line_services_line_id_service_id_pk": {
+          "name": "line_services_line_id_service_id_pk",
+          "columns": [
+            "line_id",
+            "service_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lines_next": {
+      "name": "lines_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "line_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operating_hours": {
+          "name": "operating_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operators": {
+          "name": "operators",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lines": {
+      "name": "lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "line_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operating_hours": {
+          "name": "operating_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metadata": {
+      "name": "metadata",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operators_next": {
+      "name": "operators_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "founded_at": {
+          "name": "founded_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operators": {
+      "name": "operators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "founded_at": {
+          "name": "founded_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.public_holidays": {
+      "name": "public_holidays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "holiday_name": {
+          "name": "holiday_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_revision_path_station_entries": {
+      "name": "service_revision_path_station_entries",
+      "schema": "",
+      "columns": {
+        "service_revision_id": {
+          "name": "service_revision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_code": {
+          "name": "display_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_index": {
+          "name": "path_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "service_revision_path_entries_service_revision_id_idx": {
+          "name": "service_revision_path_entries_service_revision_id_idx",
+          "columns": [
+            {
+              "expression": "service_revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_revision_path_entries_service_id_idx": {
+          "name": "service_revision_path_entries_service_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_revision_path_entries_station_id_idx": {
+          "name": "service_revision_path_entries_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_revision_path_entries_path_index_idx": {
+          "name": "service_revision_path_entries_path_index_idx",
+          "columns": [
+            {
+              "expression": "path_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sr_path_entries_revision_fk": {
+          "name": "sr_path_entries_revision_fk",
+          "tableFrom": "service_revision_path_station_entries",
+          "tableTo": "service_revisions",
+          "columnsFrom": [
+            "service_revision_id",
+            "service_id"
+          ],
+          "columnsTo": [
+            "id",
+            "service_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sr_path_entries_station_fk": {
+          "name": "sr_path_entries_station_fk",
+          "tableFrom": "service_revision_path_station_entries",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "sr_path_entries_pk": {
+          "name": "sr_path_entries_pk",
+          "columns": [
+            "service_revision_id",
+            "service_id",
+            "station_id",
+            "path_index"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_revisions": {
+      "name": "service_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operating_hours": {
+          "name": "operating_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "service_revisions_service_id_idx": {
+          "name": "service_revisions_service_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_revisions_service_id_services_id_fk": {
+          "name": "service_revisions_service_id_services_id_fk",
+          "tableFrom": "service_revisions",
+          "tableTo": "services",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "service_revisions_id_service_id_pk": {
+          "name": "service_revisions_id_service_id_pk",
+          "columns": [
+            "id",
+            "service_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services_next": {
+      "name": "services_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revisions": {
+          "name": "revisions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "services_line_id_idx": {
+          "name": "services_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "services_line_id_lines_id_fk": {
+          "name": "services_line_id_lines_id_fk",
+          "tableFrom": "services",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_codes": {
+      "name": "station_codes",
+      "schema": "",
+      "columns": {
+        "line_id": {
+          "name": "line_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structure_type": {
+          "name": "structure_type",
+          "type": "station_structure_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_codes_line_id_idx": {
+          "name": "station_codes_line_id_idx",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_codes_station_id_idx": {
+          "name": "station_codes_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "station_codes_line_id_lines_id_fk": {
+          "name": "station_codes_line_id_lines_id_fk",
+          "tableFrom": "station_codes",
+          "tableTo": "lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "station_codes_station_id_stations_id_fk": {
+          "name": "station_codes_station_id_stations_id_fk",
+          "tableFrom": "station_codes",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "station_codes_line_id_station_id_code_pk": {
+          "name": "station_codes_line_id_station_id_code_pk",
+          "columns": [
+            "line_id",
+            "station_id",
+            "code"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.station_landmarks": {
+      "name": "station_landmarks",
+      "schema": "",
+      "columns": {
+        "station_id": {
+          "name": "station_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "landmark_id": {
+          "name": "landmark_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "station_landmarks_station_id_idx": {
+          "name": "station_landmarks_station_id_idx",
+          "columns": [
+            {
+              "expression": "station_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "station_landmarks_landmark_id_idx": {
+          "name": "station_landmarks_landmark_id_idx",
+          "columns": [
+            {
+              "expression": "landmark_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "station_landmarks_station_id_stations_id_fk": {
+          "name": "station_landmarks_station_id_stations_id_fk",
+          "tableFrom": "station_landmarks",
+          "tableTo": "stations",
+          "columnsFrom": [
+            "station_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "station_landmarks_landmark_id_landmarks_id_fk": {
+          "name": "station_landmarks_landmark_id_landmarks_id_fk",
+          "tableFrom": "station_landmarks",
+          "tableTo": "landmarks",
+          "columnsFrom": [
+            "landmark_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "station_landmarks_station_id_landmark_id_pk": {
+          "name": "station_landmarks_station_id_landmark_id_pk",
+          "columns": [
+            "station_id",
+            "landmark_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations_next": {
+      "name": "stations_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geo": {
+          "name": "geo",
+          "type": "geometry(point)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "town_id": {
+          "name": "town_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "station_codes": {
+          "name": "station_codes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "landmark_ids": {
+          "name": "landmark_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "stations_next_geo_idx": {
+          "name": "stations_next_geo_idx",
+          "columns": [
+            {
+              "expression": "geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stations": {
+      "name": "stations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geo": {
+          "name": "geo",
+          "type": "geometry(point)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "town_id": {
+          "name": "town_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stations_geo_idx": {
+          "name": "stations_geo_idx",
+          "columns": [
+            {
+              "expression": "geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stations_town_id_towns_id_fk": {
+          "name": "stations_town_id_towns_id_fk",
+          "tableFrom": "stations",
+          "tableTo": "towns",
+          "columnsFrom": [
+            "town_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.statistics_snapshots": {
+      "name": "statistics_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "as_of": {
+          "name": "as_of",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "statistics_snapshots_as_of_idx": {
+          "name": "statistics_snapshots_as_of_idx",
+          "columns": [
+            {
+              "expression": "as_of",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towns_next": {
+      "name": "towns_next",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.towns": {
+      "name": "towns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.affected_entity_facility_kind": {
+      "name": "affected_entity_facility_kind",
+      "schema": "public",
+      "values": [
+        "lift",
+        "escalator",
+        "screen-door"
+      ]
+    },
+    "public.crowd_report_cluster_status": {
+      "name": "crowd_report_cluster_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected",
+        "dispatched"
+      ]
+    },
+    "public.crowd_report_effect": {
+      "name": "crowd_report_effect",
+      "schema": "public",
+      "values": [
+        "delay",
+        "no-service",
+        "crowding",
+        "skipped-stop",
+        "unknown"
+      ]
+    },
+    "public.crowd_report_status": {
+      "name": "crowd_report_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "rejected",
+        "duplicate",
+        "dispatched"
+      ]
+    },
+    "public.evidence_type": {
+      "name": "evidence_type",
+      "schema": "public",
+      "values": [
+        "statement.official",
+        "report.public",
+        "report.media"
+      ]
+    },
+    "public.facility_effect_kind": {
+      "name": "facility_effect_kind",
+      "schema": "public",
+      "values": [
+        "out-of-service",
+        "degraded"
+      ]
+    },
+    "public.impact_event_cause_type": {
+      "name": "impact_event_cause_type",
+      "schema": "public",
+      "values": [
+        "signal.fault",
+        "track.fault",
+        "train.fault",
+        "power.fault",
+        "station.fault",
+        "security",
+        "weather",
+        "passenger.incident",
+        "platform_door.fault",
+        "delay",
+        "track.work",
+        "system.upgrade",
+        "elevator.outage",
+        "escalator.outage",
+        "air_conditioning.issue",
+        "station.renovation"
+      ]
+    },
+    "public.impact_event_service_scope_type": {
+      "name": "impact_event_service_scope_type",
+      "schema": "public",
+      "values": [
+        "service.whole",
+        "service.segment",
+        "service.point"
+      ]
+    },
+    "public.issue_type": {
+      "name": "issue_type",
+      "schema": "public",
+      "values": [
+        "disruption",
+        "maintenance",
+        "infra"
+      ]
+    },
+    "public.line_type": {
+      "name": "line_type",
+      "schema": "public",
+      "values": [
+        "mrt.high",
+        "mrt.medium",
+        "lrt"
+      ]
+    },
+    "public.service_effect_kind": {
+      "name": "service_effect_kind",
+      "schema": "public",
+      "values": [
+        "delay",
+        "no-service",
+        "reduced-service",
+        "service-hours-adjustment"
+      ]
+    },
+    "public.station_structure_type": {
+      "name": "station_structure_type",
+      "schema": "public",
+      "values": [
+        "elevated",
+        "underground",
+        "at_grade",
+        "in_building"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1779600563329,
       "tag": "0010_nebulous_skaar",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1779896170223,
+      "tag": "0011_serious_kid_colt",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- add a rebuildable `statistics_snapshots` read model for assembled public statistics payloads
- refresh the snapshot after pull workflow operational facts and manual facts rebuilds
- make the statistics route read the precomputed snapshot when available, while retaining the request-time builder as a fallback
- update the production performance plan with the Phase 4 progress note

## Validation

- `npm run verify`