### PR TITLE
feat: add llms.txt agent discovery

### DIFF
--- a/app/routeTree.gen.ts
+++ b/app/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as Char123LangChar125RouteImport } from './routes/{-$lang}'
+import { Route as LlmsDottxtRouteImport } from './routes/llms[.]txt'
 import { Route as Char123LangChar125IndexRouteImport } from './routes/{-$lang}/index'
 import { Route as Char123LangChar125SystemMapRouteImport } from './routes/{-$lang}/system-map'
 import { Route as Char123LangChar125SitemapDotxmlRouteImport } from './routes/{-$lang}/sitemap[.]xml'
@@ -36,6 +37,11 @@ import { Route as InternalApiTasksCrowdReportDispatchRouteImport } from './route
 const Char123LangChar125Route = Char123LangChar125RouteImport.update({
   id: '/{-$lang}',
   path: '/{-$lang}',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LlmsDottxtRoute = LlmsDottxtRouteImport.update({
+  id: '/llms.txt',
+  path: '/llms.txt',
   getParentRoute: () => rootRouteImport,
 } as any)
 const Char123LangChar125IndexRoute = Char123LangChar125IndexRouteImport.update({
@@ -165,6 +171,7 @@ const InternalApiTasksCrowdReportDispatchRoute =
   } as any)
 
 export interface FileRoutesByFullPath {
+  '/llms.txt': typeof LlmsDottxtRoute
   '/{-$lang}': typeof Char123LangChar125RouteWithChildren
   '/api/issues-day': typeof ApiIssuesDayRoute
   '/api/reports': typeof ApiReportsRoute
@@ -190,6 +197,7 @@ export interface FileRoutesByFullPath {
   '/{-$lang}/operators/$operatorId/': typeof Char123LangChar125OperatorsOperatorIdIndexRoute
 }
 export interface FileRoutesByTo {
+  '/llms.txt': typeof LlmsDottxtRoute
   '/api/issues-day': typeof ApiIssuesDayRoute
   '/api/reports': typeof ApiReportsRoute
   '/{-$lang}/about': typeof Char123LangChar125AboutRoute
@@ -215,6 +223,7 @@ export interface FileRoutesByTo {
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
+  '/llms.txt': typeof LlmsDottxtRoute
   '/{-$lang}': typeof Char123LangChar125RouteWithChildren
   '/api/issues-day': typeof ApiIssuesDayRoute
   '/api/reports': typeof ApiReportsRoute
@@ -242,6 +251,7 @@ export interface FileRoutesById {
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
+    | '/llms.txt'
     | '/{-$lang}'
     | '/api/issues-day'
     | '/api/reports'
@@ -267,6 +277,7 @@ export interface FileRouteTypes {
     | '/{-$lang}/operators/$operatorId/'
   fileRoutesByTo: FileRoutesByTo
   to:
+    | '/llms.txt'
     | '/api/issues-day'
     | '/api/reports'
     | '/{-$lang}/about'
@@ -291,6 +302,7 @@ export interface FileRouteTypes {
     | '/{-$lang}/operators/$operatorId'
   id:
     | '__root__'
+    | '/llms.txt'
     | '/{-$lang}'
     | '/api/issues-day'
     | '/api/reports'
@@ -317,6 +329,7 @@ export interface FileRouteTypes {
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
+  LlmsDottxtRoute: typeof LlmsDottxtRoute
   Char123LangChar125Route: typeof Char123LangChar125RouteWithChildren
   ApiIssuesDayRoute: typeof ApiIssuesDayRoute
   ApiReportsRoute: typeof ApiReportsRoute
@@ -334,6 +347,13 @@ declare module '@tanstack/react-router' {
       path: '/{-$lang}'
       fullPath: '/{-$lang}'
       preLoaderRoute: typeof Char123LangChar125RouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/llms.txt': {
+      id: '/llms.txt'
+      path: '/llms.txt'
+      fullPath: '/llms.txt'
+      preLoaderRoute: typeof LlmsDottxtRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/{-$lang}/': {
@@ -541,6 +561,7 @@ const Char123LangChar125RouteWithChildren =
   Char123LangChar125Route._addFileChildren(Char123LangChar125RouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
+  LlmsDottxtRoute: LlmsDottxtRoute,
   Char123LangChar125Route: Char123LangChar125RouteWithChildren,
   ApiIssuesDayRoute: ApiIssuesDayRoute,
   ApiReportsRoute: ApiReportsRoute,

--- a/app/routes/llms[.]txt.tsx
+++ b/app/routes/llms[.]txt.tsx
@@ -8,7 +8,7 @@ export const Route = createFileRoute('/llms.txt')({
       GET() {
         return createPublicMarkdownResponse(
           getLlmsTxt({
-            rootUrl: process.env.ROOT_URL ?? 'https://www.mrtdown.org',
+            rootUrl: import.meta.env.VITE_ROOT_URL,
           }),
         );
       },

--- a/app/routes/llms[.]txt.tsx
+++ b/app/routes/llms[.]txt.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { createPublicMarkdownResponse } from '~/util/agentMarkdown';
+import { getLlmsTxt } from '~/util/llmsTxt';
+
+export const Route = createFileRoute('/llms.txt')({
+  server: {
+    handlers: {
+      GET() {
+        return createPublicMarkdownResponse(
+          getLlmsTxt({
+            rootUrl: process.env.ROOT_URL ?? 'https://www.mrtdown.org',
+          }),
+        );
+      },
+    },
+  },
+});

--- a/app/server.ts
+++ b/app/server.ts
@@ -69,6 +69,10 @@ async function appFetch(request: Request, _env: Env, ctx: ExecutionContext) {
     logResponseByteEstimate(request, responseWithHeaders.clone(), elapsedMs);
   }
 
+  if (shouldPreservePublicMarkdownCache(responseWithHeaders)) {
+    return responseWithHeaders;
+  }
+
   return addSentryAnonymousUserCookie(responseWithHeaders, sentryAnonymousUser);
 }
 
@@ -119,6 +123,10 @@ function appendInstrumentationHeaders(
       : workerTiming,
   );
   headers.set('X-MRTDown-Render', render);
+}
+
+function shouldPreservePublicMarkdownCache(response: Response) {
+  return response.headers.get('X-MRTDown-Cache') === 'public-markdown';
 }
 
 async function logResponseByteEstimate(

--- a/app/util/llmsTxt.test.ts
+++ b/app/util/llmsTxt.test.ts
@@ -9,24 +9,23 @@ describe('getLlmsTxt', () => {
     expect(getLlmsTxt({ rootUrl: 'https://example.com/base/' })).toContain(
       '[Sitemap](https://example.com/sitemap.xml)',
     );
+    expect(getLlmsTxt({ rootUrl: 'https://example.com/base/' })).toContain(
+      '[llms.txt](https://example.com/llms.txt)',
+    );
   });
 
-  it('documents the canonical Markdown route patterns', () => {
+  it('only advertises Markdown routes that exist in this phase', () => {
     const markdown = getLlmsTxt();
 
     expect(markdown).toContain('# mrtdown');
-    expect(markdown).toContain('| Current system status | /index.md');
+    expect(markdown).toContain('## Available Markdown');
     expect(markdown).toContain(
-      '| Line profile          | /lines/{lineId}/index.md',
+      'Additional entity Markdown routes will be linked here after those routes are implemented.',
     );
-    expect(markdown).toContain(
-      '| Station profile       | /stations/{stationId}/index.md',
-    );
-    expect(markdown).toContain(
-      '| Operator profile      | /operators/{operatorId}/index.md',
-    );
-    expect(markdown).toContain(
-      '| Issue profile         | /issues/{issueId}/index.md',
-    );
+    expect(markdown).not.toContain('/index.md');
+    expect(markdown).not.toContain('/lines/{lineId}/index.md');
+    expect(markdown).not.toContain('/stations/{stationId}/index.md');
+    expect(markdown).not.toContain('/operators/{operatorId}/index.md');
+    expect(markdown).not.toContain('/issues/{issueId}/index.md');
   });
 });

--- a/app/util/llmsTxt.test.ts
+++ b/app/util/llmsTxt.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { getLlmsTxt } from './llmsTxt';
+
+describe('getLlmsTxt', () => {
+  it('renders a curated agent entry point with absolute public resource links', () => {
+    expect(getLlmsTxt({ rootUrl: 'https://example.com/base/' })).toContain(
+      '[Current public status page](https://example.com/)',
+    );
+    expect(getLlmsTxt({ rootUrl: 'https://example.com/base/' })).toContain(
+      '[Sitemap](https://example.com/sitemap.xml)',
+    );
+  });
+
+  it('documents the canonical Markdown route patterns', () => {
+    const markdown = getLlmsTxt();
+
+    expect(markdown).toContain('# mrtdown');
+    expect(markdown).toContain('| Current system status | /index.md');
+    expect(markdown).toContain(
+      '| Line profile          | /lines/{lineId}/index.md',
+    );
+    expect(markdown).toContain(
+      '| Station profile       | /stations/{stationId}/index.md',
+    );
+    expect(markdown).toContain(
+      '| Operator profile      | /operators/{operatorId}/index.md',
+    );
+    expect(markdown).toContain(
+      '| Issue profile         | /issues/{issueId}/index.md',
+    );
+  });
+});

--- a/app/util/llmsTxt.ts
+++ b/app/util/llmsTxt.ts
@@ -1,0 +1,169 @@
+import type {
+  Link,
+  ListItem,
+  Paragraph,
+  PhrasingContent,
+  RootContent,
+} from 'mdast';
+import { markdownTable, serializeAgentMarkdown } from './agentMarkdown';
+
+const DEFAULT_ROOT_URL = 'https://www.mrtdown.org';
+
+interface LlmsTxtOptions {
+  rootUrl?: string;
+}
+
+export function getLlmsTxt(options?: LlmsTxtOptions) {
+  const rootUrl = options?.rootUrl ?? DEFAULT_ROOT_URL;
+  const routeTable = markdownTable({
+    headers: ['Content', 'Markdown URL', 'Human URL'],
+    rows: [
+      ['Current system status', '/index.md', '/'],
+      ['Line profile', '/lines/{lineId}/index.md', '/lines/{lineId}'],
+      [
+        'Station profile',
+        '/stations/{stationId}/index.md',
+        '/stations/{stationId}',
+      ],
+      [
+        'Operator profile',
+        '/operators/{operatorId}/index.md',
+        '/operators/{operatorId}',
+      ],
+      ['Issue profile', '/issues/{issueId}/index.md', '/issues/{issueId}'],
+    ],
+  });
+
+  const content: RootContent[] = [
+    {
+      type: 'heading',
+      depth: 1,
+      children: [{ type: 'text', value: 'mrtdown' }],
+    },
+    paragraph([
+      {
+        type: 'text',
+        value:
+          'mrtdown provides current Singapore MRT and LRT service status, disruptions, planned maintenance, and canonical transit entity context.',
+      },
+    ]),
+    {
+      type: 'heading',
+      depth: 2,
+      children: [{ type: 'text', value: 'Primary Resources' }],
+    },
+    {
+      type: 'list',
+      ordered: false,
+      spread: false,
+      children: [
+        listItem([
+          link('Current public status page', '/', rootUrl),
+          {
+            type: 'text',
+            value: ': human-facing overview of live service status.',
+          },
+        ]),
+        listItem([
+          link('Issue history', '/history', rootUrl),
+          {
+            type: 'text',
+            value: ': human-facing archive of past service issues.',
+          },
+        ]),
+        listItem([
+          link('System map', '/system-map', rootUrl),
+          {
+            type: 'text',
+            value: ': human-facing network map.',
+          },
+        ]),
+        listItem([
+          link('Sitemap', '/sitemap.xml', rootUrl),
+          {
+            type: 'text',
+            value:
+              ': discover current line, station, operator, and issue identifiers.',
+          },
+        ]),
+      ],
+    },
+    {
+      type: 'heading',
+      depth: 2,
+      children: [{ type: 'text', value: 'Markdown Routes' }],
+    },
+    paragraph([
+      {
+        type: 'text',
+        value:
+          'The first Markdown pass is en-SG only. Replace placeholders with identifiers from the sitemap or human pages.',
+      },
+    ]),
+  ];
+
+  if (routeTable != null) {
+    content.push(routeTable);
+  }
+
+  content.push(
+    {
+      type: 'heading',
+      depth: 2,
+      children: [{ type: 'text', value: 'Notes For Agents' }],
+    },
+    {
+      type: 'list',
+      ordered: false,
+      spread: false,
+      children: [
+        listItem([
+          {
+            type: 'text',
+            value:
+              'Prefer explicit Markdown URLs when available; they are generated from read-model data, not converted from rendered HTML.',
+          },
+        ]),
+        listItem([
+          {
+            type: 'text',
+            value:
+              'Crowd-sourced report signals may appear where the matching public page includes them.',
+          },
+        ]),
+        listItem([
+          {
+            type: 'text',
+            value:
+              'Do not treat this file as a full sitemap; it is a curated entry point for high-value agent routes.',
+          },
+        ]),
+      ],
+    },
+  );
+
+  return serializeAgentMarkdown(content);
+}
+
+function paragraph(children: PhrasingContent[]): Paragraph {
+  return {
+    type: 'paragraph',
+    children,
+  };
+}
+
+function listItem(children: PhrasingContent[]): ListItem {
+  return {
+    type: 'listItem',
+    spread: false,
+    children: [paragraph(children)],
+  };
+}
+
+function link(label: string, path: string, rootUrl: string): Link {
+  return {
+    type: 'link',
+    url: new URL(path, rootUrl).toString(),
+    children: [{ type: 'text', value: label }],
+  };
+}

--- a/app/util/llmsTxt.ts
+++ b/app/util/llmsTxt.ts
@@ -5,7 +5,7 @@ import type {
   PhrasingContent,
   RootContent,
 } from 'mdast';
-import { markdownTable, serializeAgentMarkdown } from './agentMarkdown';
+import { serializeAgentMarkdown } from './agentMarkdown';
 
 const DEFAULT_ROOT_URL = 'https://www.mrtdown.org';
 
@@ -15,25 +15,6 @@ interface LlmsTxtOptions {
 
 export function getLlmsTxt(options?: LlmsTxtOptions) {
   const rootUrl = options?.rootUrl ?? DEFAULT_ROOT_URL;
-  const routeTable = markdownTable({
-    headers: ['Content', 'Markdown URL', 'Human URL'],
-    rows: [
-      ['Current system status', '/index.md', '/'],
-      ['Line profile', '/lines/{lineId}/index.md', '/lines/{lineId}'],
-      [
-        'Station profile',
-        '/stations/{stationId}/index.md',
-        '/stations/{stationId}',
-      ],
-      [
-        'Operator profile',
-        '/operators/{operatorId}/index.md',
-        '/operators/{operatorId}',
-      ],
-      ['Issue profile', '/issues/{issueId}/index.md', '/issues/{issueId}'],
-    ],
-  });
-
   const content: RootContent[] = [
     {
       type: 'heading',
@@ -91,20 +72,31 @@ export function getLlmsTxt(options?: LlmsTxtOptions) {
     {
       type: 'heading',
       depth: 2,
-      children: [{ type: 'text', value: 'Markdown Routes' }],
+      children: [{ type: 'text', value: 'Available Markdown' }],
+    },
+    {
+      type: 'list',
+      ordered: false,
+      spread: false,
+      children: [
+        listItem([
+          link('llms.txt', '/llms.txt', rootUrl),
+          {
+            type: 'text',
+            value:
+              ': curated agent entry point for currently available public resources.',
+          },
+        ]),
+      ],
     },
     paragraph([
       {
         type: 'text',
         value:
-          'The first Markdown pass is en-SG only. Replace placeholders with identifiers from the sitemap or human pages.',
+          'Additional entity Markdown routes will be linked here after those routes are implemented.',
       },
     ]),
   ];
-
-  if (routeTable != null) {
-    content.push(routeTable);
-  }
 
   content.push(
     {

--- a/docs/plans/active/markdown-for-agents.md
+++ b/docs/plans/active/markdown-for-agents.md
@@ -140,8 +140,9 @@ Exit criteria:
   serialization helpers, GFM table support, date and duration formatting, and a
   cacheable `text/markdown` response helper.
 - 2026-06-11: Added the Phase 2 `/llms.txt` discovery route with a curated
-  agent entry point, links to current public resources, and documented canonical
-  Markdown URL patterns for Phase 3 entity routes.
+  agent entry point and links to current public resources. Deferred linking
+  Phase 3 entity Markdown URLs until those routes exist, so agents do not
+  follow advertised 404s.
 
 ## Decision Log
 

--- a/docs/plans/active/markdown-for-agents.md
+++ b/docs/plans/active/markdown-for-agents.md
@@ -139,6 +139,9 @@ Exit criteria:
 - 2026-05-31: Added the shared Phase 1 Markdown surface with mdast-backed
   serialization helpers, GFM table support, date and duration formatting, and a
   cacheable `text/markdown` response helper.
+- 2026-06-11: Added the Phase 2 `/llms.txt` discovery route with a curated
+  agent entry point, links to current public resources, and documented canonical
+  Markdown URL patterns for Phase 3 entity routes.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Add `/llms.txt` as a curated Markdown entry point for agents.
- Render the file through the shared mdast Markdown utilities and cover the output with unit tests.
- Preserve public Markdown cache headers by skipping the anonymous Sentry cookie path for public Markdown responses.
- Record the Phase 2 progress in the markdown-for-agents plan.

## Validation

- `npm run verify`
- Manual `curl -i http://localhost:3000/llms.txt` returned `200`, `text/markdown; charset=utf-8`, public Markdown cache headers, and no `Set-Cookie`.

## Notes

The local sandbox blocked the Drizzle `tsx` IPC pipe and the Vite dev server port bind, so the successful full verify and manual endpoint check were run with approved escalation.