### PR TITLE
fix: harden crowd report dispatch freshness

### DIFF
--- a/app/util/crowdReportDispatch.test.ts
+++ b/app/util/crowdReportDispatch.test.ts
@@ -184,6 +184,75 @@ function makeFakeDispatchEligibilityDb() {
   };
 }
 
+function makeFakePostSendMarkMissDb() {
+  const executeCalls: unknown[] = [];
+  const updateSets: unknown[] = [];
+  const whereCalls: unknown[] = [];
+  let updateCount = 0;
+  const selectBuilder = {
+    from() {
+      return this;
+    },
+    where(condition: unknown) {
+      whereCalls.push(condition);
+      return this;
+    },
+    limit() {
+      return Promise.resolve([{ id: 'cluster-1' }]);
+    },
+  };
+  const updateBuilder = {
+    set(values: unknown) {
+      const updateIndex = updateCount;
+      updateCount += 1;
+      updateSets.push(values);
+      return {
+        where(condition: unknown) {
+          whereCalls.push(condition);
+          if (updateIndex === 0) {
+            return {
+              returning() {
+                return Promise.resolve([]);
+              },
+            };
+          }
+          return Promise.resolve();
+        },
+      };
+    },
+  };
+
+  return {
+    executeCalls,
+    updateSets,
+    whereCalls,
+    db: {
+      transaction<T>(
+        callback: (transaction: {
+          execute: (
+            query: unknown,
+          ) => Promise<{ rows: Array<{ locked: boolean }> }>;
+          select: () => typeof selectBuilder;
+          update: () => typeof updateBuilder;
+        }) => Promise<T>,
+      ) {
+        return callback({
+          execute(query: unknown) {
+            executeCalls.push(query);
+            return Promise.resolve({ rows: [{ locked: true }] });
+          },
+          select() {
+            return selectBuilder;
+          },
+          update() {
+            return updateBuilder;
+          },
+        });
+      },
+    },
+  };
+}
+
 describe('buildCrowdReportIngestPayload', () => {
   it('builds a valid crowd-report ingest payload without site-local metadata', () => {
     const candidate = buildCrowdReportIngestPayload({
@@ -427,6 +496,71 @@ describe('getDispatchableCrowdReportCandidates', () => {
     expect(eligibilityWhereSql).toContain('"crowd_reports"."id" not in');
     expect(eligibilityWhereSql).toContain('count(*)::int');
     expect(eligibilityWhereSql).toContain('"crowd_reports"."id" in');
+  });
+
+  it('reports a post-send stale local success mark as failed instead of skipped', async () => {
+    const fake = makeFakePostSendMarkMissDb();
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(null, {
+        status: 204,
+      }),
+    );
+
+    await expect(
+      dispatchPendingCrowdReports(
+        fake.db as never,
+        {
+          rootUrl: 'https://mrtdown.example',
+          token: 'github-token',
+          candidates: [
+            {
+              kind: 'cluster',
+              id: 'cluster-1',
+              reportIds: ['stale-report-1'],
+              payload: IngestPayloadSchema.parse({
+                content: [
+                  {
+                    source: 'crowd-report',
+                    reportId: 'cluster:cluster-1',
+                    text: 'A community report describes this issue.',
+                    createdAt: '2026-05-24T04:40:00.000Z',
+                    observedAt: '2026-05-24T12:30:00.000+08:00',
+                    lineIds: ['BPLRT'],
+                    reportCount: 1,
+                    url: 'https://mrtdown.example/report?communitySource=cluster%3Acluster-1',
+                  },
+                ],
+              }),
+            },
+          ],
+        },
+        fetchImpl,
+      ),
+    ).resolves.toMatchObject({
+      success: false,
+      count: 1,
+      dispatched: 0,
+      failed: 1,
+      results: [
+        {
+          kind: 'cluster',
+          id: 'cluster-1',
+          success: false,
+          error:
+            'Crowd report dispatch was sent, but local success marking became stale',
+        },
+      ],
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fake.updateSets).toHaveLength(3);
+    expect(fake.updateSets[1]).toMatchObject({
+      status: 'dispatched',
+    });
+    expect(fake.updateSets[2]).toMatchObject({
+      dispatch_error:
+        'Crowd report dispatch was sent, but local success marking became stale',
+    });
   });
 });
 

--- a/app/util/crowdReportDispatch.test.ts
+++ b/app/util/crowdReportDispatch.test.ts
@@ -498,7 +498,7 @@ describe('getDispatchableCrowdReportCandidates', () => {
     expect(eligibilityWhereSql).toContain('"crowd_reports"."id" in');
   });
 
-  it('reports a post-send stale local success mark as failed instead of skipped', async () => {
+  it('reports a post-send stale local success mark as failed without closing the cluster', async () => {
     const fake = makeFakePostSendMarkMissDb();
     const fetchImpl = vi.fn().mockResolvedValue(
       new Response(null, {
@@ -553,11 +553,8 @@ describe('getDispatchableCrowdReportCandidates', () => {
     });
 
     expect(fetchImpl).toHaveBeenCalledTimes(1);
-    expect(fake.updateSets).toHaveLength(3);
+    expect(fake.updateSets).toHaveLength(2);
     expect(fake.updateSets[1]).toMatchObject({
-      status: 'dispatched',
-    });
-    expect(fake.updateSets[2]).toMatchObject({
       dispatch_error:
         'Crowd report dispatch was sent, but local success marking became stale',
     });

--- a/app/util/crowdReportDispatch.test.ts
+++ b/app/util/crowdReportDispatch.test.ts
@@ -99,13 +99,25 @@ function makeFakeClusterCandidateDb() {
   };
 }
 
-function makeFakeDispatchUpdateDb() {
+function makeFakeDispatchUpdateDb(
+  clusterUpdateRows: Array<{ id: string }> = [{ id: 'cluster-1' }],
+) {
   const whereCalls: unknown[] = [];
+  let updateCount = 0;
   const updateBuilder = {
     set() {
+      const updateIndex = updateCount;
+      updateCount += 1;
       return {
         where(condition: unknown) {
           whereCalls.push(condition);
+          if (updateIndex === 0) {
+            return {
+              returning() {
+                return Promise.resolve(clusterUpdateRows);
+              },
+            };
+          }
           return Promise.resolve();
         },
       };
@@ -334,6 +346,38 @@ describe('getDispatchableCrowdReportCandidates', () => {
     expect(reportUpdateWhereSql).not.toContain(
       '"crowd_reports"."cluster_id" =',
     );
+  });
+
+  it('does not mark cluster payload reports when the cluster freshness update misses', async () => {
+    const fake = makeFakeDispatchUpdateDb([]);
+
+    await expect(
+      markCrowdReportDispatchSuccess(
+        fake.db as never,
+        {
+          kind: 'cluster',
+          id: 'cluster-1',
+          reportIds: ['stale-report-1'],
+          payload: IngestPayloadSchema.parse({
+            content: [
+              {
+                source: 'crowd-report',
+                reportId: 'cluster:cluster-1',
+                text: 'A community report describes this issue.',
+                createdAt: '2026-05-24T04:40:00.000Z',
+                observedAt: '2026-05-24T12:30:00.000+08:00',
+                lineIds: ['BPLRT'],
+                reportCount: 1,
+                url: 'https://mrtdown.example/report?communitySource=cluster%3Acluster-1',
+              },
+            ],
+          }),
+        },
+        '2026-05-24T04:45:00.000Z',
+      ),
+    ).resolves.toBe(false);
+
+    expect(fake.whereCalls).toHaveLength(1);
   });
 
   it('rechecks cluster payload freshness under the dispatch lock', async () => {

--- a/app/util/crowdReportDispatch.test.ts
+++ b/app/util/crowdReportDispatch.test.ts
@@ -328,6 +328,8 @@ describe('getDispatchableCrowdReportCandidates', () => {
     expect(clusterUpdateWhereSql).toContain('not exists');
     expect(clusterUpdateWhereSql).toContain('"still_happening" is true');
     expect(clusterUpdateWhereSql).toContain('"crowd_reports"."id" not in');
+    expect(clusterUpdateWhereSql).toContain('count(*)::int');
+    expect(clusterUpdateWhereSql).toContain('"crowd_reports"."id" in');
     expect(reportUpdateWhereSql).toContain('"crowd_reports"."id" in');
     expect(reportUpdateWhereSql).not.toContain(
       '"crowd_reports"."cluster_id" =',
@@ -379,6 +381,8 @@ describe('getDispatchableCrowdReportCandidates', () => {
     expect(eligibilityWhereSql).toContain('not exists');
     expect(eligibilityWhereSql).toContain('"still_happening" is true');
     expect(eligibilityWhereSql).toContain('"crowd_reports"."id" not in');
+    expect(eligibilityWhereSql).toContain('count(*)::int');
+    expect(eligibilityWhereSql).toContain('"crowd_reports"."id" in');
   });
 });
 

--- a/app/util/crowdReportDispatch.ts
+++ b/app/util/crowdReportDispatch.ts
@@ -595,6 +595,31 @@ async function markCrowdReportDispatchFailureInTransaction(
     .where(getCrowdReportDispatchReportScope(candidate));
 }
 
+async function markCrowdReportClusterSentAfterStaleSuccessInTransaction(
+  tx: Pick<CrowdReportTransaction, 'update'>,
+  candidate: CrowdReportDispatchCandidate,
+  dispatchedAt: string,
+) {
+  if (candidate.kind !== 'cluster') {
+    return;
+  }
+
+  await tx
+    .update(crowdReportClustersTable)
+    .set({
+      status: 'dispatched',
+      dispatched_at: dispatchedAt,
+      updated_at: sql`now()`,
+    })
+    .where(
+      and(
+        eq(crowdReportClustersTable.id, candidate.id),
+        eq(crowdReportClustersTable.status, 'accepted'),
+        isNull(crowdReportClustersTable.dispatched_at),
+      ),
+    );
+}
+
 function getCrowdReportDispatchReportScope(
   candidate: CrowdReportDispatchCandidate,
 ) {
@@ -700,13 +725,22 @@ async function dispatchCrowdReportCandidateWithLock(
         config,
         fetchImpl,
       );
+      const dispatchedAt =
+        DateTime.now().toUTC().toISO() ?? new Date().toISOString();
       const marked = await markCrowdReportDispatchSuccessInTransaction(
         tx,
         candidate,
-        DateTime.now().toUTC().toISO() ?? new Date().toISOString(),
+        dispatchedAt,
       );
       if (!marked) {
-        return { skipped: true as const };
+        await markCrowdReportClusterSentAfterStaleSuccessInTransaction(
+          tx,
+          candidate,
+          dispatchedAt,
+        );
+        throw new Error(
+          'Crowd report dispatch was sent, but local success marking became stale',
+        );
       }
       return { skipped: false as const, dispatchResponse };
     } catch (error) {

--- a/app/util/crowdReportDispatch.ts
+++ b/app/util/crowdReportDispatch.ts
@@ -557,6 +557,7 @@ async function markCrowdReportDispatchSuccessInTransaction(
         and(
           eq(crowdReportClustersTable.id, candidate.id),
           hasNoOngoingClusterReportsOutsideDispatchPayload(candidate),
+          hasAllClusterDispatchPayloadReportsCurrent(candidate),
         ),
       );
   }
@@ -607,6 +608,23 @@ function hasNoOngoingClusterReportsOutsideDispatchPayload(
   )`;
 }
 
+function hasAllClusterDispatchPayloadReportsCurrent(
+  candidate: CrowdReportDispatchCandidate,
+) {
+  if (candidate.reportIds.length === 0) {
+    return sql`false`;
+  }
+
+  return sql`(
+    select count(*)::int
+    from ${crowdReportsTable}
+    where ${crowdReportsTable.cluster_id} = ${candidate.id}
+      and ${crowdReportsTable.status} in ('accepted', 'duplicate')
+      and ${crowdReportsTable.still_happening} is true
+      and ${inArray(crowdReportsTable.id, candidate.reportIds)}
+  ) = ${candidate.reportIds.length}`;
+}
+
 async function tryAcquireCrowdReportDispatchLock(
   tx: CrowdReportTransaction,
   candidate: CrowdReportDispatchCandidate,
@@ -633,6 +651,7 @@ async function isCrowdReportDispatchCandidateEligible(
           hasCrowdReportClusterScope(),
           hasCrowdReportClusterCurrentConfidence(),
           hasNoOngoingClusterReportsOutsideDispatchPayload(candidate),
+          hasAllClusterDispatchPayloadReportsCurrent(candidate),
         ),
       )
       .limit(1);

--- a/app/util/crowdReportDispatch.ts
+++ b/app/util/crowdReportDispatch.ts
@@ -595,31 +595,6 @@ async function markCrowdReportDispatchFailureInTransaction(
     .where(getCrowdReportDispatchReportScope(candidate));
 }
 
-async function markCrowdReportClusterSentAfterStaleSuccessInTransaction(
-  tx: Pick<CrowdReportTransaction, 'update'>,
-  candidate: CrowdReportDispatchCandidate,
-  dispatchedAt: string,
-) {
-  if (candidate.kind !== 'cluster') {
-    return;
-  }
-
-  await tx
-    .update(crowdReportClustersTable)
-    .set({
-      status: 'dispatched',
-      dispatched_at: dispatchedAt,
-      updated_at: sql`now()`,
-    })
-    .where(
-      and(
-        eq(crowdReportClustersTable.id, candidate.id),
-        eq(crowdReportClustersTable.status, 'accepted'),
-        isNull(crowdReportClustersTable.dispatched_at),
-      ),
-    );
-}
-
 function getCrowdReportDispatchReportScope(
   candidate: CrowdReportDispatchCandidate,
 ) {
@@ -733,11 +708,6 @@ async function dispatchCrowdReportCandidateWithLock(
         dispatchedAt,
       );
       if (!marked) {
-        await markCrowdReportClusterSentAfterStaleSuccessInTransaction(
-          tx,
-          candidate,
-          dispatchedAt,
-        );
         throw new Error(
           'Crowd report dispatch was sent, but local success marking became stale',
         );

--- a/app/util/crowdReportDispatch.ts
+++ b/app/util/crowdReportDispatch.ts
@@ -526,7 +526,7 @@ export async function markCrowdReportDispatchSuccess(
   candidate: CrowdReportDispatchCandidate,
   dispatchedAt = DateTime.now().toUTC().toISO() ?? new Date().toISOString(),
 ) {
-  await db.transaction((tx) =>
+  return db.transaction((tx) =>
     markCrowdReportDispatchSuccessInTransaction(tx, candidate, dispatchedAt),
   );
 }
@@ -546,7 +546,7 @@ async function markCrowdReportDispatchSuccessInTransaction(
   dispatchedAt: string,
 ) {
   if (candidate.kind === 'cluster') {
-    await tx
+    const updatedClusters = await tx
       .update(crowdReportClustersTable)
       .set({
         status: 'dispatched',
@@ -559,7 +559,12 @@ async function markCrowdReportDispatchSuccessInTransaction(
           hasNoOngoingClusterReportsOutsideDispatchPayload(candidate),
           hasAllClusterDispatchPayloadReportsCurrent(candidate),
         ),
-      );
+      )
+      .returning({ id: crowdReportClustersTable.id });
+
+    if (updatedClusters.length === 0) {
+      return false;
+    }
   }
 
   await tx
@@ -572,6 +577,7 @@ async function markCrowdReportDispatchSuccessInTransaction(
       updated_at: sql`now()`,
     })
     .where(getCrowdReportDispatchReportScope(candidate));
+  return true;
 }
 
 async function markCrowdReportDispatchFailureInTransaction(
@@ -694,11 +700,14 @@ async function dispatchCrowdReportCandidateWithLock(
         config,
         fetchImpl,
       );
-      await markCrowdReportDispatchSuccessInTransaction(
+      const marked = await markCrowdReportDispatchSuccessInTransaction(
         tx,
         candidate,
         DateTime.now().toUTC().toISO() ?? new Date().toISOString(),
       );
+      if (!marked) {
+        return { skipped: true as const };
+      }
       return { skipped: false as const, dispatchResponse };
     } catch (error) {
       await markCrowdReportDispatchFailureInTransaction(

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -481,6 +481,9 @@ Exit criteria:
 - 2026-06-11: Addressed review feedback on cluster dispatch success marking by
   making the report-row success update conditional on the guarded cluster-row
   update actually succeeding.
+- 2026-06-11: Addressed follow-up review feedback by treating post-send local
+  success-marking races as dispatch failures instead of skipped candidates, and
+  closing still-accepted clusters that already had a repository dispatch sent.
 
 ## Decision Log
 

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -482,8 +482,9 @@ Exit criteria:
   making the report-row success update conditional on the guarded cluster-row
   update actually succeeding.
 - 2026-06-11: Addressed follow-up review feedback by treating post-send local
-  success-marking races as dispatch failures instead of skipped candidates, and
-  closing still-accepted clusters that already had a repository dispatch sent.
+  success-marking races as dispatch failures instead of skipped candidates,
+  without closing clusters that may have newer ongoing reports outside the sent
+  payload.
 
 ## Decision Log
 

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -478,6 +478,9 @@ Exit criteria:
   payload's report IDs to still be the exact current ongoing accepted or
   duplicate reports attached to the cluster before dispatch or success marking
   can proceed.
+- 2026-06-11: Addressed review feedback on cluster dispatch success marking by
+  making the report-row success update conditional on the guarded cluster-row
+  update actually succeeding.
 
 ## Decision Log
 

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -474,6 +474,10 @@ Exit criteria:
   without clusters. Duplicate automation now takes the report dispatch advisory
   lock and rechecks that the original report remains accepted, unclustered, and
   undispatched before using it to seed a duplicate cluster.
+- 2026-06-11: Continued cluster dispatch freshness hardening by requiring the
+  payload's report IDs to still be the exact current ongoing accepted or
+  duplicate reports attached to the cluster before dispatch or success marking
+  can proceed.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Require cluster dispatch payload report IDs to still match current ongoing accepted or duplicate reports attached to the cluster.
- Reuse the same freshness predicate for under-lock dispatch eligibility and success marking.
- Add focused regression assertions and update the active crowdsourced reports plan log.

## Why

Cluster dispatch already skipped candidates when newer ongoing reports appeared outside the payload. It still needed the symmetric check that every report ID inside the payload remained current and attached to the cluster before dispatching or marking success.

## Validation

- `npm run test:run -- app/util/crowdReportDispatch.test.ts`
- `npm run verify`

Note: sandboxed verification hit a `tsx` IPC `EPERM` during `db:generate:check`; the full `npm run verify` was rerun outside the sandbox and passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded dispatch tests with configurable fake responses to simulate cluster freshness and post-send marking paths

* **Bug Fixes**
  * Require payload report IDs to remain current before marking dispatch successful
  * Treat races after send as dispatch failures when cluster updates don’t apply, preventing incorrect success marking

* **Documentation**
  * Added cluster dispatch hardening details to the crowdsourced reports plan
<!-- end of auto-generated comment: release notes by coderabbit.ai -->