### PR TITLE
fix: harden crowd report legacy dispatch races

### DIFF
--- a/app/util/crowdReports.test.ts
+++ b/app/util/crowdReports.test.ts
@@ -1174,6 +1174,7 @@ describe('automoderateCrowdReport', () => {
         ],
         [{ reportId: 'existing-report', lineId: 'BPLRT' }],
         [{ reportId: 'existing-report', stationId: 'BP6' }],
+        [{ id: 'existing-report' }],
       ],
       {
         id: 'report-1',
@@ -1200,6 +1201,69 @@ describe('automoderateCrowdReport', () => {
         window_end_at: '2026-05-24T04:35:00.000Z',
       },
     });
+
+    const dialect = new PgDialect();
+    const reportLockSql = dialect.sqlToQuery(fake.executes[1] as SQL);
+    expect(reportLockSql.params).toContain(
+      'crowd-report-dispatch:report:existing-report',
+    );
+  });
+
+  it('starts a fresh cluster when a legacy duplicate report was dispatched before the lock', async () => {
+    const fake = makeFakeAutomoderationDb(
+      [
+        [
+          {
+            id: 'existing-report',
+            observedAt: '2026-05-24T12:25:00.000+08:00',
+            status: 'accepted',
+            directionText: 'Towards Choa Chu Kang',
+            clusterId: null,
+          },
+        ],
+        [{ reportId: 'existing-report', lineId: 'BPLRT' }],
+        [{ reportId: 'existing-report', stationId: 'BP6' }],
+        [],
+      ],
+      {
+        id: 'report-1',
+        status: 'accepted',
+        duplicateOfId: null,
+      },
+    );
+    const ids = ['event-1', 'cluster-1'];
+
+    await expect(
+      automoderateCrowdReport(fake.db as never, 'report-1', VALID_SUBMISSION, {
+        idFactory: () => ids.shift() ?? 'unused-id',
+      }),
+    ).resolves.toEqual({
+      id: 'report-1',
+      status: 'accepted',
+      duplicateOfId: null,
+    });
+
+    expect(fake.updates[0]).toMatchObject({
+      table: crowdReportsTable,
+      values: {
+        status: 'accepted',
+        duplicate_of_id: null,
+      },
+    });
+    expect(fake.inserts[1]).toMatchObject({
+      table: crowdReportClustersTable,
+      values: {
+        id: 'cluster-1',
+        window_start_at: '2026-05-24T04:20:00.000Z',
+        window_end_at: '2026-05-24T04:40:00.000Z',
+      },
+    });
+
+    const dialect = new PgDialect();
+    const reportLockSql = dialect.sqlToQuery(fake.executes[1] as SQL);
+    expect(reportLockSql.params).toContain(
+      'crowd-report-dispatch:report:existing-report',
+    );
   });
 
   it('ignores same-context pending reports to avoid reciprocal duplicates', async () => {

--- a/app/util/crowdReports.ts
+++ b/app/util/crowdReports.ts
@@ -196,6 +196,15 @@ async function lockCrowdReportClusterDispatchInTransaction(
   );
 }
 
+async function lockCrowdReportDispatchInTransaction(
+  tx: Pick<CrowdReportTransaction, 'execute'>,
+  reportId: string,
+) {
+  await tx.execute(
+    sql`select pg_advisory_xact_lock(hashtextextended(${buildCrowdReportDispatchLockKey('report', reportId)}, 0::bigint))`,
+  );
+}
+
 async function isCrowdReportClusterAvailableForDuplicateInTransaction(
   tx: Pick<CrowdReportTransaction, 'select'>,
   clusterId: string,
@@ -208,6 +217,26 @@ async function isCrowdReportClusterAvailableForDuplicateInTransaction(
         eq(crowdReportClustersTable.id, clusterId),
         inArray(crowdReportClustersTable.status, ['pending', 'accepted']),
         isNull(crowdReportClustersTable.dispatched_at),
+      ),
+    )
+    .limit(1);
+
+  return rows.length > 0;
+}
+
+async function isLegacyCrowdReportAvailableForDuplicateInTransaction(
+  tx: Pick<CrowdReportTransaction, 'select'>,
+  reportId: string,
+) {
+  const rows = await tx
+    .select({ id: crowdReportsTable.id })
+    .from(crowdReportsTable)
+    .where(
+      and(
+        eq(crowdReportsTable.id, reportId),
+        eq(crowdReportsTable.status, 'accepted'),
+        isNull(crowdReportsTable.cluster_id),
+        isNull(crowdReportsTable.dispatched_at),
       ),
     )
     .limit(1);
@@ -989,6 +1018,16 @@ async function automoderateCrowdReportInTransaction(
       !(await isCrowdReportClusterAvailableForDuplicateInTransaction(
         tx,
         duplicate.clusterId,
+      ))
+    ) {
+      duplicate = undefined;
+    }
+  } else if (duplicate != null) {
+    await lockCrowdReportDispatchInTransaction(tx, duplicate.id);
+    if (
+      !(await isLegacyCrowdReportAvailableForDuplicateInTransaction(
+        tx,
+        duplicate.id,
       ))
     ) {
       duplicate = undefined;

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -470,6 +470,10 @@ Exit criteria:
   cluster availability after waiting on the cluster dispatch lock. Reports that
   race with a completed dispatch now start fresh accepted clusters instead of
   attaching to already-dispatched clusters.
+- 2026-06-11: Continued dispatch race hardening for legacy accepted reports
+  without clusters. Duplicate automation now takes the report dispatch advisory
+  lock and rechecks that the original report remains accepted, unclustered, and
+  undispatched before using it to seed a duplicate cluster.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Add a report-level dispatch advisory lock when duplicate automation considers a legacy accepted report that has not yet been clustered.
- Recheck that the legacy report is still accepted, unclustered, and undispatched before using it to seed a duplicate cluster.
- Add regression coverage for both the valid legacy seed path and the race where single-report dispatch wins first.
- Update the active crowdsourced reports plan progress log.

## Validation

- `npm run test:run -- app/util/crowdReports.test.ts`
- `npm run verify`

Note: the first sandboxed `npm run verify` attempt passed typecheck, lint, and format, then failed at `npm run db:generate:check` with `listen EPERM` from `tsx` creating an IPC pipe. The rerun outside the sandbox passed fully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened duplicate report handling by adding enhanced validation and locking mechanisms to prevent race conditions and ensure data integrity in legacy report processing.

* **Tests**
  * Expanded test coverage for duplicate dispatch scenarios, including new tests for validation edge cases.

* **Documentation**
  * Updated project progress documentation with details on dispatch reliability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->