### PR TITLE
perf: defer statistics disruption card

### DIFF
--- a/app/routes/{-$lang}/statistics/components/StatisticsGrid/index.tsx
+++ b/app/routes/{-$lang}/statistics/components/StatisticsGrid/index.tsx
@@ -1,10 +1,10 @@
 import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 import type React from 'react';
 import type { SystemAnalytics } from '~/util/db.queries';
-import { LongestDisruptionsCard } from './components/LongestDisruptionsCard';
 import {
   BarChartCardSkeleton,
   HeatmapCardSkeleton,
+  LongestDisruptionsCardSkeleton,
   TrendCardSkeleton,
 } from './components/StatisticsGridSkeleton';
 
@@ -26,6 +26,11 @@ const DurationTrendCards = lazy(() =>
 const LinesIssueCountCard = lazy(() =>
   import('./components/LinesIssueCountCard').then((module) => ({
     default: module.LinesIssueCountCard,
+  })),
+);
+const LongestDisruptionsCard = lazy(() =>
+  import('./components/LongestDisruptionsCard').then((module) => ({
+    default: module.LongestDisruptionsCard,
   })),
 );
 const StationsIssueCountCard = lazy(() =>
@@ -54,7 +59,11 @@ export const StatisticsGrid: React.FC<Props> = (props) => {
       >
         <LinesIssueCountCard chart={statistics.chartTotalIssueCountByLine} />
       </DeferredStatisticsCard>
-      <LongestDisruptionsCard issueIds={statistics.issueIdsDisruptionLongest} />
+      <DeferredStatisticsCard fallback={<LongestDisruptionsCardSkeleton />}>
+        <LongestDisruptionsCard
+          issueIds={statistics.issueIdsDisruptionLongest}
+        />
+      </DeferredStatisticsCard>
       <DeferredStatisticsCard
         fallback={<BarChartCardSkeleton barCount={15} heightClassName="h-72" />}
       >

--- a/docs/plans/active/production-performance.md
+++ b/docs/plans/active/production-performance.md
@@ -340,6 +340,13 @@ underlying compute and payload costs so uncached requests are also fast.
   opened. A production build emits separate client chunks for the inactive
   `MapJan2012`, `MapNov2017`, `MapDec2019`, `MapNov2024`, `MapDec2027`,
   `MapDec2029`, `MapDec2030`, and `MapDec2032` snapshots.
+- 2026-06-11: Continued Phase 5 statistics hydration cleanup by lazy-loading
+  the longest-disruptions card behind the existing statistics viewport gate and
+  skeleton. The statistics route preload set no longer includes `IssueCard`,
+  Radix Collapsible, or chevron icon chunks up front; those dependencies now
+  sit behind the separate `LongestDisruptionsCard` chunk. Tightened the
+  TanStack route-file ignore pattern so support `helpers`, `components`,
+  `hooks`, and test files are not scanned as route files during builds.
 
 ## Validation
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -50,8 +50,8 @@ export default defineConfig(() => {
       tanstackStart({
         srcDirectory: 'app',
         router: {
-          // Ignores files/folders containing 'components', 'hooks', or ending in '.test.tsx'
-          routeFileIgnorePattern: '((components|hooks)|.test.tsx)',
+          // Ignores route support folders and files ending in '.test.ts' / '.test.tsx'
+          routeFileIgnorePattern: '((components|hooks|helpers)|\\.test\\.tsx?)',
         },
       }),
       tailwindcss(),


### PR DESCRIPTION
## Summary

- Lazy-load the statistics longest-disruptions card behind the existing viewport gate and skeleton.
- Keep `IssueCard`, Radix Collapsible, and chevron icon dependencies out of the initial `/statistics` preload set.
- Tighten TanStack route-file ignores for route support folders and `.test.ts` / `.test.tsx` files.
- Record the Phase 5 progress in the production performance plan.

## Validation

- `npm run build`
- `npm run verify`