### PR TITLE
fix: return 404 for invalid history params

### DIFF
--- a/app/routes/{-$lang}/history/$year/$month.tsx
+++ b/app/routes/{-$lang}/history/$year/$month.tsx
@@ -4,7 +4,7 @@ import {
   ChevronRightIcon,
 } from '@heroicons/react/16/solid';
 import { ChevronDownIcon } from '@heroicons/react/24/outline';
-import { createFileRoute, Link } from '@tanstack/react-router';
+import { createFileRoute, Link, notFound } from '@tanstack/react-router';
 import { DateTime } from 'luxon';
 import { DropdownMenu } from 'radix-ui';
 import { useMemo } from 'react';
@@ -18,15 +18,30 @@ import { IssueCard } from '~/components/IssueCard';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
 import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
 import { useHydrated } from '~/hooks/useHydrated';
-import { getIssuesHistoryYearMonthFn } from '~/util/history.functions';
+import {
+  getIssuesHistoryYearMonthFn,
+  parseHistoryYearMonthParams,
+} from '~/util/history.functions';
 
 export const Route = createFileRoute('/{-$lang}/history/$year/$month')({
   component: HistoryMonthPage,
-  loader: ({ params }) =>
-    getIssuesHistoryYearMonthFn({
-      data: { year: params.year, month: params.month },
-    }),
+  loader: ({ params }) => {
+    const parsedParams = parseHistoryYearMonthParams(params.year, params.month);
+    if (parsedParams == null) {
+      throw notFound();
+    }
+
+    return getIssuesHistoryYearMonthFn({
+      data: parsedParams,
+    });
+  },
   async head(ctx) {
+    if (ctx.loaderData == null) {
+      return {
+        meta: [],
+      };
+    }
+
     const { lang = 'en-SG', year, month } = ctx.params;
     const { default: messages } = await import(
       `../../../../../lang/${lang}.json`

--- a/app/routes/{-$lang}/history/$year/index.tsx
+++ b/app/routes/{-$lang}/history/$year/index.tsx
@@ -5,7 +5,7 @@ import {
 } from '@heroicons/react/16/solid';
 import { ChevronDownIcon } from '@heroicons/react/24/outline';
 import { ExclamationCircleIcon } from '@heroicons/react/24/solid';
-import { createFileRoute, Link } from '@tanstack/react-router';
+import { createFileRoute, Link, notFound } from '@tanstack/react-router';
 import { DateTime } from 'luxon';
 import { DropdownMenu } from 'radix-ui';
 import { useMemo } from 'react';
@@ -18,12 +18,21 @@ import {
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
 import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
 import { useHydrated } from '~/hooks/useHydrated';
-import { getIssuesHistoryYearFn } from '~/util/history.functions';
+import {
+  getIssuesHistoryYearFn,
+  parseHistoryYearParam,
+} from '~/util/history.functions';
 
 export const Route = createFileRoute('/{-$lang}/history/$year/')({
   component: HistoryYearPage,
-  loader: ({ params }) =>
-    getIssuesHistoryYearFn({ data: { year: params.year } }),
+  loader: ({ params }) => {
+    const year = parseHistoryYearParam(params.year);
+    if (year == null) {
+      throw notFound();
+    }
+
+    return getIssuesHistoryYearFn({ data: { year } });
+  },
   async head(ctx) {
     if (ctx.loaderData == null) {
       return {

--- a/app/util/history.functions.test.ts
+++ b/app/util/history.functions.test.ts
@@ -1,0 +1,37 @@
+import { DateTime } from 'luxon';
+import { describe, expect, it } from 'vitest';
+import {
+  parseHistoryYearMonthParams,
+  parseHistoryYearParam,
+} from './history.functions';
+
+describe('parseHistoryYearParam', () => {
+  it('coerces valid year route params', () => {
+    expect(parseHistoryYearParam('2025')).toBe(2025);
+  });
+
+  it('rejects invalid year route params', () => {
+    const maxYear = DateTime.now().year + 10;
+
+    expect(parseHistoryYearParam('not-a-year')).toBeNull();
+    expect(parseHistoryYearParam('2025.5')).toBeNull();
+    expect(parseHistoryYearParam('1979')).toBeNull();
+    expect(parseHistoryYearParam((maxYear + 1).toString())).toBeNull();
+  });
+});
+
+describe('parseHistoryYearMonthParams', () => {
+  it('coerces valid year and month route params', () => {
+    expect(parseHistoryYearMonthParams('2025', '01')).toEqual({
+      year: 2025,
+      month: 1,
+    });
+  });
+
+  it('rejects invalid month route params', () => {
+    expect(parseHistoryYearMonthParams('2025', '0')).toBeNull();
+    expect(parseHistoryYearMonthParams('2025', '13')).toBeNull();
+    expect(parseHistoryYearMonthParams('2025', '1.5')).toBeNull();
+    expect(parseHistoryYearMonthParams('2025', 'not-a-month')).toBeNull();
+  });
+});

--- a/app/util/history.functions.ts
+++ b/app/util/history.functions.ts
@@ -6,9 +6,6 @@ import {
   getHistoryYearSummaryData,
 } from './db.queries';
 
-const YearSchema = z.coerce.number().int();
-const MonthSchema = z.coerce.number().int();
-
 function isHistoryYearInRange(year: number) {
   const minYear = 1980;
   const maxYear = DateTime.now().year + 10;
@@ -19,8 +16,15 @@ function isHistoryMonthInRange(month: number) {
   return month >= 1 && month <= 12;
 }
 
+const YearSchema = z.coerce.number().int();
+const HistoryYearSchema = YearSchema.refine(isHistoryYearInRange, {
+  message: 'Year is out of range',
+});
+const MonthSchema = z.coerce.number().int();
+const HistoryMonthSchema = MonthSchema.min(1).max(12);
+
 const YearInputSchema = z.object({
-  year: YearSchema,
+  year: HistoryYearSchema,
 });
 
 export function parseHistoryYearParam(year: unknown) {
@@ -37,12 +41,16 @@ export const getIssuesHistoryYearFn = createServerFn({ method: 'GET' })
   .handler((val) => getHistoryYearSummaryData(val.data.year));
 
 const YearMonthInputSchema = z.object({
+  year: HistoryYearSchema,
+  month: HistoryMonthSchema,
+});
+const YearMonthParamSchema = z.object({
   year: YearSchema,
   month: MonthSchema,
 });
 
 export function parseHistoryYearMonthParams(year: unknown, month: unknown) {
-  const result = YearMonthInputSchema.safeParse({ year, month });
+  const result = YearMonthParamSchema.safeParse({ year, month });
   if (
     !result.success ||
     !isHistoryYearInRange(result.data.year) ||

--- a/app/util/history.functions.ts
+++ b/app/util/history.functions.ts
@@ -6,20 +6,31 @@ import {
   getHistoryYearSummaryData,
 } from './db.queries';
 
-const YearSchema = z.coerce.number().refine(
-  (year) => {
-    const minYear = 1980;
-    const maxYear = DateTime.now().year + 10;
-    return year >= minYear && year <= maxYear;
-  },
-  {
-    message: 'Year is out of range',
-  },
-);
+const YearSchema = z.coerce.number().int();
+const MonthSchema = z.coerce.number().int();
+
+function isHistoryYearInRange(year: number) {
+  const minYear = 1980;
+  const maxYear = DateTime.now().year + 10;
+  return year >= minYear && year <= maxYear;
+}
+
+function isHistoryMonthInRange(month: number) {
+  return month >= 1 && month <= 12;
+}
 
 const YearInputSchema = z.object({
   year: YearSchema,
 });
+
+export function parseHistoryYearParam(year: unknown) {
+  const result = YearSchema.safeParse(year);
+  if (!result.success || !isHistoryYearInRange(result.data)) {
+    return null;
+  }
+
+  return result.data;
+}
 
 export const getIssuesHistoryYearFn = createServerFn({ method: 'GET' })
   .inputValidator(YearInputSchema)
@@ -27,8 +38,21 @@ export const getIssuesHistoryYearFn = createServerFn({ method: 'GET' })
 
 const YearMonthInputSchema = z.object({
   year: YearSchema,
-  month: z.coerce.number().min(1).max(12),
+  month: MonthSchema,
 });
+
+export function parseHistoryYearMonthParams(year: unknown, month: unknown) {
+  const result = YearMonthInputSchema.safeParse({ year, month });
+  if (
+    !result.success ||
+    !isHistoryYearInRange(result.data.year) ||
+    !isHistoryMonthInRange(result.data.month)
+  ) {
+    return null;
+  }
+
+  return result.data;
+}
 
 export const getIssuesHistoryYearMonthFn = createServerFn({ method: 'GET' })
   .inputValidator(YearMonthInputSchema)


### PR DESCRIPTION
## Summary

- Validate history year and month route params in the route loaders before calling the Zod-backed server functions.
- Keep the server-function Zod schemas focused on numeric integer shape/coercion, while explicit helpers own history-page range checks.
- Add unit coverage for valid and invalid history route params.

## Why

Invalid history URLs were reaching the server-function input validator and surfacing as Zod errors, which can be reported as 5xx noise and consume Sentry quota. These are client-routable not-found cases instead.

## Validation

- `npm run verify`