### PR TITLE
refactor: slim worker server entrypoint

### DIFF
--- a/app/server.ts
+++ b/app/server.ts
@@ -2,24 +2,22 @@ import * as Sentry from '@sentry/cloudflare';
 import handler from '@tanstack/react-start/server-entry';
 import {
   applyPublicHtmlCacheHeaders,
-  createPublicHtmlCacheResponse,
-  getPublicHtmlCacheKey,
+  getCachedPublicHtmlResponse,
   isCommunitySignalPublicPath,
   isPublicHtmlCacheLookupRequest,
   shouldCachePublicHtml,
+  storePublicHtmlResponse,
 } from './util/publicHtmlCache';
 import {
   type CrowdReportFeatureEnv,
   isCrowdReportsFeatureEnabled,
 } from './util/crowdReportFeatureFlag';
 import {
-  createSentryAnonymousUserCookie,
+  addSentryAnonymousUserCookie,
   getSentryAnonymousUser,
-  type SentryAnonymousUser,
+  stripSentryUserIpAddress,
 } from './util/sentryAnonymousUser';
 import { handleScheduledWorkflows } from './workflows/scheduled';
-
-const PUBLIC_HTML_CACHE_NAME = 'mrtdown-public-html';
 
 async function appFetch(request: Request, _env: Env, ctx: ExecutionContext) {
   const startedAt = performance.now();
@@ -123,81 +121,6 @@ function appendInstrumentationHeaders(
   headers.set('X-MRTDown-Render', render);
 }
 
-function addSentryAnonymousUserCookie(
-  response: Response,
-  sentryAnonymousUser: SentryAnonymousUser,
-) {
-  if (!sentryAnonymousUser.shouldSetCookie || response.status === 101) {
-    return response;
-  }
-
-  const cookie = createSentryAnonymousUserCookie(
-    sentryAnonymousUser.cookieValue,
-  );
-
-  try {
-    response.headers.append('Set-Cookie', cookie);
-    preventSharedCachingOfCookieResponse(response.headers);
-    return response;
-  } catch {
-    const headers = new Headers(response.headers);
-    headers.append('Set-Cookie', cookie);
-    preventSharedCachingOfCookieResponse(headers);
-    return new Response(response.body, {
-      status: response.status,
-      statusText: response.statusText,
-      headers,
-    });
-  }
-}
-
-function preventSharedCachingOfCookieResponse(headers: Headers) {
-  const cacheControl = headers.get('Cache-Control')?.toLowerCase();
-  if (
-    cacheControl == null ||
-    (!cacheControl.includes('private') && !cacheControl.includes('no-store'))
-  ) {
-    headers.set('Cache-Control', 'private, max-age=0');
-  }
-}
-
-async function getCachedPublicHtmlResponse(request: Request) {
-  if (!isPublicHtmlCacheLookupRequest(request)) {
-    return null;
-  }
-
-  try {
-    const cache = await caches.open(PUBLIC_HTML_CACHE_NAME);
-    const response = await cache.match(getPublicHtmlCacheKey(request));
-    if (response == null) {
-      return null;
-    }
-
-    const headers = new Headers(response.headers);
-    headers.set('X-MRTDown-Cache', 'hit');
-    return new Response(response.body, {
-      status: response.status,
-      statusText: response.statusText,
-      headers,
-    });
-  } catch (error) {
-    console.warn('Failed to read public HTML cache', error);
-    return null;
-  }
-}
-
-async function storePublicHtmlResponse(request: Request, response: Response) {
-  try {
-    const cache = await caches.open(PUBLIC_HTML_CACHE_NAME);
-    await cache.put(
-      getPublicHtmlCacheKey(request),
-      createPublicHtmlCacheResponse(response),
-    );
-  } catch (error) {
-    console.warn('Failed to store public HTML cache', error);
-  }
-}
-
 async function logResponseByteEstimate(
   request: Request,
   response: Response,
@@ -233,15 +156,7 @@ export default Sentry.withSentry(
     return {
       dsn: env.SENTRY_DSN ?? '',
       environment: env.TIER ?? 'development',
-      beforeSend(event) {
-        if (event.user != null) {
-          const user = { ...event.user };
-          delete user.ip_address;
-          event.user = Object.keys(user).length > 0 ? user : undefined;
-        }
-
-        return event;
-      },
+      beforeSend: stripSentryUserIpAddress,
     };
   },
   {

--- a/app/util/publicHtmlCache.ts
+++ b/app/util/publicHtmlCache.ts
@@ -1,5 +1,6 @@
 const PUBLIC_HTML_CACHE_CONTROL =
   'public, max-age=0, s-maxage=60, stale-while-revalidate=300';
+const PUBLIC_HTML_CACHE_NAME = 'mrtdown-public-html';
 
 const HTML_CONTENT_TYPES = ['text/html', 'application/xhtml+xml'];
 
@@ -143,4 +144,44 @@ export function createPublicHtmlCacheResponse(response: Response) {
     statusText: response.statusText,
     headers,
   });
+}
+
+export async function getCachedPublicHtmlResponse(request: Request) {
+  if (!isPublicHtmlCacheLookupRequest(request)) {
+    return null;
+  }
+
+  try {
+    const cache = await caches.open(PUBLIC_HTML_CACHE_NAME);
+    const response = await cache.match(getPublicHtmlCacheKey(request));
+    if (response == null) {
+      return null;
+    }
+
+    const headers = new Headers(response.headers);
+    headers.set('X-MRTDown-Cache', 'hit');
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  } catch (error) {
+    console.warn('Failed to read public HTML cache', error);
+    return null;
+  }
+}
+
+export async function storePublicHtmlResponse(
+  request: Request,
+  response: Response,
+) {
+  try {
+    const cache = await caches.open(PUBLIC_HTML_CACHE_NAME);
+    await cache.put(
+      getPublicHtmlCacheKey(request),
+      createPublicHtmlCacheResponse(response),
+    );
+  } catch (error) {
+    console.warn('Failed to store public HTML cache', error);
+  }
 }

--- a/app/util/sentryAnonymousUser.test.ts
+++ b/app/util/sentryAnonymousUser.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+  addSentryAnonymousUserCookie,
   createSentryAnonymousUserCookie,
   getSentryAnonymousUser,
+  stripSentryUserIpAddress,
 } from './sentryAnonymousUser';
 
 const EXISTING_ID = 'c4bc6391-2d15-40e8-a01f-8a1e44928abc';
