### PR TITLE
fix: prefer current service revisions

### DIFF
--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -54,6 +54,10 @@ import {
 } from '~/util/issueOperationalEffects';
 import { getPublicCrowdReportSignals } from '~/util/crowdReports';
 import {
+  deriveLineStartedAtFromBranches,
+  sortLineBranchesForCurrentView,
+} from '~/util/lineBranches';
+import {
   selectServiceRevisionForReferenceDate,
   serviceRevisionHasEnded,
 } from '~/util/serviceRevisions';
@@ -1325,7 +1329,17 @@ async function buildDataset(
   const membershipByStationId: Record<string, Station['memberships']> = {};
 
   for (const [lineId, branches] of Object.entries(branchesByLineId)) {
-    for (const branch of branches) {
+    const sortedBranches = sortLineBranchesForCurrentView(branches);
+    branchesByLineId[lineId] = sortedBranches;
+    const line = linesById[lineId];
+    if (line != null) {
+      line.startedAt = deriveLineStartedAtFromBranches(
+        line.startedAt,
+        sortedBranches,
+      );
+    }
+
+    for (const branch of sortedBranches) {
       branch.entries.forEach((entry, index) => {
         if (membershipByStationId[entry.stationId] == null) {
           membershipByStationId[entry.stationId] = [];

--- a/app/util/lineBranches.test.ts
+++ b/app/util/lineBranches.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+  deriveLineStartedAtFromBranches,
+  sortLineBranchesForCurrentView,
+} from './lineBranches';
+
+describe('sortLineBranchesForCurrentView', () => {
+  it('keeps current branches before planned future branches', () => {
+    const branches = [
+      { id: 'future-loop', startedAt: null, endedAt: null },
+      { id: 'current-main', startedAt: '2009-05-28', endedAt: null },
+      { id: 'retired-shuttle', startedAt: '2009-05-28', endedAt: '2020-01-01' },
+    ];
+
+    expect(
+      sortLineBranchesForCurrentView(branches).map((branch) => branch.id),
+    ).toEqual(['current-main', 'future-loop', 'retired-shuttle']);
+  });
+
+  it('preserves source order within the same lifecycle group', () => {
+    const branches = [
+      { id: 'branch-b', startedAt: '2017-10-21', endedAt: null },
+      { id: 'branch-a', startedAt: '2009-05-28', endedAt: null },
+    ];
+
+    expect(
+      sortLineBranchesForCurrentView(branches).map((branch) => branch.id),
+    ).toEqual(['branch-b', 'branch-a']);
+  });
+});
+
+describe('deriveLineStartedAtFromBranches', () => {
+  it('keeps a currently served line from being treated as future service', () => {
+    expect(
+      deriveLineStartedAtFromBranches('2026-07-02', [
+        { startedAt: null, endedAt: null },
+        { startedAt: '2009-05-28', endedAt: null },
+      ]),
+    ).toBe('2009-05-28');
+  });
+
+  it('keeps future-only lines future', () => {
+    expect(
+      deriveLineStartedAtFromBranches('2026-07-02', [
+        { startedAt: null, endedAt: null },
+      ]),
+    ).toBe('2026-07-02');
+  });
+
+  it('does not pull future lines back from retired-only service', () => {
+    expect(
+      deriveLineStartedAtFromBranches('2026-07-02', [
+        { startedAt: '2009-05-28', endedAt: '2020-01-01' },
+        { startedAt: null, endedAt: null },
+      ]),
+    ).toBe('2026-07-02');
+  });
+});

--- a/app/util/lineBranches.ts
+++ b/app/util/lineBranches.ts
@@ -1,0 +1,43 @@
+type LineBranchLifecycleFields = {
+  startedAt: string | null;
+  endedAt: string | null;
+};
+
+function branchLifecycleRank(branch: LineBranchLifecycleFields) {
+  if (branch.startedAt != null && branch.endedAt == null) {
+    return 0;
+  }
+  if (branch.startedAt == null && branch.endedAt == null) {
+    return 1;
+  }
+  return 2;
+}
+
+export function sortLineBranchesForCurrentView<
+  T extends LineBranchLifecycleFields,
+>(branches: readonly T[]) {
+  return [...branches].sort(
+    (first, second) => branchLifecycleRank(first) - branchLifecycleRank(second),
+  );
+}
+
+export function deriveLineStartedAtFromBranches(
+  lineStartedAt: string | null,
+  branches: readonly LineBranchLifecycleFields[],
+) {
+  const earliestStartedBranch = branches
+    .filter((branch) => branch.endedAt == null)
+    .map((branch) => branch.startedAt)
+    .filter((startedAt): startedAt is string => startedAt != null)
+    .sort((first, second) => first.localeCompare(second))[0];
+
+  if (earliestStartedBranch == null) {
+    return lineStartedAt;
+  }
+
+  if (lineStartedAt == null || lineStartedAt > earliestStartedBranch) {
+    return earliestStartedBranch;
+  }
+
+  return lineStartedAt;
+}


### PR DESCRIPTION
## Summary

- Sort line branches by lifecycle before exposing them to profile pages, so current service appears before planned future branches.
- Derive a line's effective start date from started branches when source line metadata has moved to a future revision.
- Add focused coverage for branch ordering and future-only/current-service behavior.

## Root Cause

Future service revisions could be selected or surfaced ahead of currently active service data after the future revision work landed. That made one homepage line appear as future service and made the line page default to the planned branch.

## Validation

- `npm run verify`