### PR TITLE
fix: filter unscoped crowd report signals

### DIFF
--- a/app/util/crowdReports.test.ts
+++ b/app/util/crowdReports.test.ts
@@ -1,3 +1,5 @@
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { DateTime } from 'luxon';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -1220,6 +1222,18 @@ describe('automoderateCrowdReport', () => {
 });
 
 describe('getPublicCrowdReportSignals', () => {
+  it('requires cluster affected-area scope before applying the result limit', async () => {
+    const fake = makeFakePublicSignalDb();
+
+    await getPublicCrowdReportSignals(fake.db as never);
+
+    const dialect = new PgDialect();
+    const whereSql = dialect.sqlToQuery(fake.whereCalls[0] as SQL).sql;
+
+    expect(whereSql).toContain('crowd_report_cluster_lines');
+    expect(whereSql).toContain('crowd_report_cluster_stations');
+  });
+
   it('pushes route scope into the cluster query before applying the result limit', async () => {
     const fake = makeFakePublicSignalDb();
 

--- a/app/util/crowdReports.ts
+++ b/app/util/crowdReports.ts
@@ -242,6 +242,21 @@ function hasCrowdReportClusterCurrentConfidenceSql(
   )} >= ${minDistinctIpHashes}`;
 }
 
+function hasCrowdReportClusterScopeSql() {
+  return sql`(
+    exists (
+      select 1
+      from ${crowdReportClusterLinesTable}
+      where ${crowdReportClusterLinesTable.cluster_id} = ${crowdReportClustersTable.id}
+    )
+    or exists (
+      select 1
+      from ${crowdReportClusterStationsTable}
+      where ${crowdReportClusterStationsTable.cluster_id} = ${crowdReportClustersTable.id}
+    )
+  )`;
+}
+
 function normalizePolicyText(value: string) {
   return value.trim().toLocaleLowerCase().replace(/\s+/g, ' ');
 }
@@ -1271,6 +1286,7 @@ export async function getPublicCrowdReportSignals(
     .where(
       and(
         eq(crowdReportClustersTable.status, 'accepted'),
+        hasCrowdReportClusterScopeSql(),
         hasCrowdReportClusterCurrentConfidenceSql(
           options.minReportCount ?? DEFAULT_PUBLIC_SIGNAL_MIN_REPORTS,
           options.minDistinctIpHashes ??

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -440,6 +440,9 @@ Exit criteria:
   or preview databases. It samples existing line and station data, creates
   recent automoderated reports including a public-signal cluster and from/to
   affected-stop examples, and stays separate from canonical fixture seeding.
+- 2026-05-31: Tightened public community-signal querying so clusters without
+  persisted line or station scope are excluded before result limits are applied,
+  matching the affected-area requirement for displayable crowd-report clusters.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Require public crowd-report community signal queries to include persisted cluster line or station scope before result limits are applied.
- Add a regression test that compiles the Drizzle predicate and verifies affected-area scope is part of the query.
- Record the crowdsourced-report plan progress entry.

## Impact

Unscoped accepted crowd-report clusters can no longer consume public community-signal result slots or reach display code. This keeps the public UI aligned with the affected-area requirement in the crowdsourced reports plan.

## Validation

- `npm run verify`