### PR TITLE
fix: harden crowd report cluster dispatch

### DIFF
--- a/app/util/crowdReportDispatch.test.ts
+++ b/app/util/crowdReportDispatch.test.ts
@@ -7,6 +7,7 @@ import {
   buildCrowdReportSourceUrl,
   dispatchCrowdReportPayloadToGitHub,
   getDispatchableCrowdReportCandidates,
+  markCrowdReportDispatchSuccess,
 } from './crowdReportDispatch';
 
 function makeFakeCandidateDb() {
@@ -32,6 +33,97 @@ function makeFakeCandidateDb() {
     db: {
       select() {
         return selectBuilder;
+      },
+    },
+  };
+}
+
+function makeFakeClusterCandidateDb() {
+  const whereCalls: unknown[] = [];
+  const selectResults = [
+    [
+      {
+        id: 'cluster-1',
+        effect: 'delay',
+        reportCount: 1,
+        windowEndAt: '2026-05-24T04:40:00.000Z',
+        updatedAt: '2026-05-24T04:45:00.000Z',
+      },
+    ],
+    [{ clusterId: 'cluster-1', lineId: 'BPLRT' }],
+    [{ clusterId: 'cluster-1', stationId: 'BP6' }],
+    [
+      {
+        id: 'report-1',
+        clusterId: 'cluster-1',
+        observedAt: '2026-05-24T04:30:00.000Z',
+        text: 'Train stalled near the platform for several minutes.',
+        directionText: 'Towards Choa Chu Kang',
+        delayMinutes: 10,
+        stillHappening: true,
+      },
+    ],
+  ];
+  let selectCount = 0;
+
+  return {
+    whereCalls,
+    db: {
+      select() {
+        const selectIndex = selectCount;
+        selectCount += 1;
+        return {
+          from() {
+            return this;
+          },
+          where(condition: unknown) {
+            whereCalls.push(condition);
+            if (selectIndex === 1 || selectIndex === 2) {
+              return Promise.resolve(selectResults[selectIndex]);
+            }
+            return this;
+          },
+          orderBy() {
+            if (selectIndex === 3) {
+              return Promise.resolve(selectResults[selectIndex]);
+            }
+            return this;
+          },
+          limit() {
+            return Promise.resolve(selectResults[selectIndex]);
+          },
+        };
+      },
+    },
+  };
+}
+
+function makeFakeDispatchUpdateDb() {
+  const whereCalls: unknown[] = [];
+  const updateBuilder = {
+    set() {
+      return {
+        where(condition: unknown) {
+          whereCalls.push(condition);
+          return Promise.resolve();
+        },
+      };
+    },
+  };
+
+  return {
+    whereCalls,
+    db: {
+      transaction<T>(
+        callback: (transaction: {
+          update: () => typeof updateBuilder;
+        }) => Promise<T>,
+      ) {
+        return callback({
+          update() {
+            return updateBuilder;
+          },
+        });
       },
     },
   };
@@ -118,6 +210,8 @@ describe('getDispatchableCrowdReportCandidates', () => {
 
     expect(whereSql).toContain('crowd_report_cluster_lines');
     expect(whereSql).toContain('crowd_report_cluster_stations');
+    expect(whereSql).toContain('still_happening');
+    expect(whereSql).toContain('count(distinct');
   });
 
   it('requires single-report affected-area scope before applying the result limit', async () => {
@@ -134,6 +228,67 @@ describe('getDispatchableCrowdReportCandidates', () => {
 
     expect(whereSql).toContain('crowd_report_lines');
     expect(whereSql).toContain('crowd_report_stations');
+  });
+
+  it('builds cluster dispatch payloads from ongoing reports only', async () => {
+    const fake = makeFakeClusterCandidateDb();
+
+    await getDispatchableCrowdReportCandidates(fake.db as never, {
+      kind: 'cluster',
+      limit: 1,
+      rootUrl: 'https://mrtdown.example',
+    });
+
+    const dialect = new PgDialect();
+    const reportRowsWhereSql = dialect.sqlToQuery(
+      fake.whereCalls[3] as SQL,
+    ).sql;
+
+    expect(reportRowsWhereSql).toContain('"still_happening" =');
+  });
+
+  it('marks only the report IDs included in a cluster dispatch payload', async () => {
+    const fake = makeFakeDispatchUpdateDb();
+
+    await markCrowdReportDispatchSuccess(
+      fake.db as never,
+      {
+        kind: 'cluster',
+        id: 'cluster-1',
+        reportIds: ['ongoing-report-1', 'ongoing-report-2'],
+        payload: IngestPayloadSchema.parse({
+          content: [
+            {
+              source: 'crowd-report',
+              reportId: 'cluster:cluster-1',
+              text: 'Two community reports describe this issue.',
+              createdAt: '2026-05-24T04:40:00.000Z',
+              observedAt: '2026-05-24T12:30:00.000+08:00',
+              lineIds: ['BPLRT'],
+              reportCount: 2,
+              url: 'https://mrtdown.example/report?communitySource=cluster%3Acluster-1',
+            },
+          ],
+        }),
+      },
+      '2026-05-24T04:45:00.000Z',
+    );
+
+    const dialect = new PgDialect();
+    const clusterUpdateWhereSql = dialect.sqlToQuery(
+      fake.whereCalls[0] as SQL,
+    ).sql;
+    const reportUpdateWhereSql = dialect.sqlToQuery(
+      fake.whereCalls[1] as SQL,
+    ).sql;
+
+    expect(clusterUpdateWhereSql).toContain('not exists');
+    expect(clusterUpdateWhereSql).toContain('"still_happening" is true');
+    expect(clusterUpdateWhereSql).toContain('"crowd_reports"."id" not in');
+    expect(reportUpdateWhereSql).toContain('"crowd_reports"."id" in');
+    expect(reportUpdateWhereSql).not.toContain(
+      '"crowd_reports"."cluster_id" =',
+    );
   });
 });
 

--- a/app/util/crowdReportDispatch.ts
+++ b/app/util/crowdReportDispatch.ts
@@ -4,7 +4,16 @@ import {
   type IngestContentCrowdReport,
   type IngestPayload,
 } from '@mrtdown/ingest-contracts';
-import { and, desc, eq, inArray, isNull, or, sql } from 'drizzle-orm';
+import {
+  and,
+  desc,
+  eq,
+  inArray,
+  isNull,
+  notInArray,
+  or,
+  sql,
+} from 'drizzle-orm';
 import { DateTime } from 'luxon';
 import {
   crowdReportAbuseEventsTable,
@@ -117,21 +126,29 @@ function hasCrowdReportScope() {
 }
 
 function hasCrowdReportClusterCurrentConfidence() {
-  return sql`(
-    select count(*)
+  return sql`${getCrowdReportClusterOngoingReportCountSql()} >= ${DEFAULT_DISPATCH_MIN_ONGOING_REPORTS} and ${getCrowdReportClusterOngoingDistinctIpHashCountSql()} >= ${DEFAULT_DISPATCH_MIN_DISTINCT_IP_HASHES}`;
+}
+
+function getCrowdReportClusterOngoingReportCountSql() {
+  return sql<number>`(
+    select count(*)::int
     from ${crowdReportsTable}
     where ${crowdReportsTable.cluster_id} = ${crowdReportClustersTable.id}
       and ${crowdReportsTable.status} in ('accepted', 'duplicate')
       and ${crowdReportsTable.still_happening} is true
-  ) >= ${DEFAULT_DISPATCH_MIN_ONGOING_REPORTS} and (
-    select count(distinct ${crowdReportAbuseEventsTable.ip_hash})
+  )`;
+}
+
+function getCrowdReportClusterOngoingDistinctIpHashCountSql() {
+  return sql<number>`(
+    select count(distinct ${crowdReportAbuseEventsTable.ip_hash})::int
     from ${crowdReportAbuseEventsTable}
     inner join ${crowdReportsTable}
       on ${crowdReportsTable.id} = ${crowdReportAbuseEventsTable.report_id}
     where ${crowdReportsTable.cluster_id} = ${crowdReportClustersTable.id}
       and ${crowdReportsTable.status} in ('accepted', 'duplicate')
       and ${crowdReportsTable.still_happening} is true
-  ) >= ${DEFAULT_DISPATCH_MIN_DISTINCT_IP_HASHES}`;
+  )`;
 }
 
 export function buildCrowdReportSourceUrl(
@@ -256,7 +273,7 @@ async function getDispatchableCrowdReportClusterCandidates(
     .select({
       id: crowdReportClustersTable.id,
       effect: crowdReportClustersTable.effect,
-      reportCount: crowdReportClustersTable.report_count,
+      reportCount: getCrowdReportClusterOngoingReportCountSql(),
       windowEndAt: crowdReportClustersTable.window_end_at,
       updatedAt: crowdReportClustersTable.updated_at,
     })
@@ -307,6 +324,7 @@ async function getDispatchableCrowdReportClusterCandidates(
         and(
           inArray(crowdReportsTable.cluster_id, clusterIds),
           inArray(crowdReportsTable.status, ['accepted', 'duplicate']),
+          eq(crowdReportsTable.still_happening, true),
         ),
       )
       .orderBy(desc(crowdReportsTable.observed_at)),
@@ -534,7 +552,12 @@ async function markCrowdReportDispatchSuccessInTransaction(
         dispatched_at: dispatchedAt,
         updated_at: sql`now()`,
       })
-      .where(eq(crowdReportClustersTable.id, candidate.id));
+      .where(
+        and(
+          eq(crowdReportClustersTable.id, candidate.id),
+          hasNoOngoingClusterReportsOutsideDispatchPayload(candidate),
+        ),
+      );
   }
 
   await tx
@@ -567,14 +590,20 @@ async function markCrowdReportDispatchFailureInTransaction(
 function getCrowdReportDispatchReportScope(
   candidate: CrowdReportDispatchCandidate,
 ) {
-  if (candidate.kind === 'cluster') {
-    return and(
-      eq(crowdReportsTable.cluster_id, candidate.id),
-      inArray(crowdReportsTable.status, ['accepted', 'duplicate']),
-    );
-  }
-
   return inArray(crowdReportsTable.id, candidate.reportIds);
+}
+
+function hasNoOngoingClusterReportsOutsideDispatchPayload(
+  candidate: CrowdReportDispatchCandidate,
+) {
+  return sql`not exists (
+    select 1
+    from ${crowdReportsTable}
+    where ${crowdReportsTable.cluster_id} = ${candidate.id}
+      and ${crowdReportsTable.status} in ('accepted', 'duplicate')
+      and ${crowdReportsTable.still_happening} is true
+      and ${notInArray(crowdReportsTable.id, candidate.reportIds)}
+  )`;
 }
 
 async function tryAcquireCrowdReportDispatchLock(

--- a/app/util/crowdReports.test.ts
+++ b/app/util/crowdReports.test.ts
@@ -1232,6 +1232,12 @@ describe('getPublicCrowdReportSignals', () => {
 
     expect(whereSql).toContain('crowd_report_cluster_lines');
     expect(whereSql).toContain('crowd_report_cluster_stations');
+    expect(whereSql).toContain('still_happening');
+    expect(whereSql).toContain('count(distinct');
+    expect(whereSql).toContain('max("crowd_reports"."observed_at")');
+    expect(whereSql).not.toContain(
+      '"crowd_report_clusters"."window_end_at" >=',
+    );
   });
 
   it('pushes route scope into the cluster query before applying the result limit', async () => {

--- a/app/util/crowdReports.ts
+++ b/app/util/crowdReports.ts
@@ -209,7 +209,7 @@ function getCrowdReportClusterOngoingReportCountSql(
   clusterId: string | typeof crowdReportClustersTable.id,
 ) {
   return sql<number>`(
-    select count(*)
+    select count(*)::int
     from ${crowdReportsTable}
     where ${crowdReportsTable.cluster_id} = ${clusterId}
       and ${crowdReportsTable.status} in ('accepted', 'duplicate')
@@ -221,10 +221,34 @@ function getCrowdReportClusterOngoingDistinctIpHashCountSql(
   clusterId: string | typeof crowdReportClustersTable.id,
 ) {
   return sql<number>`(
-    select count(distinct ${crowdReportAbuseEventsTable.ip_hash})
+    select count(distinct ${crowdReportAbuseEventsTable.ip_hash})::int
     from ${crowdReportAbuseEventsTable}
     inner join ${crowdReportsTable}
       on ${crowdReportsTable.id} = ${crowdReportAbuseEventsTable.report_id}
+    where ${crowdReportsTable.cluster_id} = ${clusterId}
+      and ${crowdReportsTable.status} in ('accepted', 'duplicate')
+      and ${crowdReportsTable.still_happening} is true
+  )`;
+}
+
+function getCrowdReportClusterOngoingWindowStartAtSql(
+  clusterId: string | typeof crowdReportClustersTable.id,
+) {
+  return sql<string>`(
+    select min(${crowdReportsTable.observed_at})
+    from ${crowdReportsTable}
+    where ${crowdReportsTable.cluster_id} = ${clusterId}
+      and ${crowdReportsTable.status} in ('accepted', 'duplicate')
+      and ${crowdReportsTable.still_happening} is true
+  )`;
+}
+
+function getCrowdReportClusterOngoingWindowEndAtSql(
+  clusterId: string | typeof crowdReportClustersTable.id,
+) {
+  return sql<string>`(
+    select max(${crowdReportsTable.observed_at})
+    from ${crowdReportsTable}
     where ${crowdReportsTable.cluster_id} = ${clusterId}
       and ${crowdReportsTable.status} in ('accepted', 'duplicate')
       and ${crowdReportsTable.still_happening} is true
@@ -1277,9 +1301,15 @@ export async function getPublicCrowdReportSignals(
     .select({
       id: crowdReportClustersTable.id,
       effect: crowdReportClustersTable.effect,
-      reportCount: crowdReportClustersTable.report_count,
-      windowStartAt: crowdReportClustersTable.window_start_at,
-      windowEndAt: crowdReportClustersTable.window_end_at,
+      reportCount: getCrowdReportClusterOngoingReportCountSql(
+        crowdReportClustersTable.id,
+      ),
+      windowStartAt: getCrowdReportClusterOngoingWindowStartAtSql(
+        crowdReportClustersTable.id,
+      ),
+      windowEndAt: getCrowdReportClusterOngoingWindowEndAtSql(
+        crowdReportClustersTable.id,
+      ),
       updatedAt: crowdReportClustersTable.updated_at,
     })
     .from(crowdReportClustersTable)
@@ -1292,7 +1322,12 @@ export async function getPublicCrowdReportSignals(
           options.minDistinctIpHashes ??
             DEFAULT_PUBLIC_SIGNAL_MIN_DISTINCT_IP_HASHES,
         ),
-        gte(crowdReportClustersTable.window_end_at, activeSince),
+        gte(
+          getCrowdReportClusterOngoingWindowEndAtSql(
+            crowdReportClustersTable.id,
+          ),
+          activeSince,
+        ),
         options.lineId
           ? sql`exists (select 1 from ${crowdReportClusterLinesTable} where ${crowdReportClusterLinesTable.cluster_id} = ${crowdReportClustersTable.id} and ${crowdReportClusterLinesTable.line_id} = ${options.lineId})`
           : undefined,
@@ -1301,7 +1336,11 @@ export async function getPublicCrowdReportSignals(
           : undefined,
       ),
     )
-    .orderBy(desc(crowdReportClustersTable.window_end_at))
+    .orderBy(
+      desc(
+        getCrowdReportClusterOngoingWindowEndAtSql(crowdReportClustersTable.id),
+      ),
+    )
     .limit(options.limit ?? DEFAULT_PUBLIC_SIGNAL_LIMIT);
 
   const clusterIds = clusterRows.map((cluster) => cluster.id);

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -449,6 +449,17 @@ Exit criteria:
 - 2026-06-10: Added explicit regression coverage for Phase 5 cluster dispatch
   candidate selection so accepted clusters must retain persisted line or station
   scope before dispatch limits are applied.
+- 2026-06-10: Continued Phase 6 dispatch hardening so public community-signal
+  counts and canonical cluster dispatch payloads use ongoing accepted or
+  duplicate reports only, with regression coverage for ongoing-source
+  confidence predicates.
+- 2026-06-10: Addressed review feedback on Phase 6 hardening by scoping
+  dispatch success and failure report updates to the exact ongoing reports in
+  the payload, and by deriving public community-signal recency from ongoing
+  report timestamps instead of cluster-wide windows.
+- 2026-06-11: Addressed follow-up review feedback by preventing cluster dispatch
+  from closing a cluster when new ongoing accepted or duplicate reports exist
+  outside the dispatched payload's report ID set.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Count only ongoing accepted or duplicate reports when presenting public community-signal support totals.
- Build canonical cluster dispatch payloads from ongoing supporting reports only.
- Add regression coverage for ongoing-source confidence predicates and dispatch report-row filtering.

## Why

Crowd-report clusters can contain historical or resolved reports after a cluster is accepted. Dispatch and public display should reflect current supporting evidence, not stale cluster row totals.

## Validation

- `npm run test:run -- app/util/crowdReports.test.ts app/util/crowdReportDispatch.test.ts`
- `npm run verify`

Note: the first sandboxed `npm run verify` failed because `tsx` could not create its IPC pipe under `/var/folders`; the escalated rerun passed fully.