### PR TITLE
feat: add agent markdown routes

### DIFF
--- a/app/routeTree.gen.ts
+++ b/app/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as Char123LangChar125RouteImport } from './routes/{-$lang}'
 import { Route as LlmsDottxtRouteImport } from './routes/llms[.]txt'
+import { Route as IndexDotmdRouteImport } from './routes/index[.]md'
 import { Route as Char123LangChar125IndexRouteImport } from './routes/{-$lang}/index'
 import { Route as Char123LangChar125SystemMapRouteImport } from './routes/{-$lang}/system-map'
 import { Route as Char123LangChar125SitemapDotxmlRouteImport } from './routes/{-$lang}/sitemap[.]xml'
@@ -22,6 +23,10 @@ import { Route as Char123LangChar125StatisticsIndexRouteImport } from './routes/
 import { Route as Char123LangChar125HistoryIndexRouteImport } from './routes/{-$lang}/history/index'
 import { Route as Char123LangChar125StatusLineIdRouteImport } from './routes/{-$lang}/status.$lineId'
 import { Route as Char123LangChar125StationsStationIdRouteImport } from './routes/{-$lang}/stations/$stationId'
+import { Route as StationsStationIdIndexDotmdRouteImport } from './routes/stations/$stationId/index[.]md'
+import { Route as OperatorsOperatorIdIndexDotmdRouteImport } from './routes/operators/$operatorId/index[.]md'
+import { Route as LinesLineIdIndexDotmdRouteImport } from './routes/lines/$lineId/index[.]md'
+import { Route as IssuesIssueIdIndexDotmdRouteImport } from './routes/issues/$issueId/index[.]md'
 import { Route as ApiPhSplatRouteImport } from './routes/api.ph.$'
 import { Route as Char123LangChar125OperatorsOperatorIdIndexRouteImport } from './routes/{-$lang}/operators/$operatorId/index'
 import { Route as Char123LangChar125LinesLineIdIndexRouteImport } from './routes/{-$lang}/lines/$lineId/index'
