### PR TITLE
fix: stabilize home line ordering

### DIFF
--- a/app/routes/{-$lang}/helpers/sortLineSummaries.test.ts
+++ b/app/routes/{-$lang}/helpers/sortLineSummaries.test.ts
@@ -22,12 +22,12 @@ const lineSummary = (
 };
 
 describe('sortLineSummariesWithFutureServiceLast', () => {
-  it('moves future service entries to the end', () => {
+  it('orders lines by id with future service entries at the end', () => {
     const input: LineSummary[] = [
       lineSummary('A', 'future_service'),
-      lineSummary('B', 'normal'),
       lineSummary('C', 'ongoing_maintenance'),
       lineSummary('D', 'future_service'),
+      lineSummary('B', 'normal'),
       lineSummary('E', 'ongoing_disruption'),
     ];
 

--- a/app/routes/{-$lang}/helpers/sortLineSummaries.ts
+++ b/app/routes/{-$lang}/helpers/sortLineSummaries.ts
@@ -4,15 +4,16 @@ export function sortLineSummariesWithFutureServiceLast(
   lineSummaries: LineSummary[],
 ): LineSummary[] {
   return [...lineSummaries].sort((first, second) => {
-    if (first.status === second.status) {
-      return 0;
-    }
-    if (first.status === 'future_service') {
+    const firstIsFuture = first.status === 'future_service';
+    const secondIsFuture = second.status === 'future_service';
+
+    if (firstIsFuture && !secondIsFuture) {
       return 1;
     }
-    if (second.status === 'future_service') {
+    if (!firstIsFuture && secondIsFuture) {
       return -1;
     }
-    return 0;
+
+    return first.lineId.localeCompare(second.lineId);
   });
 }


### PR DESCRIPTION
## Summary

- Sort homepage line summaries by line ID inside the current-service and future-service buckets.
- Keep future-service lines grouped after current lines.
- Update the helper test to cover deterministic ordering, not just future-last bucketing.

## Root Cause

The homepage sorter only moved `future_service` summaries to the end and otherwise preserved upstream dataset order. After the future service revision data rewrite, a line with future revisions could remain in an odd position even when it was no longer treated as future service.

## Validation

- `npm run test:run -- 'app/routes/{-$lang}/helpers/sortLineSummaries.test.ts'`
- `npm run verify`