### PR TITLE
fix: recheck crowd report dispatch payload freshness

### DIFF
--- a/app/util/crowdReportDispatch.test.ts
+++ b/app/util/crowdReportDispatch.test.ts
@@ -6,6 +6,7 @@ import {
   buildCrowdReportIngestPayload,
   buildCrowdReportSourceUrl,
   dispatchCrowdReportPayloadToGitHub,
+  dispatchPendingCrowdReports,
   getDispatchableCrowdReportCandidates,
   markCrowdReportDispatchSuccess,
 } from './crowdReportDispatch';
@@ -122,6 +123,48 @@ function makeFakeDispatchUpdateDb() {
         return callback({
           update() {
             return updateBuilder;
+          },
+        });
+      },
+    },
+  };
+}
+
+function makeFakeDispatchEligibilityDb() {
+  const executeCalls: unknown[] = [];
+  const whereCalls: unknown[] = [];
+  const selectBuilder = {
+    from() {
+      return this;
+    },
+    where(condition: unknown) {
+      whereCalls.push(condition);
+      return this;
+    },
+    limit() {
+      return Promise.resolve([]);
+    },
+  };
+
+  return {
+    executeCalls,
+    whereCalls,
+    db: {
+      transaction<T>(
+        callback: (transaction: {
+          execute: (
+            query: unknown,
+          ) => Promise<{ rows: Array<{ locked: boolean }> }>;
+          select: () => typeof selectBuilder;
+        }) => Promise<T>,
+      ) {
+        return callback({
+          execute(query: unknown) {
+            executeCalls.push(query);
+            return Promise.resolve({ rows: [{ locked: true }] });
+          },
+          select() {
+            return selectBuilder;
           },
         });
       },
@@ -289,6 +332,53 @@ describe('getDispatchableCrowdReportCandidates', () => {
     expect(reportUpdateWhereSql).not.toContain(
       '"crowd_reports"."cluster_id" =',
     );
+  });
+
+  it('rechecks cluster payload freshness under the dispatch lock', async () => {
+    const fake = makeFakeDispatchEligibilityDb();
+    const fetchImpl = vi.fn();
+
+    await dispatchPendingCrowdReports(
+      fake.db as never,
+      {
+        rootUrl: 'https://mrtdown.example',
+        token: 'github-token',
+        candidates: [
+          {
+            kind: 'cluster',
+            id: 'cluster-1',
+            reportIds: ['ongoing-report-1', 'ongoing-report-2'],
+            payload: IngestPayloadSchema.parse({
+              content: [
+                {
+                  source: 'crowd-report',
+                  reportId: 'cluster:cluster-1',
+                  text: 'Two community reports describe this issue.',
+                  createdAt: '2026-05-24T04:40:00.000Z',
+                  observedAt: '2026-05-24T12:30:00.000+08:00',
+                  lineIds: ['BPLRT'],
+                  reportCount: 2,
+                  url: 'https://mrtdown.example/report?communitySource=cluster%3Acluster-1',
+                },
+              ],
+            }),
+          },
+        ],
+      },
+      fetchImpl,
+    );
+
+    const dialect = new PgDialect();
+    const lockSql = dialect.sqlToQuery(fake.executeCalls[0] as SQL);
+    const eligibilityWhereSql = dialect.sqlToQuery(
+      fake.whereCalls[0] as SQL,
+    ).sql;
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(lockSql.params).toContain('crowd-report-dispatch:cluster:cluster-1');
+    expect(eligibilityWhereSql).toContain('not exists');
+    expect(eligibilityWhereSql).toContain('"still_happening" is true');
+    expect(eligibilityWhereSql).toContain('"crowd_reports"."id" not in');
   });
 });
 

--- a/app/util/crowdReportDispatch.ts
+++ b/app/util/crowdReportDispatch.ts
@@ -24,6 +24,7 @@ import {
   crowdReportsTable,
   crowdReportStationsTable,
 } from '~/db/schema';
+import { buildCrowdReportDispatchLockKey } from './crowdReportLocks';
 
 const DEFAULT_DISPATCH_OWNER = 'foldaway';
 const DEFAULT_DISPATCH_REPO = 'mrtdown-data';
@@ -611,7 +612,7 @@ async function tryAcquireCrowdReportDispatchLock(
   candidate: CrowdReportDispatchCandidate,
 ) {
   const result = await tx.execute<{ locked: boolean }>(
-    sql`select pg_try_advisory_xact_lock(hashtextextended(${`crowd-report-dispatch:${candidate.kind}:${candidate.id}`}, 0::bigint)) as "locked"`,
+    sql`select pg_try_advisory_xact_lock(hashtextextended(${buildCrowdReportDispatchLockKey(candidate.kind, candidate.id)}, 0::bigint)) as "locked"`,
   );
   return result.rows[0]?.locked === true;
 }
@@ -631,6 +632,7 @@ async function isCrowdReportDispatchCandidateEligible(
           isNull(crowdReportClustersTable.dispatched_at),
           hasCrowdReportClusterScope(),
           hasCrowdReportClusterCurrentConfidence(),
+          hasNoOngoingClusterReportsOutsideDispatchPayload(candidate),
         ),
       )
       .limit(1);

