### PR TITLE
fix: stabilize anonymous Sentry users

### DIFF
--- a/app/server.ts
+++ b/app/server.ts
@@ -12,12 +12,22 @@ import {
   type CrowdReportFeatureEnv,
   isCrowdReportsFeatureEnabled,
 } from './util/crowdReportFeatureFlag';
+import {
+  createSentryAnonymousUserCookie,
+  getSentryAnonymousUser,
+  type SentryAnonymousUser,
+} from './util/sentryAnonymousUser';
 import { handleScheduledWorkflows } from './workflows/scheduled';
 
 const PUBLIC_HTML_CACHE_NAME = 'mrtdown-public-html';
 
 async function appFetch(request: Request, _env: Env, ctx: ExecutionContext) {
   const startedAt = performance.now();
+  const sentryAnonymousUser = getSentryAnonymousUser(request);
+  Sentry.setUser({
+    id: sentryAnonymousUser.sentryUserId,
+    ip_address: null,
+  });
   const shouldUsePublicHtmlCache = !shouldBypassPublicHtmlCacheForCrowdReports(
     request,
     _env,
@@ -27,10 +37,13 @@ async function appFetch(request: Request, _env: Env, ctx: ExecutionContext) {
     : null;
   if (cachedResponse != null) {
     const elapsedMs = performance.now() - startedAt;
-    return addResponseInstrumentationHeaders(
-      cachedResponse,
-      elapsedMs,
-      'public-html-cache',
+    return addSentryAnonymousUserCookie(
+      addResponseInstrumentationHeaders(
+        cachedResponse,
+        elapsedMs,
+        'public-html-cache',
+      ),
+      sentryAnonymousUser,
     );
   }
 
@@ -58,7 +71,7 @@ async function appFetch(request: Request, _env: Env, ctx: ExecutionContext) {
     logResponseByteEstimate(request, responseWithHeaders.clone(), elapsedMs);
   }
 
-  return responseWithHeaders;
+  return addSentryAnonymousUserCookie(responseWithHeaders, sentryAnonymousUser);
 }
 
 function shouldBypassPublicHtmlCacheForCrowdReports(
@@ -108,6 +121,44 @@ function appendInstrumentationHeaders(
       : workerTiming,
   );
   headers.set('X-MRTDown-Render', render);
+}
+
+function addSentryAnonymousUserCookie(
+  response: Response,
+  sentryAnonymousUser: SentryAnonymousUser,
+) {
+  if (!sentryAnonymousUser.shouldSetCookie || response.status === 101) {
+    return response;
+  }
+
+  const cookie = createSentryAnonymousUserCookie(
+    sentryAnonymousUser.cookieValue,
+  );
+
+  try {
+    response.headers.append('Set-Cookie', cookie);
+    preventSharedCachingOfCookieResponse(response.headers);
+    return response;
+  } catch {
+    const headers = new Headers(response.headers);
+    headers.append('Set-Cookie', cookie);
+    preventSharedCachingOfCookieResponse(headers);
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
+}
+
+function preventSharedCachingOfCookieResponse(headers: Headers) {
+  const cacheControl = headers.get('Cache-Control')?.toLowerCase();
+  if (
+    cacheControl == null ||
+    (!cacheControl.includes('private') && !cacheControl.includes('no-store'))
+  ) {
+    headers.set('Cache-Control', 'private, max-age=0');
+  }
 }
 
 async function getCachedPublicHtmlResponse(request: Request) {
@@ -182,6 +233,15 @@ export default Sentry.withSentry(
     return {
       dsn: env.SENTRY_DSN ?? '',
       environment: env.TIER ?? 'development',
+      beforeSend(event) {
+        if (event.user != null) {
+          const user = { ...event.user };
+          delete user.ip_address;
+          event.user = Object.keys(user).length > 0 ? user : undefined;
+        }
+
+        return event;
+      },
     };
   },
   {

--- a/app/util/sentryAnonymousUser.test.ts
+++ b/app/util/sentryAnonymousUser.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createSentryAnonymousUserCookie,
+  getSentryAnonymousUser,
+} from './sentryAnonymousUser';
+
+const EXISTING_ID = 'c4bc6391-2d15-40e8-a01f-8a1e44928abc';
+const NEW_ID = '4b03ee27-a155-4a50-9462-8f035f70bf08';
+
+function request(cookie?: string) {
+  return new Request('https://www.mrtdown.org/history', {
+    headers: cookie != null ? { cookie } : undefined,
+  });
+}
+
+describe('Sentry anonymous user IDs', () => {
+  it('reuses an existing valid anonymous user cookie', () => {
+    const user = getSentryAnonymousUser(
+      request(`theme=dark; mrtdown_anon_id=${EXISTING_ID}; other=1`),
+      () => NEW_ID,
+    );
+
+    expect(user).toEqual({
+      cookieValue: EXISTING_ID,
+      sentryUserId: `anon:${EXISTING_ID}`,
+      shouldSetCookie: false,
+    });
+  });
+
+  it('creates a new anonymous user ID when the cookie is absent', () => {
+    const user = getSentryAnonymousUser(request(), () => NEW_ID);
+
+    expect(user).toEqual({
+      cookieValue: NEW_ID,
+      sentryUserId: `anon:${NEW_ID}`,
+      shouldSetCookie: true,
+    });
+  });
+
+  it('replaces invalid anonymous user cookie values', () => {
+    const user = getSentryAnonymousUser(
+      request('mrtdown_anon_id=not-a-valid-id'),
+      () => NEW_ID,
+    );
+
+    expect(user).toEqual({
+      cookieValue: NEW_ID,
+      sentryUserId: `anon:${NEW_ID}`,
+      shouldSetCookie: true,
+    });
+  });
+
+  it('creates an HttpOnly first-party cookie for the anonymous user ID', () => {
+    expect(createSentryAnonymousUserCookie(NEW_ID)).toBe(
+      [
+        `mrtdown_anon_id=${NEW_ID}`,
+        'Path=/',
+        'Max-Age=31536000',
+        'SameSite=Lax',
+        'Secure',
+        'HttpOnly',
+      ].join('; '),
+    );
+  });
+});

--- a/app/util/sentryAnonymousUser.ts
+++ b/app/util/sentryAnonymousUser.ts
@@ -1,0 +1,81 @@
+const SENTRY_ANONYMOUS_USER_COOKIE_NAME = 'mrtdown_anon_id';
+const SENTRY_ANONYMOUS_USER_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export type SentryAnonymousUser = {
+  cookieValue: string;
+  sentryUserId: string;
+  shouldSetCookie: boolean;
+};
+
+export function getSentryAnonymousUser(
+  request: Request,
+  createId = () => crypto.randomUUID(),
+): SentryAnonymousUser {
+  const existingCookieValue = getCookieValue(
+    request.headers.get('cookie'),
+    SENTRY_ANONYMOUS_USER_COOKIE_NAME,
+  );
+
+  if (
+    existingCookieValue != null &&
+    isValidSentryAnonymousUserCookieValue(existingCookieValue)
+  ) {
+    return {
+      cookieValue: existingCookieValue,
+      sentryUserId: toSentryUserId(existingCookieValue),
+      shouldSetCookie: false,
+    };
+  }
+
+  const cookieValue = createId();
+  if (!isValidSentryAnonymousUserCookieValue(cookieValue)) {
+    throw new Error('Generated invalid Sentry anonymous user ID');
+  }
+
+  return {
+    cookieValue,
+    sentryUserId: toSentryUserId(cookieValue),
+    shouldSetCookie: true,
+  };
+}
+
+export function createSentryAnonymousUserCookie(cookieValue: string) {
+  if (!isValidSentryAnonymousUserCookieValue(cookieValue)) {
+    throw new Error('Invalid Sentry anonymous user cookie value');
+  }
+
+  return [
+    `${SENTRY_ANONYMOUS_USER_COOKIE_NAME}=${cookieValue}`,
+    'Path=/',
+    `Max-Age=${SENTRY_ANONYMOUS_USER_COOKIE_MAX_AGE_SECONDS}`,
+    'SameSite=Lax',
+    'Secure',
+    'HttpOnly',
+  ].join('; ');
+}
+
+function getCookieValue(cookieHeader: string | null, cookieName: string) {
+  if (cookieHeader == null || cookieHeader === '') {
+    return null;
+  }
+
+  for (const cookiePart of cookieHeader.split(';')) {
+    const [name, ...valueParts] = cookiePart.split('=');
+    if (name?.trim() === cookieName) {
+      return valueParts.join('=').trim();
+    }
+  }
+
+  return null;
+}
+
+function isValidSentryAnonymousUserCookieValue(value: string) {
+  return UUID_PATTERN.test(value);
+}
+
+function toSentryUserId(cookieValue: string) {
+  return `anon:${cookieValue}`;
+}

--- a/app/util/sentryAnonymousUser.ts
+++ b/app/util/sentryAnonymousUser.ts
@@ -1,8 +1,9 @@
+import z from 'zod';
+
 const SENTRY_ANONYMOUS_USER_COOKIE_NAME = 'mrtdown_anon_id';
 const SENTRY_ANONYMOUS_USER_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
 
-const UUID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SentryAnonymousUserCookieSchema = z.uuid();
 
 export type SentryAnonymousUser = {
   cookieValue: string;
@@ -73,7 +74,7 @@ function getCookieValue(cookieHeader: string | null, cookieName: string) {
 }
 
 function isValidSentryAnonymousUserCookieValue(value: string) {
-  return UUID_PATTERN.test(value);
+  return SentryAnonymousUserCookieSchema.safeParse(value).success;
 }
 
 function toSentryUserId(cookieValue: string) {


### PR DESCRIPTION
## Summary

- Add a first-party anonymous Sentry user cookie for stable affected-user attribution without retaining IP addresses.
- Set server-side Sentry user IDs as `anon:<uuid>` and strip `user.ip_address` in `beforeSend`.
- Mark first-time cookie responses as private so shared caches cannot replay a generated anonymous ID.

## Root Cause

Sentry's Cloudflare/JavaScript request IP extraction can attribute events to a Cloudflare edge IP when proxy headers are present, causing unrelated visitors or bots to appear as the same affected user.

## Validation

- `npm run verify`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented anonymous user identification system to enhance error monitoring, improve analytics accuracy, and enable better application instrumentation and tracking
  * Enhanced cookie-based session tracking with improved privacy controls, secure data validation, and optimized user data handling in monitoring systems

* **Tests**
  * Added comprehensive test suite for anonymous user identification behavior, cookie generation, and validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-site/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->