### PR TITLE
fix: filter unscoped crowd report dispatch

### DIFF
--- a/app/util/crowdReportDispatch.test.ts
+++ b/app/util/crowdReportDispatch.test.ts
@@ -1,10 +1,41 @@
 import { IngestPayloadSchema } from '@mrtdown/ingest-contracts';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { describe, expect, it, vi } from 'vitest';
 import {
   buildCrowdReportIngestPayload,
   buildCrowdReportSourceUrl,
   dispatchCrowdReportPayloadToGitHub,
+  getDispatchableCrowdReportCandidates,
 } from './crowdReportDispatch';
+
+function makeFakeCandidateDb() {
+  const whereCalls: unknown[] = [];
+  const selectBuilder = {
+    from() {
+      return this;
+    },
+    where(condition: unknown) {
+      whereCalls.push(condition);
+      return this;
+    },
+    orderBy() {
+      return this;
+    },
+    limit() {
+      return Promise.resolve([]);
+    },
+  };
+
+  return {
+    whereCalls,
+    db: {
+      select() {
+        return selectBuilder;
+      },
+    },
+  };
+}
 
 describe('buildCrowdReportIngestPayload', () => {
   it('builds a valid crowd-report ingest payload without site-local metadata', () => {
@@ -69,6 +100,24 @@ describe('buildCrowdReportSourceUrl', () => {
     expect(
       buildCrowdReportSourceUrl('https://mrtdown.example', 'report', 'r1'),
     ).toBe('https://mrtdown.example/report?communitySource=report%3Ar1');
+  });
+});
+
+describe('getDispatchableCrowdReportCandidates', () => {
+  it('requires single-report affected-area scope before applying the result limit', async () => {
+    const fake = makeFakeCandidateDb();
+
+    await getDispatchableCrowdReportCandidates(fake.db as never, {
+      kind: 'report',
+      limit: 1,
+      rootUrl: 'https://mrtdown.example',
+    });
+
+    const dialect = new PgDialect();
+    const whereSql = dialect.sqlToQuery(fake.whereCalls[0] as SQL).sql;
+
+    expect(whereSql).toContain('crowd_report_lines');
+    expect(whereSql).toContain('crowd_report_stations');
   });
 });
 

--- a/app/util/crowdReportDispatch.ts
+++ b/app/util/crowdReportDispatch.ts
@@ -109,6 +109,13 @@ function hasCrowdReportClusterScope() {
   );
 }
 
+function hasCrowdReportScope() {
+  return or(
+    sql`exists (select 1 from ${crowdReportLinesTable} where ${crowdReportLinesTable.report_id} = ${crowdReportsTable.id})`,
+    sql`exists (select 1 from ${crowdReportStationsTable} where ${crowdReportStationsTable.report_id} = ${crowdReportsTable.id})`,
+  );
+}
+
 function hasCrowdReportClusterCurrentConfidence() {
   return sql`(
     select count(*)
@@ -375,6 +382,7 @@ async function getDispatchableSingleCrowdReportCandidates(
         eq(crowdReportsTable.status, 'accepted'),
         isNull(crowdReportsTable.dispatched_at),
         isNull(crowdReportsTable.cluster_id),
+        hasCrowdReportScope(),
       ),
     )
     .orderBy(desc(crowdReportsTable.observed_at))
@@ -609,6 +617,7 @@ async function isCrowdReportDispatchCandidateEligible(
         eq(crowdReportsTable.status, 'accepted'),
         isNull(crowdReportsTable.dispatched_at),
         isNull(crowdReportsTable.cluster_id),
+        hasCrowdReportScope(),
       ),
     )
     .limit(1);

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -432,6 +432,9 @@ Exit criteria:
   high-confidence public and dispatchable clusters to satisfy report-count and
   source-diversity thresholds using reports that explicitly say the issue is
   still happening.
+- 2026-05-31: Tightened single-report canonical dispatch candidate selection so
+  accepted reports without persisted line or station scope are excluded before
+  dispatch batch limits are applied and rechecked under the dispatch lock.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Require accepted single-report dispatch candidates to have persisted line or station scope before dispatch batch limits are applied.
- Recheck single-report affected-area scope under the dispatch advisory lock before canonical ingest dispatch.
- Add a focused SQL-shape regression test and record the progress in the crowdsourced reports plan.

## Validation

- `npm run test:run -- app/util/crowdReportDispatch.test.ts`
- `npm run verify`

Note: full verification was run outside the sandbox because the sandbox previously blocked `tsx` IPC pipe creation during `db:generate:check` with `listen EPERM`.