### PR TITLE
feat: track route web vitals

### DIFF
--- a/app/components/RouteWebVitals.tsx
+++ b/app/components/RouteWebVitals.tsx
@@ -12,14 +12,44 @@ type EventTimingEntry = PerformanceEntry & {
   interactionId?: number;
 };
 
+type WebVitalName = 'CLS' | 'FCP' | 'INP' | 'LCP';
+
+type MetricValue = {
+  route: string;
+  value: number;
+};
+
+type ClsSessionWindow = {
+  currentStartTime: number | null;
+  currentLastEntryTime: number | null;
+  currentValue: number;
+  maxValue: number;
+};
+
+const MAX_CLS_SESSION_GAP_MS = 1000;
+const MAX_CLS_SESSION_DURATION_MS = 5000;
+
+function createClsSessionWindow(): ClsSessionWindow {
+  return {
+    currentStartTime: null,
+    currentLastEntryTime: null,
+    currentValue: 0,
+    maxValue: 0,
+  };
+}
+
 export function RouteWebVitals() {
   const posthog = usePostHog();
   const route = useRouterState({
     select: (state) => getRouteTelemetryPath(state.location.pathname),
   });
   const routeRef = useRef(route);
+  const reportRouteMetricsRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
+    if (routeRef.current !== route) {
+      reportRouteMetricsRef.current?.();
+    }
     routeRef.current = route;
   }, [route]);
 
