### PR TITLE
docs: expose llms discovery in robots

### DIFF
--- a/docs/plans/active/markdown-for-agents.md
+++ b/docs/plans/active/markdown-for-agents.md
@@ -147,6 +147,9 @@ Exit criteria:
   `/stations/$stationId/index.md`, `/operators/$operatorId/index.md`, and
   `/issues/$issueId/index.md` routes backed by read-model server functions.
   Updated `/llms.txt` to advertise the new Markdown surface.
+- 2026-06-11: Started Phase 4 discovery by adding `/llms.txt` to
+  `public/robots.txt`. Kept Markdown URLs out of the XML sitemap for now so the
+  curated agent entry point remains the expansion surface.
 
 ## Decision Log
 
@@ -165,6 +168,9 @@ Exit criteria:
   (`mdast-util-to-markdown` plus `mdast-util-gfm`) instead of hand-assembling
   Markdown strings, so escaping and GFM tables follow maintained Markdown
   rules.
+- 2026-06-11: Keep Markdown routes discoverable through `/llms.txt` instead of
+  the dynamic XML sitemap until there is observed crawler demand for sitemap
+  inclusion.
 
 ## Validation
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Disallow:
+LLMS: https://www.mrtdown.org/llms.txt
 Sitemap: https://www.mrtdown.org/sitemap.xml


### PR DESCRIPTION
## Summary

- Add the `LLMS` pointer to `public/robots.txt` so crawlers can discover the curated `/llms.txt` entry point.
- Update the markdown-for-agents plan with the Phase 4 progress note and the decision to keep Markdown URLs discoverable through `/llms.txt` rather than the XML sitemap for now.

## Validation

- `npm run verify`
- Local runtime checks for `GET /robots.txt` and `GET /llms.txt`