@@ -42,6 +47,11 @@ const Char123LangChar125Route = Char123LangChar125RouteImport.update({
 const LlmsDottxtRoute = LlmsDottxtRouteImport.update({
   id: '/llms.txt',
   path: '/llms.txt',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const IndexDotmdRoute = IndexDotmdRouteImport.update({
+  id: '/index.md',
+  path: '/index.md',
   getParentRoute: () => rootRouteImport,
 } as any)
 const Char123LangChar125IndexRoute = Char123LangChar125IndexRouteImport.update({
@@ -106,6 +116,28 @@ const Char123LangChar125StationsStationIdRoute =
     path: '/stations/$stationId',
     getParentRoute: () => Char123LangChar125Route,
   } as any)
+const StationsStationIdIndexDotmdRoute =
+  StationsStationIdIndexDotmdRouteImport.update({
+    id: '/stations/$stationId/index.md',
+    path: '/stations/$stationId/index.md',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const OperatorsOperatorIdIndexDotmdRoute =
+  OperatorsOperatorIdIndexDotmdRouteImport.update({
+    id: '/operators/$operatorId/index.md',
+    path: '/operators/$operatorId/index.md',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const LinesLineIdIndexDotmdRoute = LinesLineIdIndexDotmdRouteImport.update({
+  id: '/lines/$lineId/index.md',
+  path: '/lines/$lineId/index.md',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const IssuesIssueIdIndexDotmdRoute = IssuesIssueIdIndexDotmdRouteImport.update({
+  id: '/issues/$issueId/index.md',
+  path: '/issues/$issueId/index.md',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiPhSplatRoute = ApiPhSplatRouteImport.update({
   id: '/api/ph/$',
   path: '/api/ph/$',
@@ -171,6 +203,7 @@ const InternalApiTasksCrowdReportDispatchRoute =
   } as any)
 
 export interface FileRoutesByFullPath {
+  '/index.md': typeof IndexDotmdRoute
   '/llms.txt': typeof LlmsDottxtRoute
   '/{-$lang}': typeof Char123LangChar125RouteWithChildren
   '/api/issues-day': typeof ApiIssuesDayRoute
@@ -181,6 +214,10 @@ export interface FileRoutesByFullPath {
   '/{-$lang}/system-map': typeof Char123LangChar125SystemMapRoute
   '/{-$lang}/': typeof Char123LangChar125IndexRoute
   '/api/ph/$': typeof ApiPhSplatRoute
+  '/issues/$issueId/index.md': typeof IssuesIssueIdIndexDotmdRoute
+  '/lines/$lineId/index.md': typeof LinesLineIdIndexDotmdRoute
+  '/operators/$operatorId/index.md': typeof OperatorsOperatorIdIndexDotmdRoute
+  '/stations/$stationId/index.md': typeof StationsStationIdIndexDotmdRoute
   '/{-$lang}/stations/$stationId': typeof Char123LangChar125StationsStationIdRoute
   '/{-$lang}/status/$lineId': typeof Char123LangChar125StatusLineIdRoute
   '/{-$lang}/history/': typeof Char123LangChar125HistoryIndexRoute
@@ -197,6 +234,7 @@ export interface FileRoutesByFullPath {
   '/{-$lang}/operators/$operatorId/': typeof Char123LangChar125OperatorsOperatorIdIndexRoute
 }
 export interface FileRoutesByTo {
+  '/index.md': typeof IndexDotmdRoute
   '/llms.txt': typeof LlmsDottxtRoute
   '/api/issues-day': typeof ApiIssuesDayRoute
   '/api/reports': typeof ApiReportsRoute
@@ -206,6 +244,10 @@ export interface FileRoutesByTo {
   '/{-$lang}/system-map': typeof Char123LangChar125SystemMapRoute
   '/{-$lang}': typeof Char123LangChar125IndexRoute
   '/api/ph/$': typeof ApiPhSplatRoute
+  '/issues/$issueId/index.md': typeof IssuesIssueIdIndexDotmdRoute
+  '/lines/$lineId/index.md': typeof LinesLineIdIndexDotmdRoute
+  '/operators/$operatorId/index.md': typeof OperatorsOperatorIdIndexDotmdRoute
+  '/stations/$stationId/index.md': typeof StationsStationIdIndexDotmdRoute
   '/{-$lang}/stations/$stationId': typeof Char123LangChar125StationsStationIdRoute
   '/{-$lang}/status/$lineId': typeof Char123LangChar125StatusLineIdRoute
   '/{-$lang}/history': typeof Char123LangChar125HistoryIndexRoute
@@ -223,6 +265,7 @@ export interface FileRoutesByTo {
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
+  '/index.md': typeof IndexDotmdRoute
   '/llms.txt': typeof LlmsDottxtRoute
   '/{-$lang}': typeof Char123LangChar125RouteWithChildren
   '/api/issues-day': typeof ApiIssuesDayRoute
@@ -233,6 +276,10 @@ export interface FileRoutesById {
   '/{-$lang}/system-map': typeof Char123LangChar125SystemMapRoute
   '/{-$lang}/': typeof Char123LangChar125IndexRoute
   '/api/ph/$': typeof ApiPhSplatRoute
+  '/issues/$issueId/index.md': typeof IssuesIssueIdIndexDotmdRoute
+  '/lines/$lineId/index.md': typeof LinesLineIdIndexDotmdRoute
+  '/operators/$operatorId/index.md': typeof OperatorsOperatorIdIndexDotmdRoute
+  '/stations/$stationId/index.md': typeof StationsStationIdIndexDotmdRoute
   '/{-$lang}/stations/$stationId': typeof Char123LangChar125StationsStationIdRoute
   '/{-$lang}/status/$lineId': typeof Char123LangChar125StatusLineIdRoute
   '/{-$lang}/history/': typeof Char123LangChar125HistoryIndexRoute
@@ -251,6 +298,7 @@ export interface FileRoutesById {
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
+    | '/index.md'
     | '/llms.txt'
     | '/{-$lang}'
     | '/api/issues-day'
@@ -261,6 +309,10 @@ export interface FileRouteTypes {
     | '/{-$lang}/system-map'
     | '/{-$lang}/'
     | '/api/ph/$'
+    | '/issues/$issueId/index.md'
+    | '/lines/$lineId/index.md'
+    | '/operators/$operatorId/index.md'
+    | '/stations/$stationId/index.md'
     | '/{-$lang}/stations/$stationId'
     | '/{-$lang}/status/$lineId'
     | '/{-$lang}/history/'
@@ -277,6 +329,7 @@ export interface FileRouteTypes {
     | '/{-$lang}/operators/$operatorId/'
   fileRoutesByTo: FileRoutesByTo
   to:
+    | '/index.md'
     | '/llms.txt'
     | '/api/issues-day'
     | '/api/reports'
@@ -286,6 +339,10 @@ export interface FileRouteTypes {
     | '/{-$lang}/system-map'
     | '/{-$lang}'
     | '/api/ph/$'
+    | '/issues/$issueId/index.md'
+    | '/lines/$lineId/index.md'
+    | '/operators/$operatorId/index.md'
+    | '/stations/$stationId/index.md'
     | '/{-$lang}/stations/$stationId'
     | '/{-$lang}/status/$lineId'
     | '/{-$lang}/history'
@@ -302,6 +359,7 @@ export interface FileRouteTypes {
     | '/{-$lang}/operators/$operatorId'
   id:
     | '__root__'
+    | '/index.md'
     | '/llms.txt'
     | '/{-$lang}'
     | '/api/issues-day'
@@ -312,6 +370,10 @@ export interface FileRouteTypes {
     | '/{-$lang}/system-map'
     | '/{-$lang}/'
     | '/api/ph/$'
+    | '/issues/$issueId/index.md'
+    | '/lines/$lineId/index.md'
+    | '/operators/$operatorId/index.md'
+    | '/stations/$stationId/index.md'
     | '/{-$lang}/stations/$stationId'
     | '/{-$lang}/status/$lineId'
     | '/{-$lang}/history/'
@@ -329,11 +391,16 @@ export interface FileRouteTypes {
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
+  IndexDotmdRoute: typeof IndexDotmdRoute
   LlmsDottxtRoute: typeof LlmsDottxtRoute
   Char123LangChar125Route: typeof Char123LangChar125RouteWithChildren
   ApiIssuesDayRoute: typeof ApiIssuesDayRoute
   ApiReportsRoute: typeof ApiReportsRoute
   ApiPhSplatRoute: typeof ApiPhSplatRoute
+  IssuesIssueIdIndexDotmdRoute: typeof IssuesIssueIdIndexDotmdRoute
+  LinesLineIdIndexDotmdRoute: typeof LinesLineIdIndexDotmdRoute
+  OperatorsOperatorIdIndexDotmdRoute: typeof OperatorsOperatorIdIndexDotmdRoute
+  StationsStationIdIndexDotmdRoute: typeof StationsStationIdIndexDotmdRoute
   InternalApiTasksCrowdReportDispatchRoute: typeof InternalApiTasksCrowdReportDispatchRoute
   InternalApiTasksFactsRoute: typeof InternalApiTasksFactsRoute
   InternalApiTasksPublicHolidaysRoute: typeof InternalApiTasksPublicHolidaysRoute
@@ -354,6 +421,13 @@ declare module '@tanstack/react-router' {
       path: '/llms.txt'
       fullPath: '/llms.txt'
       preLoaderRoute: typeof LlmsDottxtRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/index.md': {
+      id: '/index.md'
+      path: '/index.md'
+      fullPath: '/index.md'
+      preLoaderRoute: typeof IndexDotmdRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/{-$lang}/': {
@@ -432,6 +506,34 @@ declare module '@tanstack/react-router' {
       fullPath: '/{-$lang}/stations/$stationId'
       preLoaderRoute: typeof Char123LangChar125StationsStationIdRouteImport
       parentRoute: typeof Char123LangChar125Route
+    }
+    '/stations/$stationId/index.md': {
+      id: '/stations/$stationId/index.md'
+      path: '/stations/$stationId/index.md'
+      fullPath: '/stations/$stationId/index.md'
+      preLoaderRoute: typeof StationsStationIdIndexDotmdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/operators/$operatorId/index.md': {
+      id: '/operators/$operatorId/index.md'
+      path: '/operators/$operatorId/index.md'
+      fullPath: '/operators/$operatorId/index.md'
+      preLoaderRoute: typeof OperatorsOperatorIdIndexDotmdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/lines/$lineId/index.md': {
+      id: '/lines/$lineId/index.md'
+      path: '/lines/$lineId/index.md'
+      fullPath: '/lines/$lineId/index.md'
+      preLoaderRoute: typeof LinesLineIdIndexDotmdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/issues/$issueId/index.md': {
+      id: '/issues/$issueId/index.md'
+      path: '/issues/$issueId/index.md'
+      fullPath: '/issues/$issueId/index.md'
+      preLoaderRoute: typeof IssuesIssueIdIndexDotmdRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/api/ph/$': {
       id: '/api/ph/$'
@@ -561,11 +663,16 @@ const Char123LangChar125RouteWithChildren =
   Char123LangChar125Route._addFileChildren(Char123LangChar125RouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
+  IndexDotmdRoute: IndexDotmdRoute,
   LlmsDottxtRoute: LlmsDottxtRoute,
   Char123LangChar125Route: Char123LangChar125RouteWithChildren,
   ApiIssuesDayRoute: ApiIssuesDayRoute,
   ApiReportsRoute: ApiReportsRoute,
   ApiPhSplatRoute: ApiPhSplatRoute,
+  IssuesIssueIdIndexDotmdRoute: IssuesIssueIdIndexDotmdRoute,
+  LinesLineIdIndexDotmdRoute: LinesLineIdIndexDotmdRoute,
+  OperatorsOperatorIdIndexDotmdRoute: OperatorsOperatorIdIndexDotmdRoute,
+  StationsStationIdIndexDotmdRoute: StationsStationIdIndexDotmdRoute,
   InternalApiTasksCrowdReportDispatchRoute:
     InternalApiTasksCrowdReportDispatchRoute,
   InternalApiTasksFactsRoute: InternalApiTasksFactsRoute,

--- a/app/routes/index[.]md.tsx
+++ b/app/routes/index[.]md.tsx
@@ -1,0 +1,23 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { HOME_OVERVIEW_INITIAL_DATE_COUNT } from '~/constants';
+import { createPublicMarkdownResponse } from '~/util/agentMarkdown';
+import { getOverviewMarkdown } from '~/util/agentMarkdownContent';
+import { getOverviewFn } from '~/util/overview.functions';
+
+export const Route = createFileRoute('/index.md')({
+  server: {
+    handlers: {
+      async GET() {
+        const overview = await getOverviewFn({
+          data: { days: HOME_OVERVIEW_INITIAL_DATE_COUNT },
+        });
+
+        return createPublicMarkdownResponse(
+          getOverviewMarkdown(overview, {
+            rootUrl: import.meta.env.VITE_ROOT_URL,
+          }),
+        );
+      },
+    },
+  },
+});

--- a/app/routes/issues/$issueId/index[.]md.tsx
+++ b/app/routes/issues/$issueId/index[.]md.tsx
@@ -1,0 +1,22 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { createPublicMarkdownResponse } from '~/util/agentMarkdown';
+import { getIssueMarkdown } from '~/util/agentMarkdownContent';
+import { getIssueFn } from '~/util/issue.functions';
+
+export const Route = createFileRoute('/issues/$issueId/index.md')({
+  server: {
+    handlers: {
+      async GET({ params }) {
+        const issue = await getIssueFn({
+          data: { issueId: params.issueId },
+        });
+
+        return createPublicMarkdownResponse(
+          getIssueMarkdown(issue, {
+            rootUrl: import.meta.env.VITE_ROOT_URL,
+          }),
+        );
+      },
+    },
+  },
+});

--- a/app/routes/lines/$lineId/index[.]md.tsx
+++ b/app/routes/lines/$lineId/index[.]md.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { createPublicMarkdownResponse } from '~/util/agentMarkdown';
+import { getLineMarkdown } from '~/util/agentMarkdownContent';
+import { getLineProfileFn } from '~/util/lines.functions';
+
+const DATE_COUNT = 90;
+
+export const Route = createFileRoute('/lines/$lineId/index.md')({
+  server: {
+    handlers: {
+      async GET({ params }) {
+        const profile = await getLineProfileFn({
+          data: { lineId: params.lineId, days: DATE_COUNT },
+        });
+
+        return createPublicMarkdownResponse(
+          getLineMarkdown(profile, {
+            rootUrl: import.meta.env.VITE_ROOT_URL,
+          }),
+        );
+      },
+    },
+  },
+});

--- a/app/routes/operators/$operatorId/index[.]md.tsx
+++ b/app/routes/operators/$operatorId/index[.]md.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { createPublicMarkdownResponse } from '~/util/agentMarkdown';
+import { getOperatorMarkdown } from '~/util/agentMarkdownContent';
+import { getOperatorProfileFn } from '~/util/operator.functions';
+
+const DATE_COUNT = 90;
+
+export const Route = createFileRoute('/operators/$operatorId/index.md')({
+  server: {
+    handlers: {
+      async GET({ params }) {
+        const profile = await getOperatorProfileFn({
+          data: { operatorId: params.operatorId, days: DATE_COUNT },
+        });
+
+        return createPublicMarkdownResponse(
+          getOperatorMarkdown(profile, {
+            rootUrl: import.meta.env.VITE_ROOT_URL,
+          }),
+        );
+      },
+    },
+  },
+});

--- a/app/routes/stations/$stationId/index[.]md.tsx
+++ b/app/routes/stations/$stationId/index[.]md.tsx
@@ -1,0 +1,22 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { createPublicMarkdownResponse } from '~/util/agentMarkdown';
+import { getStationMarkdown } from '~/util/agentMarkdownContent';
+import { getStationProfileFn } from '~/util/station.functions';
+
+export const Route = createFileRoute('/stations/$stationId/index.md')({
+  server: {
+    handlers: {
+      async GET({ params }) {
+        const profile = await getStationProfileFn({
+          data: { stationId: params.stationId },
+        });
+
+        return createPublicMarkdownResponse(
+          getStationMarkdown(profile, {
+            rootUrl: import.meta.env.VITE_ROOT_URL,
+          }),
+        );
+      },
+    },
+  },
+});

--- a/app/util/agentMarkdownContent.test.ts
+++ b/app/util/agentMarkdownContent.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import { getIssueMarkdown, getOverviewMarkdown } from './agentMarkdownContent';
+
+describe('agent Markdown content builders', () => {
+  it('renders overview Markdown from read-model data', () => {
+    const markdown = getOverviewMarkdown(
+      {
+        data: {
+          issueIdsActiveNow: ['issue-1'],
+          issueIdsActiveToday: [],
+          lineSummaries: [
+            {
+              lineId: 'EWL',
+              status: 'ongoing_disruption',
+              uptimeRatio: 0.995,
+              totalDowntimeSeconds: 300,
+            },
+          ],
+          communitySignals: [
+            {
+              id: 'signal-1',
+              effect: 'delay',
+              reportCount: 2,
+              lineIds: ['EWL'],
+              stationIds: ['EW1'],
+              windowStartAt: '2026-06-11T08:00:00+08:00',
+              windowEndAt: '2026-06-11T09:00:00+08:00',
+              updatedAt: '2026-06-11T09:00:00+08:00',
+            },
+          ],
+        },
+        included: {
+          lines: {
+            EWL: {
+              id: 'EWL',
+              name: translations('East West Line'),
+            },
+          },
+          stations: {
+            EW1: {
+              id: 'EW1',
+              name: translations('Pasir Ris'),
+            },
+          },
+          issues: {
+            'issue-1': {
+              id: 'issue-1',
+              title: translations('Train fault near Pasir Ris'),
+              type: 'disruption',
+              durationSeconds: 300,
+              lineIds: ['EWL'],
+              branchesAffected: [],
+              intervals: [],
+              subtypes: [],
+            },
+          },
+          landmarks: {},
+          towns: {},
+          operators: {},
+        },
+      } as unknown as Parameters<typeof getOverviewMarkdown>[0],
+      { rootUrl: 'https://example.com' },
+    );
+
+    expect(markdown).toContain('# Singapore MRT & LRT Service Status');
+    expect(markdown).toContain(
+      '[Train fault near Pasir Ris](https://example.com/issues/issue-1/index.md)',
+    );
+    expect(markdown).toContain('East West Line');
+    expect(markdown).toContain('99.5%');
+    expect(markdown).toContain('5m');
+    expect(markdown).toContain('/lines/EWL/index.md');
+    expect(markdown).toContain('## Community Reports');
+    expect(markdown).toContain('Delay');
+    expect(markdown).toContain('Pasir Ris (EW1)');
+  });
+
+  it('renders issue Markdown with affected network, intervals, and updates', () => {
+    const markdown = getIssueMarkdown(
+      {
+        data: {
+          id: 'issue-1',
+          updates: [
+            {
+              type: 'statement.official',
+              text: 'Operator update with *markdown-sensitive* text.',
+              textTranslations: null,
+              sourceUrl: 'https://example.com/source',
+              createdAt: '2026-06-11T09:15:00+08:00',
+            },
+          ],
+        },
+        included: {
+          lines: {
+            EWL: {
+              id: 'EWL',
+              name: translations('East West Line'),
+            },
+          },
+          stations: {
+            EW1: {
+              id: 'EW1',
+              name: translations('Pasir Ris'),
+            },
+            EW2: {
+              id: 'EW2',
+              name: translations('Tampines'),
+            },
+          },
+          issues: {
+            'issue-1': {
+              id: 'issue-1',
+              title: translations('Train fault near Pasir Ris'),
+              type: 'disruption',
+              durationSeconds: 1800,
+              lineIds: ['EWL'],
+              branchesAffected: [
+                {
+                  lineId: 'EWL',
+                  branchId: 'ewl-main',
+                  stationIds: ['EW1', 'EW2'],
+                },
+              ],
+              intervals: [
+                {
+                  status: 'ended',
+                  startAt: '2026-06-11T08:45:00+08:00',
+                  endAt: '2026-06-11T09:15:00+08:00',
+                },
+              ],
+              subtypes: ['train.fault'],
+            },
+          },
+          landmarks: {},
+          towns: {},
+          operators: {},
+        },
+      } as unknown as Parameters<typeof getIssueMarkdown>[0],
+      { rootUrl: 'https://example.com' },
+    );
+
+    expect(markdown).toContain('# Train fault near Pasir Ris');
+    expect(markdown).toContain(
+      'Disruption issue affecting East West Line (EWL).',
+    );
+    expect(markdown).toContain('Duration: 30m');
+    expect(markdown).toContain('Pasir Ris (EW1), Tampines (EW2)');
+    expect(markdown).toContain('2026-06-11T08:45:00+08:00');
+    expect(markdown).toContain(
+      'Operator update with \\*markdown-sensitive\\* text.',
+    );
+    expect(markdown).toContain('<https://example.com/source>');
+  });
+});
+
+function translations(value: string) {
+  return {
+    'en-SG': value,
+    'zh-Hans': null,
+    ms: null,
+    ta: null,
+  };
+}

--- a/app/util/agentMarkdownContent.ts
+++ b/app/util/agentMarkdownContent.ts
@@ -1,0 +1,5 @@
+export { getIssueMarkdown } from './agentMarkdownContent/issue';
+export { getLineMarkdown } from './agentMarkdownContent/line';
+export { getOperatorMarkdown } from './agentMarkdownContent/operator';
+export { getOverviewMarkdown } from './agentMarkdownContent/overview';
+export { getStationMarkdown } from './agentMarkdownContent/station';

--- a/app/util/agentMarkdownContent/issue.ts
+++ b/app/util/agentMarkdownContent/issue.ts
@@ -1,0 +1,112 @@
+import {
+  formatMarkdownDateTime,
+  formatMarkdownDurationSeconds,
+  markdownTable,
+  serializeAgentMarkdown,
+} from '../agentMarkdown';
+import {
+  compactRootContent,
+  entityName,
+  formatLineList,
+  formatSubtypes,
+  heading,
+  ISSUE_TYPE_LABELS,
+  issueTitle,
+  link,
+  list,
+  paragraph,
+  stationNames,
+  text,
+} from './shared';
+import { DEFAULT_ROOT_URL, type AgentMarkdownOptions } from './types';
+import type { IssuePayload } from './types';
+
+export function getIssueMarkdown(
+  payload: IssuePayload,
+  options?: AgentMarkdownOptions,
+) {
+  const rootUrl = options?.rootUrl ?? DEFAULT_ROOT_URL;
+  const { data, included } = payload;
+  const issue = included.issues[data.id];
+  const title = issue != null ? issueTitle(issue) : data.id;
+  const intervalsTable =
+    issue == null
+      ? null
+      : markdownTable({
+          headers: ['Status', 'Start', 'End'],
+          rows: issue.intervals.map((interval) => [
+            interval.status,
+            formatMarkdownDateTime(interval.startAt),
+            interval.endAt != null
+              ? formatMarkdownDateTime(interval.endAt)
+              : 'Ongoing',
+          ]),
+        });
+  const affectedRows =
+    issue?.branchesAffected.map((branch) => {
+      const line = included.lines[branch.lineId];
+      return [
+        branch.lineId,
+        line != null ? entityName(line) : branch.lineId,
+        stationNames(branch.stationIds, included).join(', '),
+      ];
+    }) ?? [];
+  const affectedTable = markdownTable({
+    headers: ['Line', 'Name', 'Affected stations'],
+    rows: affectedRows,
+  });
+  const updateItems = data.updates.map((update) => [
+    text(`${formatMarkdownDateTime(update.createdAt)}: ${update.text}`),
+    ...(update.sourceUrl != null
+      ? [text(' Source: '), link(update.sourceUrl, update.sourceUrl, rootUrl)]
+      : []),
+  ]);
+
+  return serializeAgentMarkdown(
+    compactRootContent([
+      heading(1, title),
+      ...(issue != null
+        ? [
+            paragraph([
+              text(
+                `${ISSUE_TYPE_LABELS[issue.type]} issue affecting ${formatLineList(
+                  issue.lineIds,
+                  included,
+                )}.`,
+              ),
+            ]),
+          ]
+        : []),
+      heading(2, 'Links'),
+      list([
+        [link('Human page', `/issues/${data.id}`, rootUrl)],
+        [link('Overview Markdown', '/index.md', rootUrl)],
+      ]),
+      ...(issue != null
+        ? [
+            heading(2, 'Facts'),
+            list([
+              [text(`Issue ID: ${issue.id}`)],
+              [text(`Type: ${ISSUE_TYPE_LABELS[issue.type]}`)],
+              [text(`Subtypes: ${formatSubtypes(issue.subtypes)}`)],
+              [
+                text(
+                  `Duration: ${formatMarkdownDurationSeconds(
+                    issue.durationSeconds,
+                  )}`,
+                ),
+              ],
+            ]),
+          ]
+        : []),
+      heading(2, 'Affected Network'),
+      affectedTable,
+      heading(2, 'Intervals'),
+      intervalsTable,
+      heading(2, 'Updates'),
+      updateItems.length > 0
+        ? list(updateItems)
+        : paragraph([text('No updates are available.')]),
+    ]),
+  );
+}

--- a/app/util/agentMarkdownContent/line.ts
+++ b/app/util/agentMarkdownContent/line.ts
@@ -1,0 +1,108 @@
+import {
+  formatMarkdownDate,
+  markdownTable,
+  serializeAgentMarkdown,
+} from '../agentMarkdown';
+import {
+  communitySignalsSection,
+  compactRootContent,
+  entityName,
+  formatBranchStationCount,
+  formatDurationNullable,
+  formatIssueCounts,
+  formatPercent,
+  heading,
+  issueListOrEmpty,
+  LINE_STATUS_LABELS,
+  link,
+  list,
+  paragraph,
+  stationLinksSection,
+  stationNames,
+  text,
+} from './shared';
+import { DEFAULT_ROOT_URL, type AgentMarkdownOptions } from './types';
+import type { LineProfilePayload } from './types';
+
+export function getLineMarkdown(
+  payload: LineProfilePayload,
+  options?: AgentMarkdownOptions,
+) {
+  const rootUrl = options?.rootUrl ?? DEFAULT_ROOT_URL;
+  const { data, included } = payload;
+  const line = included.lines[data.lineId];
+  const lineName = line != null ? entityName(line) : data.lineId;
+  const operators =
+    line?.operators
+      .map((entry) => included.operators[entry.operatorId])
+      .filter((operator) => operator != null)
+      .map((operator) => entityName(operator)) ?? [];
+  const recentIssues = data.issueIdsRecent
+    .map((issueId) => included.issues[issueId])
+    .filter((issue) => issue != null);
+  const nextMaintenance =
+    data.issueIdNextMaintenance != null
+      ? included.issues[data.issueIdNextMaintenance]
+      : null;
+  const branchRows = data.branches.map((branch) => [
+    branch.id,
+    formatBranchStationCount(branch.stationIds.length),
+    stationNames(branch.stationIds, included).join(', '),
+  ]);
+  const branchTable = markdownTable({
+    headers: ['Branch', 'Stations', 'Station order'],
+    rows: branchRows,
+  });
+
+  return serializeAgentMarkdown(
+    compactRootContent([
+      heading(1, `${lineName} (${data.lineId})`),
+      paragraph([
+        text(`Current status: ${LINE_STATUS_LABELS[data.lineSummary.status]}.`),
+      ]),
+      heading(2, 'Links'),
+      list([
+        [link('Human page', `/lines/${data.lineId}`, rootUrl)],
+        [link('Overview Markdown', '/index.md', rootUrl)],
+      ]),
+      heading(2, 'Facts'),
+      list([
+        [text(`Line ID: ${data.lineId}`)],
+        [text(`Operators: ${operators.join(', ') || 'Unknown'}`)],
+        [
+          text(
+            `Started: ${
+              line?.startedAt != null
+                ? formatMarkdownDate(line.startedAt)
+                : 'Future'
+            }`,
+          ),
+        ],
+        [text(`Recent uptime: ${formatPercent(data.lineSummary.uptimeRatio)}`)],
+        [
+          text(
+            `Recent downtime: ${formatDurationNullable(
+              data.lineSummary.totalDowntimeSeconds,
+            )}`,
+          ),
+        ],
+        [text(`Issue counts: ${formatIssueCounts(data.issueCountByType)}`)],
+      ]),
+      ...issueListOrEmpty(
+        'Next Planned Maintenance',
+        nextMaintenance != null ? [nextMaintenance] : [],
+        rootUrl,
+      ),
+      ...issueListOrEmpty('Recent Issues', recentIssues, rootUrl),
+      heading(2, 'Branches'),
+      branchTable,
+      ...stationLinksSection(
+        'Interchanges',
+        data.stationIdsInterchanges,
+        included,
+        rootUrl,
+      ),
+      ...communitySignalsSection(data.communitySignals, included, rootUrl),
+    ]),
+  );
+}

--- a/app/util/agentMarkdownContent/operator.ts
+++ b/app/util/agentMarkdownContent/operator.ts
@@ -1,0 +1,101 @@
+import {
+  formatMarkdownDurationSeconds,
+  markdownTable,
+  serializeAgentMarkdown,
+} from '../agentMarkdown';
+import {
+  compactRootContent,
+  entityName,
+  formatIssueCounts,
+  formatPercent,
+  heading,
+  issueListOrEmpty,
+  LINE_STATUS_LABELS,
+  link,
+  list,
+  paragraph,
+  stationLinksSection,
+  text,
+} from './shared';
+import { DEFAULT_ROOT_URL, type AgentMarkdownOptions } from './types';
+import type { OperatorProfilePayload } from './types';
+
+const OPERATOR_STATUS_LABELS = {
+  all_operational: 'All lines operational',
+  all_lines_closed_for_day: 'All lines outside service hours',
+  some_lines_disrupted: 'Some lines disrupted',
+  some_lines_under_maintenance: 'Some lines under maintenance',
+};
+
+export function getOperatorMarkdown(
+  payload: OperatorProfilePayload,
+  options?: AgentMarkdownOptions,
+) {
+  const rootUrl = options?.rootUrl ?? DEFAULT_ROOT_URL;
+  const { data, included } = payload;
+  const operator = included.operators[data.operatorId];
+  const operatorName =
+    operator != null ? entityName(operator) : data.operatorId;
+  const recentIssues = data.issueIdsRecent
+    .map((issueId) => included.issues[issueId])
+    .filter((issue) => issue != null);
+  const performanceTable = markdownTable({
+    headers: ['Line', 'Name', 'Status', 'Uptime', 'Issues', 'Markdown'],
+    rows: data.linePerformanceComparison.map((performance) => {
+      const line = included.lines[performance.lineId];
+      return [
+        performance.lineId,
+        line != null ? entityName(line) : performance.lineId,
+        LINE_STATUS_LABELS[performance.status],
+        formatPercent(performance.uptimeRatio),
+        performance.issueCount.toString(),
+        `/lines/${performance.lineId}/index.md`,
+      ];
+    }),
+  });
+
+  return serializeAgentMarkdown(
+    compactRootContent([
+      heading(1, operatorName),
+      paragraph([
+        text(
+          `Current status: ${
+            OPERATOR_STATUS_LABELS[data.currentOperationalStatus]
+          }.`,
+        ),
+      ]),
+      heading(2, 'Links'),
+      list([
+        [link('Human page', `/operators/${data.operatorId}`, rootUrl)],
+        [link('Overview Markdown', '/index.md', rootUrl)],
+      ]),
+      heading(2, 'Facts'),
+      list([
+        [text(`Operator ID: ${data.operatorId}`)],
+        [text(`Lines operated: ${data.lineIds.length}`)],
+        [text(`Stations operated: ${data.totalStationsOperated}`)],
+        [text(`Founded: ${operator?.foundedAt ?? 'Unknown'}`)],
+        [text(`Years of operation: ${data.yearsOfOperation}`)],
+        [text(`Aggregate uptime: ${formatPercent(data.aggregateUptimeRatio)}`)],
+        [
+          text(
+            `Total recent downtime: ${formatMarkdownDurationSeconds(
+              data.totalDowntimeDurationSeconds,
+            )}`,
+          ),
+        ],
+        [text(`Issue counts: ${formatIssueCounts(data.totalIssuesByType)}`)],
+      ]),
+      heading(2, 'Line Performance'),
+      performanceTable,
+      ...stationLinksSection(
+        'Lines Currently Affected',
+        data.linesAffected,
+        included,
+        rootUrl,
+        'line',
+      ),
+      ...issueListOrEmpty('Recent Issues', recentIssues, rootUrl),
+    ]),
+  );
+}

--- a/app/util/agentMarkdownContent/overview.ts
+++ b/app/util/agentMarkdownContent/overview.ts
@@ -1,0 +1,80 @@
+import { markdownTable, serializeAgentMarkdown } from '../agentMarkdown';
+import {
+  communitySignalsSection,
+  compactRootContent,
+  entityName,
+  formatDurationNullable,
+  formatPercent,
+  heading,
+  issueListOrEmpty,
+  LINE_STATUS_LABELS,
+  link,
+  list,
+  paragraph,
+  text,
+} from './shared';
+import { DEFAULT_ROOT_URL, type AgentMarkdownOptions } from './types';
+import type { OverviewPayload } from './types';
+
+export function getOverviewMarkdown(
+  payload: OverviewPayload,
+  options?: AgentMarkdownOptions,
+) {
+  const rootUrl = options?.rootUrl ?? DEFAULT_ROOT_URL;
+  const { data, included } = payload;
+  const activeNowIssues = data.issueIdsActiveNow
+    .map((issueId) => included.issues[issueId])
+    .filter((issue) => issue != null);
+  const activeTodayIssues = data.issueIdsActiveToday
+    .map((issueId) => included.issues[issueId])
+    .filter((issue) => issue != null);
+
+  const lineRows = data.lineSummaries.map((summary) => {
+    const line = included.lines[summary.lineId];
+    return [
+      summary.lineId,
+      line != null ? entityName(line) : summary.lineId,
+      LINE_STATUS_LABELS[summary.status],
+      formatPercent(summary.uptimeRatio),
+      formatDurationNullable(summary.totalDowntimeSeconds),
+      `/lines/${summary.lineId}/index.md`,
+    ];
+  });
+  const lineTable = markdownTable({
+    headers: [
+      'Line',
+      'Name',
+      'Current status',
+      'Uptime',
+      'Downtime',
+      'Markdown',
+    ],
+    rows: lineRows,
+  });
+
+  return serializeAgentMarkdown(
+    compactRootContent([
+      heading(1, 'Singapore MRT & LRT Service Status'),
+      paragraph([
+        text(
+          'Current public read-model summary for Singapore MRT and LRT service status.',
+        ),
+      ]),
+      heading(2, 'Links'),
+      list([
+        [link('Human page', '/', rootUrl)],
+        [link('llms.txt', '/llms.txt', rootUrl)],
+      ]),
+      heading(2, 'Current Advisories'),
+      ...issueListOrEmpty('Active disruptions now', activeNowIssues, rootUrl),
+      ...issueListOrEmpty(
+        'Planned maintenance and infrastructure advisories today',
+        activeTodayIssues,
+        rootUrl,
+      ),
+      heading(2, 'Line Status'),
+      lineTable,
+      ...communitySignalsSection(data.communitySignals, included, rootUrl),
+    ]),
+  );
+}

--- a/app/util/agentMarkdownContent/shared.ts
+++ b/app/util/agentMarkdownContent/shared.ts
@@ -1,0 +1,248 @@
+import type { IssueType } from '@mrtdown/core';
+import type {
+  Link,
+  List,
+  ListItem,
+  Paragraph,
+  PhrasingContent,
+  RootContent,
+} from 'mdast';
+import {
+  formatMarkdownDateTime,
+  formatMarkdownDurationSeconds,
+  markdownTable,
+} from '../agentMarkdown';
+import type { PublicCrowdReportSignal } from '../crowdReports';
+import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
+import type { IncludedEntities, Issue, LineSummaryStatus } from '~/types';
+
+const DEFAULT_LOCALE = 'en-SG';
+
+export const ISSUE_TYPE_LABELS = {
+  disruption: 'Disruption',
+  maintenance: 'Maintenance',
+  infra: 'Infrastructure',
+} satisfies Record<IssueType, string>;
+
+export const LINE_STATUS_LABELS = {
+  future_service: 'Under development',
+  closed_for_day: 'Outside service hours',
+  ongoing_disruption: 'Disruption',
+  ongoing_maintenance: 'Maintenance',
+  ongoing_infra: 'Infrastructure issue',
+  normal: 'Operational',
+} satisfies Record<LineSummaryStatus, string>;
+
+const CROWD_REPORT_EFFECT_LABELS = {
+  delay: 'Delay',
+  'no-service': 'No service',
+  crowding: 'Crowding',
+  'skipped-stop': 'Train skipped stop',
+  unknown: 'Not sure',
+};
+
+export function communitySignalsSection(
+  signals: PublicCrowdReportSignal[],
+  included: IncludedEntities,
+  rootUrl: string,
+): RootContent[] {
+  if (signals.length === 0) {
+    return [];
+  }
+
+  const rows = signals.map((signal) => [
+    CROWD_REPORT_EFFECT_LABELS[signal.effect ?? 'unknown'],
+    signal.reportCount.toString(),
+    formatLineList(signal.lineIds, included),
+    stationNames(signal.stationIds, included).join(', '),
+    formatMarkdownDateTime(signal.updatedAt),
+  ]);
+  const table = markdownTable({
+    headers: ['Effect', 'Reports', 'Lines', 'Stations', 'Updated'],
+    rows,
+  });
+
+  return compactRootContent([
+    heading(2, 'Community Reports'),
+    paragraph([
+      text(
+        'Aggregated commuter reports shown separately from official operator advisories.',
+      ),
+    ]),
+    table,
+    paragraph([link('Submit report', '/report', rootUrl)]),
+  ]);
+}
+
+export function issueListOrEmpty(
+  title: string,
+  issues: Issue[],
+  rootUrl: string,
+): RootContent[] {
+  return [
+    heading(3, title),
+    issues.length > 0
+      ? list(
+          issues.map((issue) => [
+            link(issueTitle(issue), `/issues/${issue.id}/index.md`, rootUrl),
+            text(` (${ISSUE_TYPE_LABELS[issue.type]})`),
+          ]),
+        )
+      : paragraph([text('None.')]),
+  ];
+}
+
+export function stationLinksSection(
+  title: string,
+  ids: string[],
+  included: IncludedEntities,
+  rootUrl: string,
+  entityType: 'station' | 'line' = 'station',
+): RootContent[] {
+  if (ids.length === 0) {
+    return [];
+  }
+
+  return [
+    heading(2, title),
+    list(
+      ids.map((id) => {
+        if (entityType === 'line') {
+          const line = included.lines[id];
+          return [
+            link(
+              line != null ? entityName(line) : id,
+              `/lines/${id}/index.md`,
+              rootUrl,
+            ),
+          ];
+        }
+        const station = included.stations[id];
+        return [
+          link(
+            station != null ? entityName(station) : id,
+            `/stations/${id}/index.md`,
+            rootUrl,
+          ),
+        ];
+      }),
+    ),
+  ];
+}
+
+export function stationNames(stationIds: string[], included: IncludedEntities) {
+  return stationIds.map((stationId) => {
+    const station = included.stations[stationId];
+    return station != null
+      ? `${entityName(station)} (${stationId})`
+      : stationId;
+  });
+}
+
+export function formatLineList(lineIds: string[], included: IncludedEntities) {
+  if (lineIds.length === 0) {
+    return 'None';
+  }
+
+  return lineIds
+    .map((lineId) => {
+      const line = included.lines[lineId];
+      return line != null ? `${entityName(line)} (${lineId})` : lineId;
+    })
+    .join(', ');
+}
+
+export function formatIssueCounts(counts: Partial<Record<IssueType, number>>) {
+  return (Object.keys(ISSUE_TYPE_LABELS) as IssueType[])
+    .map((type) => `${ISSUE_TYPE_LABELS[type]}: ${counts[type] ?? 0}`)
+    .join(', ');
+}
+
+export function formatSubtypes(subtypes: string[]) {
+  if (subtypes.length === 0) {
+    return 'None';
+  }
+  return subtypes.map((subtype) => subtype.replaceAll('.', ' ')).join(', ');
+}
+
+export function formatPercent(value: number | null) {
+  if (value == null) {
+    return 'N/A';
+  }
+
+  return new Intl.NumberFormat(DEFAULT_LOCALE, {
+    style: 'percent',
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+export function formatDurationNullable(value: number | null) {
+  return value == null ? 'N/A' : formatMarkdownDurationSeconds(value);
+}
+
+export function formatBranchStationCount(count: number) {
+  return `${count} ${count === 1 ? 'station' : 'stations'}`;
+}
+
+export function entityName(entity: {
+  name: Parameters<typeof getLocalizedTranslation>[0];
+}) {
+  return getLocalizedTranslation(entity.name, DEFAULT_LOCALE);
+}
+
+export function issueTitle(issue: Issue) {
+  return getLocalizedTranslation(issue.title, DEFAULT_LOCALE);
+}
+
+export function heading(depth: 1 | 2 | 3, value: string): RootContent {
+  return {
+    type: 'heading',
+    depth,
+    children: [text(value)],
+  };
+}
+
+export function paragraph(children: PhrasingContent[]): Paragraph {
+  return {
+    type: 'paragraph',
+    children,
+  };
+}
+
+export function list(items: PhrasingContent[][]): List {
+  return {
+    type: 'list',
+    ordered: false,
+    spread: false,
+    children: items.map(listItem),
+  };
+}
+
+export function link(label: string, path: string, rootUrl: string): Link {
+  return {
+    type: 'link',
+    url: new URL(path, rootUrl).toString(),
+    children: [text(label)],
+  };
+}
+
+export function text(value: string): PhrasingContent {
+  return {
+    type: 'text',
+    value,
+  };
+}
+
+export function compactRootContent(
+  children: Array<RootContent | null>,
+): RootContent[] {
+  return children.filter((child) => child != null);
+}
+
+function listItem(children: PhrasingContent[]): ListItem {
+  return {
+    type: 'listItem',
+    spread: false,
+    children: [paragraph(children)],
+  };
+}

--- a/app/util/agentMarkdownContent/station.ts
+++ b/app/util/agentMarkdownContent/station.ts
@@ -1,0 +1,103 @@
+import type { PhrasingContent } from 'mdast';
+import { markdownTable, serializeAgentMarkdown } from '../agentMarkdown';
+import {
+  communitySignalsSection,
+  compactRootContent,
+  entityName,
+  formatIssueCounts,
+  heading,
+  issueListOrEmpty,
+  LINE_STATUS_LABELS,
+  link,
+  list,
+  paragraph,
+  text,
+} from './shared';
+import { DEFAULT_ROOT_URL, type AgentMarkdownOptions } from './types';
+import type { IncludedEntities, Station } from '~/types';
+import type { StationProfilePayload } from './types';
+
+export function getStationMarkdown(
+  payload: StationProfilePayload,
+  options?: AgentMarkdownOptions,
+) {
+  const rootUrl = options?.rootUrl ?? DEFAULT_ROOT_URL;
+  const { data, included } = payload;
+  const station = included.stations[data.stationId];
+  const stationName = station != null ? entityName(station) : data.stationId;
+  const recentIssues = data.issueIdsRecent
+    .map((issueId) => included.issues[issueId])
+    .filter((issue) => issue != null);
+  const memberships = uniqueStationMemberships(station);
+  const membershipRows = memberships.map((membership) => {
+    const line = included.lines[membership.lineId];
+    return [
+      membership.code,
+      membership.lineId,
+      line != null ? entityName(line) : membership.lineId,
+      membership.structureType,
+      membership.startedAt,
+    ];
+  });
+  const membershipTable = markdownTable({
+    headers: ['Code', 'Line ID', 'Line', 'Structure', 'Started'],
+    rows: membershipRows,
+  });
+
+  return serializeAgentMarkdown(
+    compactRootContent([
+      heading(1, `${stationName} Station (${data.stationId})`),
+      paragraph([text(`Current status: ${LINE_STATUS_LABELS[data.status]}.`)]),
+      heading(2, 'Links'),
+      list([
+        [link('Human page', `/stations/${data.stationId}`, rootUrl)],
+        [link('Overview Markdown', '/index.md', rootUrl)],
+      ]),
+      heading(2, 'Facts'),
+      list([
+        [text(`Station ID: ${data.stationId}`)],
+        [text(`Issue counts: ${formatIssueCounts(data.issueCountByType)}`)],
+        ...stationAreaFacts(station, included),
+      ]),
+      heading(2, 'Lines Served'),
+      membershipTable,
+      ...issueListOrEmpty('Recent Issues', recentIssues, rootUrl),
+      ...communitySignalsSection(data.communitySignals, included, rootUrl),
+    ]),
+  );
+}
+
+function stationAreaFacts(
+  station: Station | undefined,
+  included: IncludedEntities,
+): PhrasingContent[][] {
+  if (station == null) {
+    return [];
+  }
+  const town = included.towns[station.townId];
+  const landmarks = station.landmarkIds
+    .map((landmarkId) => included.landmarks[landmarkId])
+    .filter((landmark) => landmark != null)
+    .map((landmark) => entityName(landmark));
+
+  return [
+    [text(`Town: ${town != null ? entityName(town) : station.townId}`)],
+    [text(`Nearby landmarks: ${landmarks.join(', ') || 'None listed'}`)],
+  ];
+}
+
+function uniqueStationMemberships(station: Station | undefined) {
+  if (station == null) {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  return station.memberships.filter((membership) => {
+    const key = `${membership.lineId}:${membership.code}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}

--- a/app/util/agentMarkdownContent/types.ts
+++ b/app/util/agentMarkdownContent/types.ts
@@ -1,0 +1,23 @@
+import type {
+  getIssueData,
+  getLineProfileData,
+  getOperatorProfileData,
+  getOverviewData,
+  getStationProfileData,
+} from '../db.queries';
+
+export const DEFAULT_ROOT_URL = 'https://www.mrtdown.org';
+
+export interface AgentMarkdownOptions {
+  rootUrl?: string;
+}
+
+export type OverviewPayload = Awaited<ReturnType<typeof getOverviewData>>;
+export type LineProfilePayload = Awaited<ReturnType<typeof getLineProfileData>>;
+export type StationProfilePayload = Awaited<
+  ReturnType<typeof getStationProfileData>
+>;
+export type OperatorProfilePayload = Awaited<
+  ReturnType<typeof getOperatorProfileData>
+>;
+export type IssuePayload = Awaited<ReturnType<typeof getIssueData>>;

--- a/app/util/llmsTxt.test.ts
+++ b/app/util/llmsTxt.test.ts
@@ -14,18 +14,15 @@ describe('getLlmsTxt', () => {
     );
   });
 
-  it('only advertises Markdown routes that exist in this phase', () => {
+  it('advertises canonical Markdown routes and entity route patterns', () => {
     const markdown = getLlmsTxt();
 
     expect(markdown).toContain('# mrtdown');
     expect(markdown).toContain('## Available Markdown');
-    expect(markdown).toContain(
-      'Additional entity Markdown routes will be linked here after those routes are implemented.',
-    );
-    expect(markdown).not.toContain('/index.md');
-    expect(markdown).not.toContain('/lines/{lineId}/index.md');
-    expect(markdown).not.toContain('/stations/{stationId}/index.md');
-    expect(markdown).not.toContain('/operators/{operatorId}/index.md');
-    expect(markdown).not.toContain('/issues/{issueId}/index.md');
+    expect(markdown).toContain('/index.md');
+    expect(markdown).toContain('/lines/%7BlineId%7D/index.md');
+    expect(markdown).toContain('/stations/%7BstationId%7D/index.md');
+    expect(markdown).toContain('/operators/%7BoperatorId%7D/index.md');
+    expect(markdown).toContain('/issues/%7BissueId%7D/index.md');
   });
 });

--- a/app/util/llmsTxt.ts
+++ b/app/util/llmsTxt.ts
@@ -87,15 +87,55 @@ export function getLlmsTxt(options?: LlmsTxtOptions) {
               ': curated agent entry point for currently available public resources.',
           },
         ]),
+        listItem([
+          link('Overview Markdown', '/index.md', rootUrl),
+          {
+            type: 'text',
+            value:
+              ': current system status, active advisories, line status, and public community report signals.',
+          },
+        ]),
+        listItem([
+          link('Line Markdown pattern', '/lines/{lineId}/index.md', rootUrl),
+          {
+            type: 'text',
+            value:
+              ': line profile, current status, recent issues, branches, interchanges, and public community report signals.',
+          },
+        ]),
+        listItem([
+          link(
+            'Station Markdown pattern',
+            '/stations/{stationId}/index.md',
+            rootUrl,
+          ),
+          {
+            type: 'text',
+            value:
+              ': station profile, served lines, current status, recent issues, and public community report signals.',
+          },
+        ]),
+        listItem([
+          link(
+            'Operator Markdown pattern',
+            '/operators/{operatorId}/index.md',
+            rootUrl,
+          ),
+          {
+            type: 'text',
+            value:
+              ': operator profile, current status, line performance, and recent issues.',
+          },
+        ]),
+        listItem([
+          link('Issue Markdown pattern', '/issues/{issueId}/index.md', rootUrl),
+          {
+            type: 'text',
+            value: ': issue summary, affected network, intervals, and updates.',
+          },
+        ]),
       ],
     },
-    paragraph([
-      {
-        type: 'text',
-        value:
-          'Additional entity Markdown routes will be linked here after those routes are implemented.',
-      },
-    ]),
   ];
 
   content.push(

--- a/docs/plans/active/markdown-for-agents.md
+++ b/docs/plans/active/markdown-for-agents.md
@@ -143,6 +143,10 @@ Exit criteria:
   agent entry point and links to current public resources. Deferred linking
   Phase 3 entity Markdown URLs until those routes exist, so agents do not
   follow advertised 404s.
+- 2026-06-11: Added the Phase 3 `/index.md`, `/lines/$lineId/index.md`,
+  `/stations/$stationId/index.md`, `/operators/$operatorId/index.md`, and
+  `/issues/$issueId/index.md` routes backed by read-model server functions.
+  Updated `/llms.txt` to advertise the new Markdown surface.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Add explicit app-owned Markdown routes for the overview, lines, stations, operators, and issues.
- Build Markdown from read-model server function data through focused agent Markdown content builders.
- Update `/llms.txt` to advertise the new Markdown surface and add coverage for the new content builders.
- Record Phase 3 progress in the markdown-for-agents plan.

## Validation

- `npm run verify`

Note: `/llms.txt` was smoke-tested locally and returned `text/markdown` with public markdown cache headers. DB-backed local route smoke checks require a local Postgres instance; the local dev server failed those requests with `ECONNREFUSED localhost:5432`, so automated verification is the completed validation for the DB-backed paths.