--- a/app/util/crowdReportLocks.ts
+++ b/app/util/crowdReportLocks.ts
@@ -1,0 +1,8 @@
+type CrowdReportDispatchLockKind = 'cluster' | 'report';
+
+export function buildCrowdReportDispatchLockKey(
+  kind: CrowdReportDispatchLockKind,
+  id: string,
+) {
+  return `crowd-report-dispatch:${kind}:${id}`;
+}

--- a/app/util/crowdReports.test.ts
+++ b/app/util/crowdReports.test.ts
@@ -1049,6 +1049,7 @@ describe('automoderateCrowdReport', () => {
         ],
         [{ reportId: 'existing-report', lineId: 'BPLRT' }],
         [{ reportId: 'existing-report', stationId: 'BP6' }],
+        [{ id: 'cluster-1' }],
       ],
       {
         id: 'report-1',
@@ -1090,6 +1091,73 @@ describe('automoderateCrowdReport', () => {
     expect(fake.updates[2]).toMatchObject({
       table: crowdReportClustersTable,
     });
+
+    const dialect = new PgDialect();
+    const clusterLockSql = dialect.sqlToQuery(fake.executes[1] as SQL);
+    expect(clusterLockSql.sql).toContain('pg_advisory_xact_lock');
+    expect(clusterLockSql.params).toContain(
+      'crowd-report-dispatch:cluster:cluster-1',
+    );
+  });
+
+  it('starts a fresh cluster when a duplicate cluster was dispatched before the lock', async () => {
+    const fake = makeFakeAutomoderationDb(
+      [
+        [
+          {
+            id: 'existing-report',
+            status: 'accepted',
+            directionText: 'Towards Choa Chu Kang',
+            clusterId: 'cluster-1',
+          },
+        ],
+        [{ reportId: 'existing-report', lineId: 'BPLRT' }],
+        [{ reportId: 'existing-report', stationId: 'BP6' }],
+        [],
+      ],
+      {
+        id: 'report-1',
+        status: 'accepted',
+        duplicateOfId: null,
+      },
+    );
+    const ids = ['event-1', 'cluster-2'];
+
+    await expect(
+      automoderateCrowdReport(fake.db as never, 'report-1', VALID_SUBMISSION, {
+        idFactory: () => ids.shift() ?? 'unused-id',
+      }),
+    ).resolves.toEqual({
+      id: 'report-1',
+      status: 'accepted',
+      duplicateOfId: null,
+    });
+
+    expect(fake.updates[0]).toMatchObject({
+      table: crowdReportsTable,
+      values: {
+        status: 'accepted',
+        duplicate_of_id: null,
+      },
+    });
+    expect(fake.inserts[1]).toMatchObject({
+      table: crowdReportClustersTable,
+      values: {
+        id: 'cluster-2',
+      },
+    });
+    expect(fake.updates[1]).toMatchObject({
+      table: crowdReportsTable,
+      values: {
+        cluster_id: 'cluster-2',
+      },
+    });
+
+    const dialect = new PgDialect();
+    const clusterLockSql = dialect.sqlToQuery(fake.executes[1] as SQL);
+    expect(clusterLockSql.params).toContain(
+      'crowd-report-dispatch:cluster:cluster-1',
+    );
   });
 
   it('seeds a legacy duplicate cluster from the original accepted report timestamp', async () => {
@@ -1193,6 +1261,7 @@ describe('automoderateCrowdReport', () => {
         ],
         [{ reportId: 'existing-report', lineId: 'BPLRT' }],
         [{ reportId: 'existing-report', stationId: 'BP6' }],
+        [{ id: 'cluster-1' }],
       ],
       {
         id: 'report-1',

--- a/app/util/crowdReports.ts
+++ b/app/util/crowdReports.ts
@@ -18,6 +18,7 @@ import {
   stationsTable,
   crowdReportStationsTable,
 } from '~/db/schema';
+import { buildCrowdReportDispatchLockKey } from './crowdReportLocks';
 
 const SG_TIMEZONE = 'Asia/Singapore';
 const DEFAULT_RATE_LIMIT_PER_HOUR = 5;
@@ -184,6 +185,34 @@ function buildDuplicateLockKey(submission: CrowdReportSubmission) {
     lineIds: normalizeIdSet(submission.lineIds),
     stationIds: normalizeIdSet(submission.stationIds),
   });
+}
+
+async function lockCrowdReportClusterDispatchInTransaction(
+  tx: Pick<CrowdReportTransaction, 'execute'>,
+  clusterId: string,
+) {
+  await tx.execute(
+    sql`select pg_advisory_xact_lock(hashtextextended(${buildCrowdReportDispatchLockKey('cluster', clusterId)}, 0::bigint))`,
+  );
+}
+
+async function isCrowdReportClusterAvailableForDuplicateInTransaction(
+  tx: Pick<CrowdReportTransaction, 'select'>,
+  clusterId: string,
+) {
+  const rows = await tx
+    .select({ id: crowdReportClustersTable.id })
+    .from(crowdReportClustersTable)
+    .where(
+      and(
+        eq(crowdReportClustersTable.id, clusterId),
+        inArray(crowdReportClustersTable.status, ['pending', 'accepted']),
+        isNull(crowdReportClustersTable.dispatched_at),
+      ),
+    )
+    .limit(1);
+
+  return rows.length > 0;
 }
 
 function getCrowdReportClusterWindow(
@@ -948,12 +977,23 @@ async function automoderateCrowdReportInTransaction(
     );
   }
 
-  const duplicate = await findDuplicateCrowdReport(
+  let duplicate = await findDuplicateCrowdReport(
     tx,
     reportId,
     submission,
     duplicateWindowMinutes,
   );
+  if (duplicate?.clusterId != null) {
+    await lockCrowdReportClusterDispatchInTransaction(tx, duplicate.clusterId);
+    if (
+      !(await isCrowdReportClusterAvailableForDuplicateInTransaction(
+        tx,
+        duplicate.clusterId,
+      ))
+    ) {
+      duplicate = undefined;
+    }
+  }
   const status = duplicate == null ? 'accepted' : 'duplicate';
 
   const [updatedReport] = await tx

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -460,6 +460,16 @@ Exit criteria:
 - 2026-06-11: Addressed follow-up review feedback by preventing cluster dispatch
   from closing a cluster when new ongoing accepted or duplicate reports exist
   outside the dispatched payload's report ID set.
+- 2026-06-11: Continued Phase 6 dispatch hardening by rechecking cluster
+  payload freshness under the dispatch lock, so stale candidates are skipped
+  instead of posting partial cluster payloads when newer ongoing reports arrive.
+- 2026-06-11: Addressed review feedback on the dispatch freshness hardening by
+  making duplicate-report clustering observe the same cluster dispatch advisory
+  lock before attaching a report to an existing cluster.
+- 2026-06-11: Addressed follow-up review feedback by rechecking duplicate
+  cluster availability after waiting on the cluster dispatch lock. Reports that
+  race with a completed dispatch now start fresh accepted clusters instead of
+  attaching to already-dispatched clusters.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Recheck cluster dispatch payload freshness while holding the dispatch lock.
- Skip stale cluster candidates when newer ongoing accepted or duplicate reports exist outside the payload's report ID set.
- Add regression coverage for the lock-time eligibility predicate and update the active crowdsourced reports plan.

## Validation

- `npm run test:run -- app/util/crowdReportDispatch.test.ts`
- `npm run verify`

Note: the first sandboxed `npm run verify` attempt failed because `tsx` could not open its temp IPC pipe (`listen EPERM`). The rerun outside the sandbox completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of crowd report dispatching to prevent duplicate-report handling issues.
  * Added validity checks during dispatch to skip outdated candidates automatically.

* **Tests**
  * Enhanced test coverage for report dispatch processes.

* **Documentation**
  * Updated progress documentation for crowd-sourced report improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->