### PR TITLE
perf: precompute statistics included payload

### DIFF
--- a/app/util/db.queries.test.ts
+++ b/app/util/db.queries.test.ts
@@ -1,7 +1,12 @@
 import { DateTime } from 'luxon';
 import { describe, expect, it } from 'vitest';
 import type { Issue, Line, Station } from '~/types';
-import { buildLineSummary, selectIncludedEntities } from './db.queries';
+import {
+  buildLineSummary,
+  parseStatisticsSnapshotPayload,
+  selectIncludedEntities,
+  type SystemAnalytics,
+} from './db.queries';
 
 const REFERENCE_NOW = DateTime.fromISO('2026-02-23T23:59:00', {
   zone: 'Asia/Singapore',
@@ -99,6 +104,26 @@ function buildIssue(
     serviceEffectKinds: [],
     facilityEffectKinds: [],
   } as Parameters<typeof buildLineSummary>[1][number];
+}
+
+function buildStatistics(): SystemAnalytics {
+  return {
+    timeScaleChartsIssueCount: [],
+    timeScaleChartsIssueDuration: [],
+    chartTotalIssueCountByLine: {
+      title: 'Issue Count by Line',
+      data: [],
+    },
+    chartTotalIssueCountByStation: {
+      title: 'Issue Count by Station',
+      data: [],
+    },
+    chartRollingYearHeatmap: {
+      title: 'Rolling Year Heatmap',
+      data: [],
+    },
+    issueIdsDisruptionLongest: ['disruption-1'],
+  };
 }
 
 describe('buildLineSummary', () => {
@@ -221,6 +246,50 @@ describe('buildLineSummary', () => {
     );
 
     expect(summary.status).toBe('closed_for_day');
+  });
+});
+
+describe('parseStatisticsSnapshotPayload', () => {
+  it('reads precomputed statistics snapshots with included entities', () => {
+    const statistics = buildStatistics();
+    const included = {
+      issues: {},
+      lines: {},
+      stations: {},
+      operators: {},
+      towns: {},
+      landmarks: {},
+    };
+
+    expect(
+      parseStatisticsSnapshotPayload({
+        kind: 'statistics_snapshot.v1',
+        data: statistics,
+        included,
+      }),
+    ).toEqual({
+      data: statistics,
+      included,
+    });
+  });
+
+  it('keeps legacy statistics-only snapshots as a fallback', () => {
+    const statistics = buildStatistics();
+
+    expect(parseStatisticsSnapshotPayload(statistics)).toEqual({
+      data: statistics,
+      included: null,
+    });
+  });
+
+  it('rejects malformed statistics snapshot payloads', () => {
+    expect(
+      parseStatisticsSnapshotPayload({
+        kind: 'statistics_snapshot.v1',
+        data: buildStatistics(),
+      }),
+    ).toBeNull();
+    expect(parseStatisticsSnapshotPayload({})).toBeNull();
   });
 });
 

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -165,6 +165,12 @@ export type SystemAnalytics = {
   issueIdsDisruptionLongest: string[];
 };
 
