### PR TITLE
test: cover crowd report cluster dispatch scope

### DIFF
--- a/app/util/crowdReportDispatch.test.ts
+++ b/app/util/crowdReportDispatch.test.ts
@@ -104,6 +104,22 @@ describe('buildCrowdReportSourceUrl', () => {
 });
 
 describe('getDispatchableCrowdReportCandidates', () => {
+  it('requires cluster affected-area scope before applying the result limit', async () => {
+    const fake = makeFakeCandidateDb();
+
+    await getDispatchableCrowdReportCandidates(fake.db as never, {
+      kind: 'cluster',
+      limit: 1,
+      rootUrl: 'https://mrtdown.example',
+    });
+
+    const dialect = new PgDialect();
+    const whereSql = dialect.sqlToQuery(fake.whereCalls[0] as SQL).sql;
+
+    expect(whereSql).toContain('crowd_report_cluster_lines');
+    expect(whereSql).toContain('crowd_report_cluster_stations');
+  });
+
   it('requires single-report affected-area scope before applying the result limit', async () => {
     const fake = makeFakeCandidateDb();
 

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -446,6 +446,9 @@ Exit criteria:
 - 2026-05-31: Tightened single-report canonical dispatch candidate selection so
   accepted reports without persisted line or station scope are excluded before
   dispatch batch limits are applied and rechecked under the dispatch lock.
+- 2026-06-10: Added explicit regression coverage for Phase 5 cluster dispatch
+  candidate selection so accepted clusters must retain persisted line or station
+  scope before dispatch limits are applied.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Add regression coverage that cluster crowd-report dispatch candidate selection requires persisted line or station scope before result limits are applied.
- Update the active crowdsourced reports plan log with the Phase 5 continuation.

## Validation

- `npm run test:run -- app/util/crowdReportDispatch.test.ts`
- `npm run verify` (rerun with escalation after sandbox EPERM on the `tsx` IPC pipe used by `db:generate:check`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for cluster dispatch candidate selection to validate persisted scope handling.

* **Chores**
  * Updated progress documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->