### PR TITLE
perf: lazy-load statistics charts

### DIFF
--- a/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/StatisticsGridSkeleton/index.tsx
+++ b/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/StatisticsGridSkeleton/index.tsx
@@ -27,7 +27,7 @@ function CardSkeleton(props: React.PropsWithChildren) {
   );
 }
 
-function TrendCardSkeleton() {
+export function TrendCardSkeleton() {
   return (
     <CardSkeleton>
       <div className="mb-2 h-5 w-56 rounded-md bg-gray-200 dark:bg-gray-700" />
@@ -67,7 +67,7 @@ function TrendCardSkeleton() {
   );
 }
 
-function HeatmapCardSkeleton() {
+export function HeatmapCardSkeleton() {
   return (
     <CardSkeleton>
       <div className="mb-1 h-5 w-48 rounded-md bg-gray-200 dark:bg-gray-700" />
@@ -119,7 +119,7 @@ interface BarChartCardSkeletonProps {
   heightClassName: string;
 }
 
-function BarChartCardSkeleton(props: BarChartCardSkeletonProps) {
+export function BarChartCardSkeleton(props: BarChartCardSkeletonProps) {
   const { barCount, heightClassName } = props;
   const barIds = barCount === 15 ? STATION_BAR_IDS : LINE_BAR_IDS;
 
@@ -148,7 +148,7 @@ function BarChartCardSkeleton(props: BarChartCardSkeletonProps) {
   );
 }
 
-function LongestDisruptionsCardSkeleton() {
+export function LongestDisruptionsCardSkeleton() {
   return (
     <CardSkeleton>
       <div className="mb-4 h-5 w-44 rounded-md bg-gray-200 dark:bg-gray-700" />

--- a/app/routes/{-$lang}/statistics/components/StatisticsGrid/index.tsx
+++ b/app/routes/{-$lang}/statistics/components/StatisticsGrid/index.tsx
@@ -1,11 +1,38 @@
+import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 import type React from 'react';
 import type { SystemAnalytics } from '~/util/db.queries';
-import { CountTrendCards } from './components/CountTrendCards';
-import { DisruptionsHeatmap } from './components/DisruptionsHeatmap';
-import { DurationTrendCards } from './components/DurationTrendCards';
-import { LinesIssueCountCard } from './components/LinesIssueCountCard';
 import { LongestDisruptionsCard } from './components/LongestDisruptionsCard';
-import { StationsIssueCountCard } from './components/StationsIssueCountCard';
+import {
+  BarChartCardSkeleton,
+  HeatmapCardSkeleton,
+  TrendCardSkeleton,
+} from './components/StatisticsGridSkeleton';
+
+const CountTrendCards = lazy(() =>
+  import('./components/CountTrendCards').then((module) => ({
+    default: module.CountTrendCards,
+  })),
+);
+const DisruptionsHeatmap = lazy(() =>
+  import('./components/DisruptionsHeatmap').then((module) => ({
+    default: module.DisruptionsHeatmap,
+  })),
+);
+const DurationTrendCards = lazy(() =>
+  import('./components/DurationTrendCards').then((module) => ({
+    default: module.DurationTrendCards,
+  })),
+);
+const LinesIssueCountCard = lazy(() =>
+  import('./components/LinesIssueCountCard').then((module) => ({
+    default: module.LinesIssueCountCard,
+  })),
+);
+const StationsIssueCountCard = lazy(() =>
+  import('./components/StationsIssueCountCard').then((module) => ({
+    default: module.StationsIssueCountCard,
+  })),
+);
 
 interface Props {
   statistics: SystemAnalytics;
@@ -16,14 +43,74 @@ export const StatisticsGrid: React.FC<Props> = (props) => {
 
   return (
     <div className="grid grid-cols-1 gap-4 text-gray-800 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6 dark:text-gray-200">
-      <CountTrendCards graphs={statistics.timeScaleChartsIssueCount} />
-      <DisruptionsHeatmap chart={statistics.chartRollingYearHeatmap} />
-      <LinesIssueCountCard chart={statistics.chartTotalIssueCountByLine} />
+      <DeferredStatisticsCard fallback={<TrendCardSkeleton />}>
+        <CountTrendCards graphs={statistics.timeScaleChartsIssueCount} />
+      </DeferredStatisticsCard>
+      <DeferredStatisticsCard fallback={<HeatmapCardSkeleton />}>
+        <DisruptionsHeatmap chart={statistics.chartRollingYearHeatmap} />
+      </DeferredStatisticsCard>
+      <DeferredStatisticsCard
+        fallback={<BarChartCardSkeleton barCount={8} heightClassName="h-64" />}
+      >
+        <LinesIssueCountCard chart={statistics.chartTotalIssueCountByLine} />
+      </DeferredStatisticsCard>
       <LongestDisruptionsCard issueIds={statistics.issueIdsDisruptionLongest} />
-      <StationsIssueCountCard
-        chart={statistics.chartTotalIssueCountByStation}
-      />
-      <DurationTrendCards graphs={statistics.timeScaleChartsIssueDuration} />
+      <DeferredStatisticsCard
+        fallback={<BarChartCardSkeleton barCount={15} heightClassName="h-72" />}
+      >
+        <StationsIssueCountCard
+          chart={statistics.chartTotalIssueCountByStation}
+        />
+      </DeferredStatisticsCard>
+      <DeferredStatisticsCard fallback={<TrendCardSkeleton />}>
+        <DurationTrendCards graphs={statistics.timeScaleChartsIssueDuration} />
+      </DeferredStatisticsCard>
     </div>
   );
 };
+
+interface DeferredStatisticsCardProps {
+  children: React.ReactNode;
+  fallback: React.ReactNode;
+}
+
+function DeferredStatisticsCard(props: DeferredStatisticsCardProps) {
+  const { children, fallback } = props;
+  const [shouldRender, setShouldRender] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (shouldRender) {
+      return;
+    }
+
+    const container = containerRef.current;
+    if (container == null || !('IntersectionObserver' in window)) {
+      setShouldRender(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setShouldRender(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: '600px 0px' },
+    );
+
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [shouldRender]);
+
+  return (
+    <div className="col-span-6" ref={containerRef}>
+      {shouldRender ? (
+        <Suspense fallback={fallback}>{children}</Suspense>
+      ) : (
+        fallback
+      )}
+    </div>
+  );
+}

--- a/docs/plans/active/production-performance.md
+++ b/docs/plans/active/production-performance.md
@@ -315,6 +315,13 @@ underlying compute and payload costs so uncached requests are also fast.
   now captures browser FCP, LCP, CLS, and approximate INP metrics through the
   existing PostHog provider in production, tagged with normalized route paths so
   entity IDs do not create high-cardinality analytics dimensions.
+- 2026-06-10: Continued Phase 5 statistics hydration cleanup. The statistics
+  grid now lazy-loads chart-heavy cards behind stable skeleton placeholders and
+  an `IntersectionObserver` viewport gate, keeping Recharts and chart card code
+  out of the initial statistics route render until the cards are near view. A
+  production build emits separate client chunks for `CountTrendCards`,
+  `DurationTrendCards`, `LinesIssueCountCard`, `StationsIssueCountCard`, and
+  `DisruptionsHeatmap`.
 
 ## Validation
 


### PR DESCRIPTION
## Summary

- Lazy-load chart-heavy statistics cards behind stable skeleton placeholders.
- Gate chart rendering with `IntersectionObserver` so Recharts and chart card code load when cards are near the viewport.
- Update the production performance plan with the Phase 5 progress note and observed chunk split.

## Validation

- `npm run build`
- `npm run verify` (passed after rerunning outside the sandbox because the sandboxed run blocked `tsx` IPC pipe creation during `db:generate:check`)

## Notes

A local browser smoke check could not complete because the dev server crashed on page load without local Postgres listening on `localhost:5432`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Statistics page now lazy-loads chart cards as they scroll into view, reducing initial page load time.
  * Skeleton placeholders display while individual cards are fetching.

* **Documentation**
  * Updated performance optimization notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->