@@ -36,9 +66,9 @@ export function RouteWebVitals() {
       PerformanceObserver.supportedEntryTypes?.includes(entryType) ?? false;
 
     const captureMetric = (
-      metric: 'CLS' | 'FCP' | 'INP' | 'LCP',
+      metric: WebVitalName,
       value: number,
-      extraProperties: Record<string, unknown> = {},
+      routeForMetric: string,
     ) => {
       if (!Number.isFinite(value)) {
         return;
@@ -47,23 +77,54 @@ export function RouteWebVitals() {
       posthog.capture('web_vital', {
         metric,
         value,
-        route: routeRef.current,
-        pathname: window.location.pathname,
-        ...extraProperties,
+        route: routeForMetric,
       });
     };
 
     const observers: PerformanceObserver[] = [];
-    let cumulativeLayoutShift = 0;
-    let largestContentfulPaint = 0;
-    let maxInteractionDuration = 0;
+    let clsSessionWindow = createClsSessionWindow();
+    let hasClsSupport = false;
+    let largestContentfulPaint: MetricValue | null = null;
+    let maxInteractionDuration: MetricValue | null = null;
     let reportedFinalMetrics = false;
+
+    const resetRouteMetrics = () => {
+      clsSessionWindow = createClsSessionWindow();
+      largestContentfulPaint = null;
+      maxInteractionDuration = null;
+    };
+
+    const reportCurrentRouteMetrics = () => {
+      if (largestContentfulPaint != null) {
+        captureMetric(
+          'LCP',
+          largestContentfulPaint.value,
+          largestContentfulPaint.route,
+        );
+      }
+
+      if (hasClsSupport) {
+        captureMetric('CLS', clsSessionWindow.maxValue, routeRef.current);
+      }
+
+      if (maxInteractionDuration != null) {
+        captureMetric(
+          'INP',
+          maxInteractionDuration.value,
+          maxInteractionDuration.route,
+        );
+      }
+
+      resetRouteMetrics();
+    };
+
+    reportRouteMetricsRef.current = reportCurrentRouteMetrics;
 
     if (supportsEntryType('paint')) {
       const paintObserver = new PerformanceObserver((entryList) => {
         for (const entry of entryList.getEntries()) {
           if (entry.name === 'first-contentful-paint') {
-            captureMetric('FCP', entry.startTime);
+            captureMetric('FCP', entry.startTime, routeRef.current);
           }
         }
       });
@@ -74,7 +135,10 @@ export function RouteWebVitals() {
     if (supportsEntryType('largest-contentful-paint')) {
       const lcpObserver = new PerformanceObserver((entryList) => {
         for (const entry of entryList.getEntries()) {
-          largestContentfulPaint = entry.startTime;
+          largestContentfulPaint = {
+            route: routeRef.current,
+            value: entry.startTime,
+          };
         }
       });
       lcpObserver.observe({
@@ -85,11 +149,33 @@ export function RouteWebVitals() {
     }
 
     if (supportsEntryType('layout-shift')) {
+      hasClsSupport = true;
       const clsObserver = new PerformanceObserver((entryList) => {
         for (const entry of entryList.getEntries() as LayoutShiftEntry[]) {
-          if (!entry.hadRecentInput) {
-            cumulativeLayoutShift += entry.value;
+          if (entry.hadRecentInput) {
+            continue;
           }
+
+          const currentStartTime = clsSessionWindow.currentStartTime;
+          const currentLastEntryTime = clsSessionWindow.currentLastEntryTime;
+          const startsNewSession =
+            currentStartTime == null ||
+            currentLastEntryTime == null ||
+            entry.startTime - currentLastEntryTime > MAX_CLS_SESSION_GAP_MS ||
+            entry.startTime - currentStartTime > MAX_CLS_SESSION_DURATION_MS;
+
+          if (startsNewSession) {
+            clsSessionWindow.currentStartTime = entry.startTime;
+            clsSessionWindow.currentValue = entry.value;
+          } else {
+            clsSessionWindow.currentValue += entry.value;
+          }
+
+          clsSessionWindow.currentLastEntryTime = entry.startTime;
+          clsSessionWindow.maxValue = Math.max(
+            clsSessionWindow.maxValue,
+            clsSessionWindow.currentValue,
+          );
         }
       });
       clsObserver.observe({ type: 'layout-shift', buffered: true });
@@ -100,10 +186,16 @@ export function RouteWebVitals() {
       const inpObserver = new PerformanceObserver((entryList) => {
         for (const entry of entryList.getEntries() as EventTimingEntry[]) {
           if (entry.interactionId != null && entry.interactionId > 0) {
-            maxInteractionDuration = Math.max(
-              maxInteractionDuration,
-              entry.duration,
-            );
+            const value = entry.duration;
+            if (
+              maxInteractionDuration == null ||
+              value > maxInteractionDuration.value
+            ) {
+              maxInteractionDuration = {
+                route: routeRef.current,
+                value,
+              };
+            }
           }
         }
       });
@@ -121,13 +213,8 @@ export function RouteWebVitals() {
       }
 
       reportedFinalMetrics = true;
-      if (largestContentfulPaint > 0) {
-        captureMetric('LCP', largestContentfulPaint);
-      }
-      captureMetric('CLS', cumulativeLayoutShift);
-      if (maxInteractionDuration > 0) {
-        captureMetric('INP', maxInteractionDuration);
-      }
+      reportCurrentRouteMetrics();
+      reportRouteMetricsRef.current = null;
     };
 
     const handleVisibilityChange = () => {
@@ -142,6 +229,7 @@ export function RouteWebVitals() {
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       window.removeEventListener('pagehide', reportFinalMetrics);
+      reportRouteMetricsRef.current = null;
       for (const observer of observers) {
         observer.disconnect();
       }

--- a/app/components/RouteWebVitals.tsx
+++ b/app/components/RouteWebVitals.tsx
@@ -264,7 +264,6 @@ export function RouteWebVitals() {
 
       reportedFinalMetrics = true;
       flushCurrentRouteMetrics();
-      reportRouteMetricsRef.current = null;
     };
 
     const handleVisibilityChange = () => {
@@ -280,6 +279,7 @@ export function RouteWebVitals() {
       }
 
       reportFinalMetrics();
+      reportRouteMetricsRef.current = null;
     };
 
     const handlePageShow = (event: PageTransitionEvent) => {

--- a/app/components/RouteWebVitals.tsx
+++ b/app/components/RouteWebVitals.tsx
@@ -1,0 +1,152 @@
+import { usePostHog } from '@posthog/react';
+import { useRouterState } from '@tanstack/react-router';
+import { useEffect, useRef } from 'react';
+import { getRouteTelemetryPath } from '~/helpers/getRouteTelemetryPath';
+
+type LayoutShiftEntry = PerformanceEntry & {
+  hadRecentInput: boolean;
+  value: number;
+};
+
+type EventTimingEntry = PerformanceEntry & {
+  interactionId?: number;
+};
+
+export function RouteWebVitals() {
+  const posthog = usePostHog();
+  const route = useRouterState({
+    select: (state) => getRouteTelemetryPath(state.location.pathname),
+  });
+  const routeRef = useRef(route);
+
+  useEffect(() => {
+    routeRef.current = route;
+  }, [route]);
+
+  useEffect(() => {
+    if (
+      !import.meta.env.PROD ||
+      typeof window === 'undefined' ||
+      !('PerformanceObserver' in window)
+    ) {
+      return;
+    }
+
+    const supportsEntryType = (entryType: string) =>
+      PerformanceObserver.supportedEntryTypes?.includes(entryType) ?? false;
+
+    const captureMetric = (
+      metric: 'CLS' | 'FCP' | 'INP' | 'LCP',
+      value: number,
+      extraProperties: Record<string, unknown> = {},
+    ) => {
+      if (!Number.isFinite(value)) {
+        return;
+      }
+
+      posthog.capture('web_vital', {
+        metric,
+        value,
+        route: routeRef.current,
+        pathname: window.location.pathname,
+        ...extraProperties,
+      });
+    };
+
+    const observers: PerformanceObserver[] = [];
+    let cumulativeLayoutShift = 0;
+    let largestContentfulPaint = 0;
+    let maxInteractionDuration = 0;
+    let reportedFinalMetrics = false;
+
+    if (supportsEntryType('paint')) {
+      const paintObserver = new PerformanceObserver((entryList) => {
+        for (const entry of entryList.getEntries()) {
+          if (entry.name === 'first-contentful-paint') {
+            captureMetric('FCP', entry.startTime);
+          }
+        }
+      });
+      paintObserver.observe({ type: 'paint', buffered: true });
+      observers.push(paintObserver);
+    }
+
+    if (supportsEntryType('largest-contentful-paint')) {
+      const lcpObserver = new PerformanceObserver((entryList) => {
+        for (const entry of entryList.getEntries()) {
+          largestContentfulPaint = entry.startTime;
+        }
+      });
+      lcpObserver.observe({
+        type: 'largest-contentful-paint',
+        buffered: true,
+      });
+      observers.push(lcpObserver);
+    }
+
+    if (supportsEntryType('layout-shift')) {
+      const clsObserver = new PerformanceObserver((entryList) => {
+        for (const entry of entryList.getEntries() as LayoutShiftEntry[]) {
+          if (!entry.hadRecentInput) {
+            cumulativeLayoutShift += entry.value;
+          }
+        }
+      });
+      clsObserver.observe({ type: 'layout-shift', buffered: true });
+      observers.push(clsObserver);
+    }
+
+    if (supportsEntryType('event')) {
+      const inpObserver = new PerformanceObserver((entryList) => {
+        for (const entry of entryList.getEntries() as EventTimingEntry[]) {
+          if (entry.interactionId != null && entry.interactionId > 0) {
+            maxInteractionDuration = Math.max(
+              maxInteractionDuration,
+              entry.duration,
+            );
+          }
+        }
+      });
+      inpObserver.observe({
+        type: 'event',
+        buffered: true,
+        durationThreshold: 40,
+      } as PerformanceObserverInit);
+      observers.push(inpObserver);
+    }
+
+    const reportFinalMetrics = () => {
+      if (reportedFinalMetrics) {
+        return;
+      }
+
+      reportedFinalMetrics = true;
+      if (largestContentfulPaint > 0) {
+        captureMetric('LCP', largestContentfulPaint);
+      }
+      captureMetric('CLS', cumulativeLayoutShift);
+      if (maxInteractionDuration > 0) {
+        captureMetric('INP', maxInteractionDuration);
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        reportFinalMetrics();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('pagehide', reportFinalMetrics);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('pagehide', reportFinalMetrics);
+      for (const observer of observers) {
+        observer.disconnect();
+      }
+    };
+  }, [posthog]);
+
+  return null;
+}

--- a/app/components/RouteWebVitals.tsx
+++ b/app/components/RouteWebVitals.tsx
@@ -82,6 +82,7 @@ export function RouteWebVitals() {
     };
 
     const observers: PerformanceObserver[] = [];
+    const pendingRecordDrainers: Array<() => void> = [];
     let clsSessionWindow = createClsSessionWindow();
     let hasClsSupport = false;
     let hasPendingRouteMetrics = false;
@@ -109,7 +110,7 @@ export function RouteWebVitals() {
         );
       }
 
-      if (hasClsSupport && clsSessionWindow.maxValue > 0) {
+      if (hasClsSupport) {
         captureMetric('CLS', clsSessionWindow.maxValue, routeRef.current);
       }
 
@@ -124,95 +125,135 @@ export function RouteWebVitals() {
       resetRouteMetrics();
     };
 
-    reportRouteMetricsRef.current = reportCurrentRouteMetrics;
+    const drainPendingRecords = () => {
+      for (const drainPendingRecords of pendingRecordDrainers) {
+        drainPendingRecords();
+      }
+    };
+
+    const flushCurrentRouteMetrics = () => {
+      drainPendingRecords();
+      reportCurrentRouteMetrics();
+    };
+
+    reportRouteMetricsRef.current = flushCurrentRouteMetrics;
+
+    const processPaintEntries = (entries: PerformanceEntry[]) => {
+      for (const entry of entries) {
+        if (entry.name === 'first-contentful-paint') {
+          captureMetric('FCP', entry.startTime, routeRef.current);
+          hasPendingRouteMetrics = true;
+        }
+      }
+    };
+
+    const processLcpEntries = (entries: PerformanceEntry[]) => {
+      for (const entry of entries) {
+        largestContentfulPaint = {
+          route: routeRef.current,
+          value: entry.startTime,
+        };
+        hasPendingRouteMetrics = true;
+      }
+    };
+
+    const processClsEntries = (entries: LayoutShiftEntry[]) => {
+      for (const entry of entries) {
+        if (entry.hadRecentInput) {
+          continue;
+        }
+
+        const currentStartTime = clsSessionWindow.currentStartTime;
+        const currentLastEntryTime = clsSessionWindow.currentLastEntryTime;
+        const startsNewSession =
+          currentStartTime == null ||
+          currentLastEntryTime == null ||
+          entry.startTime - currentLastEntryTime > MAX_CLS_SESSION_GAP_MS ||
+          entry.startTime - currentStartTime > MAX_CLS_SESSION_DURATION_MS;
+
+        if (startsNewSession) {
+          clsSessionWindow.currentStartTime = entry.startTime;
+          clsSessionWindow.currentValue = entry.value;
+        } else {
+          clsSessionWindow.currentValue += entry.value;
+        }
+
+        clsSessionWindow.currentLastEntryTime = entry.startTime;
+        clsSessionWindow.maxValue = Math.max(
+          clsSessionWindow.maxValue,
+          clsSessionWindow.currentValue,
+        );
+        hasPendingRouteMetrics = true;
+      }
+    };
+
+    const processEventEntries = (entries: EventTimingEntry[]) => {
+      for (const entry of entries) {
+        if (entry.interactionId != null && entry.interactionId > 0) {
+          const value = entry.duration;
+          if (
+            maxInteractionDuration == null ||
+            value > maxInteractionDuration.value
+          ) {
+            maxInteractionDuration = {
+              route: routeRef.current,
+              value,
+            };
+            hasPendingRouteMetrics = true;
+          }
+        }
+      }
+    };
 
     if (supportsEntryType('paint')) {
       const paintObserver = new PerformanceObserver((entryList) => {
-        for (const entry of entryList.getEntries()) {
-          if (entry.name === 'first-contentful-paint') {
-            captureMetric('FCP', entry.startTime, routeRef.current);
-          }
-        }
+        processPaintEntries(entryList.getEntries());
       });
       paintObserver.observe({ type: 'paint', buffered: true });
+      pendingRecordDrainers.push(() =>
+        processPaintEntries(paintObserver.takeRecords()),
+      );
       observers.push(paintObserver);
     }
 
     if (supportsEntryType('largest-contentful-paint')) {
       const lcpObserver = new PerformanceObserver((entryList) => {
-        for (const entry of entryList.getEntries()) {
-          largestContentfulPaint = {
-            route: routeRef.current,
-            value: entry.startTime,
-          };
-          hasPendingRouteMetrics = true;
-        }
+        processLcpEntries(entryList.getEntries());
       });
       lcpObserver.observe({
         type: 'largest-contentful-paint',
         buffered: true,
       });
+      pendingRecordDrainers.push(() =>
+        processLcpEntries(lcpObserver.takeRecords()),
+      );
       observers.push(lcpObserver);
     }
 
     if (supportsEntryType('layout-shift')) {
       hasClsSupport = true;
       const clsObserver = new PerformanceObserver((entryList) => {
-        for (const entry of entryList.getEntries() as LayoutShiftEntry[]) {
-          if (entry.hadRecentInput) {
-            continue;
-          }
-
-          const currentStartTime = clsSessionWindow.currentStartTime;
-          const currentLastEntryTime = clsSessionWindow.currentLastEntryTime;
-          const startsNewSession =
-            currentStartTime == null ||
-            currentLastEntryTime == null ||
-            entry.startTime - currentLastEntryTime > MAX_CLS_SESSION_GAP_MS ||
-            entry.startTime - currentStartTime > MAX_CLS_SESSION_DURATION_MS;
-
-          if (startsNewSession) {
-            clsSessionWindow.currentStartTime = entry.startTime;
-            clsSessionWindow.currentValue = entry.value;
-          } else {
-            clsSessionWindow.currentValue += entry.value;
-          }
-
-          clsSessionWindow.currentLastEntryTime = entry.startTime;
-          clsSessionWindow.maxValue = Math.max(
-            clsSessionWindow.maxValue,
-            clsSessionWindow.currentValue,
-          );
-          hasPendingRouteMetrics = true;
-        }
+        processClsEntries(entryList.getEntries() as LayoutShiftEntry[]);
       });
       clsObserver.observe({ type: 'layout-shift', buffered: true });
+      pendingRecordDrainers.push(() =>
+        processClsEntries(clsObserver.takeRecords() as LayoutShiftEntry[]),
+      );
       observers.push(clsObserver);
     }
 
     if (supportsEntryType('event')) {
       const inpObserver = new PerformanceObserver((entryList) => {
-        for (const entry of entryList.getEntries() as EventTimingEntry[]) {
-          if (entry.interactionId != null && entry.interactionId > 0) {
-            const value = entry.duration;
-            if (
-              maxInteractionDuration == null ||
-              value > maxInteractionDuration.value
-            ) {
-              maxInteractionDuration = {
-                route: routeRef.current,
-                value,
-              };
-              hasPendingRouteMetrics = true;
-            }
-          }
-        }
+        processEventEntries(entryList.getEntries() as EventTimingEntry[]);
       });
       inpObserver.observe({
         type: 'event',
         buffered: true,
         durationThreshold: 40,
       } as PerformanceObserverInit);
+      pendingRecordDrainers.push(() =>
+        processEventEntries(inpObserver.takeRecords() as EventTimingEntry[]),
+      );
       observers.push(inpObserver);
     }
 
@@ -222,22 +263,31 @@ export function RouteWebVitals() {
       }
 
       reportedFinalMetrics = true;
-      reportCurrentRouteMetrics();
+      flushCurrentRouteMetrics();
       reportRouteMetricsRef.current = null;
     };
 
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'hidden') {
-        reportCurrentRouteMetrics();
+        flushCurrentRouteMetrics();
       }
     };
 
+    const handlePageHide = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        flushCurrentRouteMetrics();
+        return;
+      }
+
+      reportFinalMetrics();
+    };
+
     document.addEventListener('visibilitychange', handleVisibilityChange);
-    window.addEventListener('pagehide', reportFinalMetrics);
+    window.addEventListener('pagehide', handlePageHide);
 
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
-      window.removeEventListener('pagehide', reportFinalMetrics);
+      window.removeEventListener('pagehide', handlePageHide);
       reportRouteMetricsRef.current = null;
       for (const observer of observers) {
         observer.disconnect();

--- a/app/components/RouteWebVitals.tsx
+++ b/app/components/RouteWebVitals.tsx
@@ -282,12 +282,21 @@ export function RouteWebVitals() {
       reportFinalMetrics();
     };
 
+    const handlePageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        reportedFinalMetrics = false;
+        reportRouteMetricsRef.current = flushCurrentRouteMetrics;
+      }
+    };
+
     document.addEventListener('visibilitychange', handleVisibilityChange);
     window.addEventListener('pagehide', handlePageHide);
+    window.addEventListener('pageshow', handlePageShow);
 
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       window.removeEventListener('pagehide', handlePageHide);
+      window.removeEventListener('pageshow', handlePageShow);
       reportRouteMetricsRef.current = null;
       for (const observer of observers) {
         observer.disconnect();

--- a/app/components/RouteWebVitals.tsx
+++ b/app/components/RouteWebVitals.tsx
@@ -84,17 +84,23 @@ export function RouteWebVitals() {
     const observers: PerformanceObserver[] = [];
     let clsSessionWindow = createClsSessionWindow();
     let hasClsSupport = false;
+    let hasPendingRouteMetrics = false;
     let largestContentfulPaint: MetricValue | null = null;
     let maxInteractionDuration: MetricValue | null = null;
     let reportedFinalMetrics = false;
 
     const resetRouteMetrics = () => {
       clsSessionWindow = createClsSessionWindow();
+      hasPendingRouteMetrics = false;
       largestContentfulPaint = null;
       maxInteractionDuration = null;
     };
 
     const reportCurrentRouteMetrics = () => {
+      if (!hasPendingRouteMetrics) {
+        return;
+      }
+
       if (largestContentfulPaint != null) {
         captureMetric(
           'LCP',
@@ -103,7 +109,7 @@ export function RouteWebVitals() {
         );
       }
 
-      if (hasClsSupport) {
+      if (hasClsSupport && clsSessionWindow.maxValue > 0) {
         captureMetric('CLS', clsSessionWindow.maxValue, routeRef.current);
       }
 
@@ -139,6 +145,7 @@ export function RouteWebVitals() {
             route: routeRef.current,
             value: entry.startTime,
           };
+          hasPendingRouteMetrics = true;
         }
       });
       lcpObserver.observe({
@@ -176,6 +183,7 @@ export function RouteWebVitals() {
             clsSessionWindow.maxValue,
             clsSessionWindow.currentValue,
           );
+          hasPendingRouteMetrics = true;
         }
       });
       clsObserver.observe({ type: 'layout-shift', buffered: true });
@@ -195,6 +203,7 @@ export function RouteWebVitals() {
                 route: routeRef.current,
                 value,
               };
+              hasPendingRouteMetrics = true;
             }
           }
         }
@@ -219,7 +228,7 @@ export function RouteWebVitals() {
 
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'hidden') {
-        reportFinalMetrics();
+        reportCurrentRouteMetrics();
       }
     };
 

--- a/app/helpers/getRouteTelemetryPath.test.ts
+++ b/app/helpers/getRouteTelemetryPath.test.ts
@@ -24,4 +24,9 @@ describe('getRouteTelemetryPath', () => {
     );
     expect(getRouteTelemetryPath('/status/CCL')).toBe('/status/:lineId');
   });
+
+  it('buckets unknown routes to a fixed not-found path', () => {
+    expect(getRouteTelemetryPath('/en-SG/2026-05-31-random')).toBe('/404');
+    expect(getRouteTelemetryPath('/unexpected/deep/path')).toBe('/404');
+  });
 });

--- a/app/helpers/getRouteTelemetryPath.test.ts
+++ b/app/helpers/getRouteTelemetryPath.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { getRouteTelemetryPath } from './getRouteTelemetryPath';
+
+describe('getRouteTelemetryPath', () => {
+  it('normalizes supported localized public routes', () => {
+    expect(getRouteTelemetryPath('/en-SG')).toBe('/');
+    expect(getRouteTelemetryPath('/zh-Hans/statistics')).toBe('/statistics');
+    expect(getRouteTelemetryPath('/ms/history/2026/05')).toBe(
+      '/history/:year/:month',
+    );
+    expect(getRouteTelemetryPath('/ta/history/page/3')).toBe(
+      '/history/page/:pageNum',
+    );
+  });
+
+  it('removes high-cardinality entity IDs', () => {
+    expect(getRouteTelemetryPath('/lines/EWL')).toBe('/lines/:lineId');
+    expect(getRouteTelemetryPath('/operators/SMRT')).toBe(
+      '/operators/:operatorId',
+    );
+    expect(getRouteTelemetryPath('/stations/NS1')).toBe('/stations/:stationId');
+    expect(getRouteTelemetryPath('/issues/2026-05-31-example')).toBe(
+      '/issues/:issueId',
+    );
+    expect(getRouteTelemetryPath('/status/CCL')).toBe('/status/:lineId');
+  });
+});

--- a/app/helpers/getRouteTelemetryPath.ts
+++ b/app/helpers/getRouteTelemetryPath.ts
@@ -1,0 +1,45 @@
+import { LANGUAGES } from '~/constants';
+
+export function getRouteTelemetryPath(pathname: string) {
+  const segments = pathname.split('/').filter(Boolean);
+  const routeSegments = LANGUAGES.includes(segments[0] ?? '')
+    ? segments.slice(1)
+    : segments;
+
+  if (routeSegments.length === 0) {
+    return '/';
+  }
+
+  const [route, second, third] = routeSegments;
+
+  switch (route) {
+    case 'about':
+    case 'report':
+    case 'statistics':
+    case 'system-map':
+      return `/${route}`;
+    case 'history':
+      if (second === 'page') {
+        return '/history/page/:pageNum';
+      }
+      if (second != null && third != null) {
+        return '/history/:year/:month';
+      }
+      if (second != null) {
+        return '/history/:year';
+      }
+      return '/history';
+    case 'issues':
+      return '/issues/:issueId';
+    case 'lines':
+      return '/lines/:lineId';
+    case 'operators':
+      return '/operators/:operatorId';
+    case 'stations':
+      return '/stations/:stationId';
+    case 'status':
+      return '/status/:lineId';
+    default:
+      return `/${routeSegments.join('/')}`;
+  }
+}

--- a/app/helpers/getRouteTelemetryPath.ts
+++ b/app/helpers/getRouteTelemetryPath.ts
@@ -40,6 +40,6 @@ export function getRouteTelemetryPath(pathname: string) {
     case 'status':
       return '/status/:lineId';
     default:
-      return `/${routeSegments.join('/')}`;
+      return '/404';
   }
 }

--- a/app/routes/__root.tsx
+++ b/app/routes/__root.tsx
@@ -7,6 +7,7 @@ import {
   useRouterState,
 } from '@tanstack/react-router';
 import { LANGUAGES } from '~/constants';
+import { RouteWebVitals } from '~/components/RouteWebVitals';
 import { getPosthogOptions } from '~/helpers/getPosthogOptions';
 import stylesheet from '../index.css?url';
 
@@ -66,6 +67,7 @@ function RootComponent() {
         apiKey={import.meta.env.VITE_PUBLIC_POSTHOG_KEY}
         options={posthogOptions}
       >
+        <RouteWebVitals />
         <Outlet />
       </PostHogProvider>
     </RootDocument>

--- a/docs/plans/active/production-performance.md
+++ b/docs/plans/active/production-performance.md
@@ -311,6 +311,10 @@ underlying compute and payload costs so uncached requests are also fast.
   a dataset when the v1 snapshot shape is available, while legacy
   statistics-only snapshot rows still fall back to the previous included-entity
   assembly path.
+- 2026-05-31: Started Phase 5 production Web Vitals telemetry. The root route
+  now captures browser FCP, LCP, CLS, and approximate INP metrics through the
+  existing PostHog provider in production, tagged with normalized route paths so
+  entity IDs do not create high-cardinality analytics dimensions.
 
 ## Validation
 


### PR DESCRIPTION
## Summary

- Add production-only browser Web Vitals capture for FCP, LCP, CLS, and approximate INP through the existing PostHog provider.
- Normalize route paths before telemetry emission so entity IDs do not create high-cardinality analytics dimensions.
- Record the Phase 5 progress note in the production performance plan.

## Validation

- `npm run verify`
- `npm run build`

Notes: the first sandboxed `npm run verify` attempt failed because `tsx` could not create its IPC pipe; rerunning outside the sandbox passed. The production build passed with existing warnings for Sentry auth token absence, Wrangler log-write permissions, ignored route helper files, and large chunks.