+type StatisticsSnapshotPayload = {
+  kind: 'statistics_snapshot.v1';
+  data: SystemAnalytics;
+  included: IncludedEntities;
+};
+
 type StatisticsTimeWindow = {
   title: string;
   dataTimeScale: TimeScale;
@@ -3826,10 +3832,13 @@ export async function getHistoryDayData(
 
 const STATISTICS_SNAPSHOT_ID = 'latest';
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
 function isSystemAnalytics(value: unknown): value is SystemAnalytics {
   return (
-    value != null &&
-    typeof value === 'object' &&
+    isRecord(value) &&
     Array.isArray(
       (value as Partial<SystemAnalytics>).timeScaleChartsIssueCount,
     ) &&
@@ -3849,6 +3858,53 @@ function isSystemAnalytics(value: unknown): value is SystemAnalytics {
   );
 }
 
+function isIncludedEntities(value: unknown): value is IncludedEntities {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    isRecord(value.issues) &&
+    isRecord(value.lines) &&
+    isRecord(value.stations) &&
+    isRecord(value.operators) &&
+    isRecord(value.towns) &&
+    isRecord(value.landmarks)
+  );
+}
+
+function isStatisticsSnapshotPayload(
+  value: unknown,
+): value is StatisticsSnapshotPayload {
+  return (
+    isRecord(value) &&
+    value.kind === 'statistics_snapshot.v1' &&
+    isSystemAnalytics(value.data) &&
+    isIncludedEntities(value.included)
+  );
+}
+
+export function parseStatisticsSnapshotPayload(value: unknown): {
+  data: SystemAnalytics;
+  included: IncludedEntities | null;
+} | null {
+  if (isStatisticsSnapshotPayload(value)) {
+    return {
+      data: value.data,
+      included: value.included,
+    };
+  }
+
+  if (isSystemAnalytics(value)) {
+    return {
+      data: value,
+      included: null,
+    };
+  }
+
+  return null;
+}
+
 async function getLatestStatisticsSnapshot(db?: AppDb) {
   const database = db ?? (await getDefaultDb());
   try {
@@ -3861,7 +3917,7 @@ async function getLatestStatisticsSnapshot(db?: AppDb) {
         .where(eq(statisticsSnapshotsTable.id, STATISTICS_SNAPSHOT_ID))
         .limit(1),
     );
-    return isSystemAnalytics(snapshot?.data) ? snapshot.data : null;
+    return parseStatisticsSnapshotPayload(snapshot?.data);
   } catch (error) {
     if (isUndefinedTableError(error)) {
       return null;
@@ -4075,19 +4131,27 @@ export async function rebuildStatisticsSnapshot(db?: AppDb) {
     const asOf = isoDateTime(nowSg());
     const dataset = await buildDataset(nowSg(), database);
     const data = await buildStatisticsDataFromDataset(dataset, database);
+    const included = timeSyncServerSpan('statistics_snapshot_included', () =>
+      getStatisticsIncluded(dataset, data),
+    );
+    const snapshotPayload = {
+      kind: 'statistics_snapshot.v1',
+      data,
+      included,
+    } satisfies StatisticsSnapshotPayload;
     await timeServerSpan('statistics_snapshot_upsert', () =>
       database
         .insert(statisticsSnapshotsTable)
         .values({
           id: STATISTICS_SNAPSHOT_ID,
           as_of: asOf,
-          data,
+          data: snapshotPayload,
         })
         .onConflictDoUpdate({
           target: [statisticsSnapshotsTable.id],
           set: {
             as_of: asOf,
-            data,
+            data: snapshotPayload,
             updated_at: sql`now()`,
           },
         }),
@@ -4103,13 +4167,25 @@ export async function getStatisticsData() {
   return timeServerSpan('statistics_data', async () => {
     const snapshot = await getLatestStatisticsSnapshot();
     if (snapshot != null) {
+      if (snapshot.included != null) {
+        recordServerTiming('statistics_included', 0, 'source=snapshot');
+        return {
+          data: snapshot.data,
+          included: snapshot.included,
+        };
+      }
+
       const dataset = await timeServerSpan('statistics_included_dataset', () =>
-        buildDataset(nowSg(), undefined, snapshot.issueIdsDisruptionLongest),
+        buildDataset(
+          nowSg(),
+          undefined,
+          snapshot.data.issueIdsDisruptionLongest,
+        ),
       );
       return {
-        data: snapshot,
+        data: snapshot.data,
         included: timeSyncServerSpan('statistics_included', () =>
-          getStatisticsIncluded(dataset, snapshot),
+          getStatisticsIncluded(dataset, snapshot.data),
         ),
       };
     }

--- a/docs/plans/active/production-performance.md
+++ b/docs/plans/active/production-performance.md
@@ -305,6 +305,12 @@ underlying compute and payload costs so uncached requests are also fast.
   operational facts and manual facts rebuilds, and make the statistics route use
   the snapshot when available. The existing request-time statistics builder
   remains as a fallback for development and un-migrated environments.
+- 2026-05-30: Continued Phase 4 by storing the statistics route's pruned
+  included-entity payload inside new statistics snapshot rows. The request path
+  now returns precomputed snapshot data and included entities without rebuilding
+  a dataset when the v1 snapshot shape is available, while legacy
+  statistics-only snapshot rows still fall back to the previous included-entity
+  assembly path.
 
 ## Validation
 


### PR DESCRIPTION
## Summary

- Store the statistics route's pruned included-entity payload inside new `statistics_snapshots` rows.
- Return precomputed snapshot data and included entities directly on the `/statistics` snapshot path.
- Keep legacy statistics-only snapshots working by falling back to request-time included-entity assembly.
- Update the active production performance plan with the Phase 4 progress note.

## Validation

- `npm run verify` passed after rerunning with filesystem escalation for `tsx` IPC during `db:generate:check`.
- The successful run covered typecheck, lint, format check, Drizzle migration drift check, and 147 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Statistics snapshots now support precomputed included data for improved performance.

* **Bug Fixes**
  * Legacy snapshot formats are properly handled as fallbacks.

* **Tests**
  * Added comprehensive test coverage for snapshot payload parsing and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/foldaway/mrtdown-site/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->