### PR TITLE
fix: harden crowd report cluster confidence

### DIFF
--- a/app/util/crowdReportDispatch.ts
+++ b/app/util/crowdReportDispatch.ts
@@ -21,6 +21,7 @@ const DEFAULT_DISPATCH_REPO = 'mrtdown-data';
 const DEFAULT_DISPATCH_EVENT_TYPE = 'ingest';
 const DEFAULT_DISPATCH_LIMIT = 10;
 const DEFAULT_DISPATCH_TIMEOUT_MS = 15_000;
+const DEFAULT_DISPATCH_MIN_ONGOING_REPORTS = 3;
 const DEFAULT_DISPATCH_MIN_DISTINCT_IP_HASHES = 2;
 const MAX_DISPATCH_LIMIT = 50;
 
@@ -108,13 +109,21 @@ function hasCrowdReportClusterScope() {
   );
 }
 
-function hasCrowdReportClusterSourceDiversity() {
+function hasCrowdReportClusterCurrentConfidence() {
   return sql`(
+    select count(*)
+    from ${crowdReportsTable}
+    where ${crowdReportsTable.cluster_id} = ${crowdReportClustersTable.id}
+      and ${crowdReportsTable.status} in ('accepted', 'duplicate')
+      and ${crowdReportsTable.still_happening} is true
+  ) >= ${DEFAULT_DISPATCH_MIN_ONGOING_REPORTS} and (
     select count(distinct ${crowdReportAbuseEventsTable.ip_hash})
     from ${crowdReportAbuseEventsTable}
     inner join ${crowdReportsTable}
       on ${crowdReportsTable.id} = ${crowdReportAbuseEventsTable.report_id}
     where ${crowdReportsTable.cluster_id} = ${crowdReportClustersTable.id}
+      and ${crowdReportsTable.status} in ('accepted', 'duplicate')
+      and ${crowdReportsTable.still_happening} is true
   ) >= ${DEFAULT_DISPATCH_MIN_DISTINCT_IP_HASHES}`;
 }
 
@@ -250,7 +259,7 @@ async function getDispatchableCrowdReportClusterCandidates(
         eq(crowdReportClustersTable.status, 'accepted'),
         isNull(crowdReportClustersTable.dispatched_at),
         hasCrowdReportClusterScope(),
-        hasCrowdReportClusterSourceDiversity(),
+        hasCrowdReportClusterCurrentConfidence(),
       ),
     )
     .orderBy(desc(crowdReportClustersTable.window_end_at))
@@ -584,7 +593,7 @@ async function isCrowdReportDispatchCandidateEligible(
           eq(crowdReportClustersTable.status, 'accepted'),
           isNull(crowdReportClustersTable.dispatched_at),
           hasCrowdReportClusterScope(),
-          hasCrowdReportClusterSourceDiversity(),
+          hasCrowdReportClusterCurrentConfidence(),
         ),
       )
       .limit(1);

--- a/app/util/crowdReports.test.ts
+++ b/app/util/crowdReports.test.ts
@@ -954,6 +954,38 @@ describe('automoderateCrowdReport', () => {
     });
   });
 