@@ -61,5 +63,56 @@ describe('Sentry anonymous user IDs', () => {
         'HttpOnly',
       ].join('; '),
     );
+  });
+
+  it('adds the anonymous user cookie and prevents shared response caching', () => {
+    const response = addSentryAnonymousUserCookie(
+      new Response('ok', {
+        headers: {
+          'cache-control': 'public, s-maxage=60',
+        },
+      }),
+      {
+        cookieValue: NEW_ID,
+        sentryUserId: `anon:${NEW_ID}`,
+        shouldSetCookie: true,
+      },
+    );
+
+    expect(response.headers.get('set-cookie')).toBe(
+      createSentryAnonymousUserCookie(NEW_ID),
+    );
+    expect(response.headers.get('cache-control')).toBe('private, max-age=0');
+  });
+
+  it('does not add the anonymous user cookie when it is already present', () => {
+    const response = addSentryAnonymousUserCookie(new Response('ok'), {
+      cookieValue: EXISTING_ID,
+      sentryUserId: `anon:${EXISTING_ID}`,
+      shouldSetCookie: false,
+    });
+
+    expect(response.headers.get('set-cookie')).toBeNull();
+  });
+
+  it('strips Sentry user IP addresses without removing stable IDs', () => {
+    expect(
+      stripSentryUserIpAddress({
+        user: {
+          id: `anon:${EXISTING_ID}`,
+          ip_address: '172.70.42.77',
+        },
+      }),
+    ).toEqual({
+      user: {
+        id: `anon:${EXISTING_ID}`,
+      },
+    });
+
+    expect(
+      stripSentryUserIpAddress({ user: { ip_address: '172.70.42.77' } }),
+    ).toEqual({
+      user: undefined,
+    });
   });
 });

--- a/app/util/sentryAnonymousUser.ts
+++ b/app/util/sentryAnonymousUser.ts
@@ -58,6 +58,48 @@ export function createSentryAnonymousUserCookie(cookieValue: string) {
   ].join('; ');
 }
 
+export function addSentryAnonymousUserCookie(
+  response: Response,
+  sentryAnonymousUser: SentryAnonymousUser,
+) {
+  if (!sentryAnonymousUser.shouldSetCookie || response.status === 101) {
+    return response;
+  }
+
+  const cookie = createSentryAnonymousUserCookie(
+    sentryAnonymousUser.cookieValue,
+  );
+
+  try {
+    response.headers.append('Set-Cookie', cookie);
+    preventSharedCachingOfCookieResponse(response.headers);
+    return response;
+  } catch {
+    const headers = new Headers(response.headers);
+    headers.append('Set-Cookie', cookie);
+    preventSharedCachingOfCookieResponse(headers);
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
+}
+
+export function stripSentryUserIpAddress<
+  TEvent extends { user?: Record<string, unknown> | null },
+>(event: TEvent) {
+  if (event.user == null) {
+    return event;
+  }
+
+  const user = { ...event.user };
+  delete user.ip_address;
+  event.user = Object.keys(user).length > 0 ? user : undefined;
+
+  return event;
+}
+
 function getCookieValue(cookieHeader: string | null, cookieName: string) {
   if (cookieHeader == null || cookieHeader === '') {
     return null;
@@ -75,6 +117,16 @@ function getCookieValue(cookieHeader: string | null, cookieName: string) {
 
 function isValidSentryAnonymousUserCookieValue(value: string) {
   return SentryAnonymousUserCookieSchema.safeParse(value).success;
+}
+
+function preventSharedCachingOfCookieResponse(headers: Headers) {
+  const cacheControl = headers.get('Cache-Control')?.toLowerCase();
+  if (
+    cacheControl == null ||
+    (!cacheControl.includes('private') && !cacheControl.includes('no-store'))
+  ) {
+    headers.set('Cache-Control', 'private, max-age=0');
+  }
 }
 
 function toSentryUserId(cookieValue: string) {


### PR DESCRIPTION
## Summary

- Move public HTML cache read/write helpers out of `app/server.ts` and into `app/util/publicHtmlCache.ts`.
- Move Sentry anonymous user cookie response handling and user IP stripping into `app/util/sentryAnonymousUser.ts`.
- Add direct tests for the moved Sentry response/user helper behavior.

## Impact

This keeps the Worker entrypoint focused on request orchestration without changing runtime behavior.

## Validation

- `npm run verify`