+  it('keeps a non-ongoing first-report cluster private even when test thresholds are low', async () => {
+    const fake = makeFakeAutomoderationDb([[]], {
+      id: 'report-1',
+      status: 'accepted',
+      duplicateOfId: null,
+    });
+
+    await automoderateCrowdReport(
+      fake.db as never,
+      'report-1',
+      {
+        ...VALID_SUBMISSION,
+        isStillHappening: false,
+      },
+      {
+        idFactory: () => 'event-1',
+        now: NOW,
+        publicSignalMinReports: 1,
+        publicSignalMinDistinctIpHashes: 1,
+      },
+    );
+
+    expect(fake.inserts[1]).toMatchObject({
+      table: crowdReportClustersTable,
+      values: {
+        id: 'event-1',
+        report_count: 1,
+        status: 'pending',
+      },
+    });
+  });
+
   it('rejects low-quality reports before duplicate detection and clustering', async () => {
     const fake = makeFakeAutomoderationDb([], {
       id: 'report-1',

--- a/app/util/crowdReports.ts
+++ b/app/util/crowdReports.ts
@@ -205,7 +205,19 @@ function getCrowdReportClusterWindow(
   return { windowStartAt, windowEndAt };
 }
 
-function getCrowdReportClusterDistinctIpHashCountSql(
+function getCrowdReportClusterOngoingReportCountSql(
+  clusterId: string | typeof crowdReportClustersTable.id,
+) {
+  return sql<number>`(
+    select count(*)
+    from ${crowdReportsTable}
+    where ${crowdReportsTable.cluster_id} = ${clusterId}
+      and ${crowdReportsTable.status} in ('accepted', 'duplicate')
+      and ${crowdReportsTable.still_happening} is true
+  )`;
+}
+
+function getCrowdReportClusterOngoingDistinctIpHashCountSql(
   clusterId: string | typeof crowdReportClustersTable.id,
 ) {
   return sql<number>`(
@@ -214,11 +226,18 @@ function getCrowdReportClusterDistinctIpHashCountSql(
     inner join ${crowdReportsTable}
       on ${crowdReportsTable.id} = ${crowdReportAbuseEventsTable.report_id}
     where ${crowdReportsTable.cluster_id} = ${clusterId}
+      and ${crowdReportsTable.status} in ('accepted', 'duplicate')
+      and ${crowdReportsTable.still_happening} is true
   )`;
 }
 
-function hasCrowdReportClusterSourceDiversitySql(minDistinctIpHashes: number) {
-  return sql`${getCrowdReportClusterDistinctIpHashCountSql(
+function hasCrowdReportClusterCurrentConfidenceSql(
+  minReportCount: number,
+  minDistinctIpHashes: number,
+) {
+  return sql`${getCrowdReportClusterOngoingReportCountSql(
+    crowdReportClustersTable.id,
+  )} >= ${minReportCount} and ${getCrowdReportClusterOngoingDistinctIpHashCountSql(
     crowdReportClustersTable.id,
   )} >= ${minDistinctIpHashes}`;
 }
@@ -965,7 +984,9 @@ async function createCrowdReportClusterInTransaction(
     window_end_at: windowEndAt,
     report_count: 1,
     status:
-      publicSignalMinReports <= 1 && publicSignalMinDistinctIpHashes <= 1
+      submission.isStillHappening === true &&
+      publicSignalMinReports <= 1 &&
+      publicSignalMinDistinctIpHashes <= 1
         ? 'accepted'
         : 'pending',
   });
@@ -1052,7 +1073,7 @@ async function clusterModeratedCrowdReportInTransaction(
     .update(crowdReportClustersTable)
     .set({
       report_count: sql`${crowdReportClustersTable.report_count} + 1`,
-      status: sql`case when ${crowdReportClustersTable.status} = 'pending' and ${crowdReportClustersTable.report_count} + 1 >= ${publicSignalMinReports} and ${getCrowdReportClusterDistinctIpHashCountSql(clusterId)} >= ${publicSignalMinDistinctIpHashes} then 'accepted'::crowd_report_cluster_status else ${crowdReportClustersTable.status} end`,
+      status: sql`case when ${crowdReportClustersTable.status} = 'pending' and ${getCrowdReportClusterOngoingReportCountSql(clusterId)} >= ${publicSignalMinReports} and ${getCrowdReportClusterOngoingDistinctIpHashCountSql(clusterId)} >= ${publicSignalMinDistinctIpHashes} then 'accepted'::crowd_report_cluster_status else ${crowdReportClustersTable.status} end`,
       window_start_at: sql`least(${crowdReportClustersTable.window_start_at}, ${windowStartAt}::timestamptz)`,
       window_end_at: sql`greatest(${crowdReportClustersTable.window_end_at}, ${windowEndAt}::timestamptz)`,
       updated_at: sql`now()`,
@@ -1250,11 +1271,8 @@ export async function getPublicCrowdReportSignals(
     .where(
       and(
         eq(crowdReportClustersTable.status, 'accepted'),
-        gte(
-          crowdReportClustersTable.report_count,
+        hasCrowdReportClusterCurrentConfidenceSql(
           options.minReportCount ?? DEFAULT_PUBLIC_SIGNAL_MIN_REPORTS,
-        ),
-        hasCrowdReportClusterSourceDiversitySql(
           options.minDistinctIpHashes ??
             DEFAULT_PUBLIC_SIGNAL_MIN_DISTINCT_IP_HASHES,
         ),

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -428,6 +428,10 @@ Exit criteria:
 - 2026-05-27: Continued Phase 6 canonical-ingest hardening by auto-rejecting
   obvious prompt-injection report text before it can be forwarded into the
   LLM-assisted `mrtdown-data` triage path.
+- 2026-05-28: Continued Phase 6 community-signal hardening by requiring
+  high-confidence public and dispatchable clusters to satisfy report-count and
+  source-diversity thresholds using reports that explicitly say the issue is
+  still happening.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Require public crowd-report cluster confidence to be based on accepted or duplicate reports that explicitly say the issue is still happening.
- Apply the same ongoing-report confidence gate before dispatching accepted clusters to canonical ingest.
- Add regression coverage for non-ongoing reports staying private and update the active crowdsourced reports plan log.

## Validation

- `npm run test:run -- app/util/crowdReports.test.ts app/util/crowdReportDispatch.test.ts`
- `npm run verify`

Note: the first sandboxed `npm run verify` attempt failed at `db:generate:check` because `tsx` could not create its IPC pipe under `/var/folders/...`; rerunning the same command outside the sandbox passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined cluster confidence evaluation to focus on ongoing reports when determining public visibility and dispatch eligibility.
  * Clusters now achieve public status only when containing sufficient ongoing reports with adequate source diversity.
  * Improved dispatch candidate selection through updated confidence assessment logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-site/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->