### PR TITLE
test: cover agent markdown entity builders

### DIFF
--- a/app/util/agentMarkdownContent.test.ts
+++ b/app/util/agentMarkdownContent.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { getIssueMarkdown, getOverviewMarkdown } from './agentMarkdownContent';
+import {
+  getIssueMarkdown,
+  getLineMarkdown,
+  getOperatorMarkdown,
+  getOverviewMarkdown,
+  getStationMarkdown,
+} from './agentMarkdownContent';
 
 describe('agent Markdown content builders', () => {
   it('renders overview Markdown from read-model data', () => {
@@ -151,6 +157,257 @@ describe('agent Markdown content builders', () => {
     );
     expect(markdown).toContain('<https://example.com/source>');
   });
+
+  it('renders line Markdown with facts, branches, interchanges, and community signals', () => {
+    const markdown = getLineMarkdown(
+      {
+        data: {
+          lineId: 'EWL',
+          lineSummary: {
+            status: 'ongoing_disruption',
+            uptimeRatio: 0.998,
+            totalDowntimeSeconds: 600,
+          },
+          branches: [
+            {
+              id: 'ewl-main',
+              lineId: 'EWL',
+              stationIds: ['EW1', 'EW2'],
+            },
+          ],
+          issueIdNextMaintenance: 'issue-maintenance',
+          issueIdsRecent: ['issue-disruption'],
+          issueCountByType: { disruption: 1, maintenance: 1 },
+          timeScaleGraphsIssueCount: [],
+          timeScaleGraphsUptimeRatios: [],
+          stationIdsInterchanges: ['EW2'],
+          communitySignals: [
+            {
+              id: 'signal-1',
+              effect: 'crowding',
+              reportCount: 3,
+              lineIds: ['EWL'],
+              stationIds: ['EW2'],
+              windowStartAt: '2026-06-11T10:00:00+08:00',
+              windowEndAt: '2026-06-11T11:00:00+08:00',
+              updatedAt: '2026-06-11T11:00:00+08:00',
+            },
+          ],
+        },
+        included: {
+          lines: {
+            EWL: {
+              id: 'EWL',
+              name: translations('East West Line'),
+              startedAt: '1987-12-12',
+              operators: [{ operatorId: 'SMRT' }],
+            },
+          },
+          stations: {
+            EW1: {
+              id: 'EW1',
+              name: translations('Pasir Ris'),
+            },
+            EW2: {
+              id: 'EW2',
+              name: translations('Tampines'),
+            },
+          },
+          issues: {
+            'issue-disruption': issue('issue-disruption', 'Train fault'),
+            'issue-maintenance': issue(
+              'issue-maintenance',
+              'Track maintenance',
+              'maintenance',
+            ),
+          },
+          landmarks: {},
+          towns: {},
+          operators: {
+            SMRT: {
+              id: 'SMRT',
+              name: translations('SMRT Trains'),
+            },
+          },
+        },
+      } as unknown as Parameters<typeof getLineMarkdown>[0],
+      { rootUrl: 'https://example.com' },
+    );
+
+    expect(markdown).toContain('# East West Line (EWL)');
+    expect(markdown).toContain('Current status: Disruption.');
+    expect(markdown).toContain('Operators: SMRT Trains');
+    expect(markdown).toContain('Recent uptime: 99.8%');
+    expect(markdown).toContain('Recent downtime: 10m');
+    expect(markdown).toContain(
+      '[Track maintenance](https://example.com/issues/issue-maintenance/index.md)',
+    );
+    expect(markdown).toContain('| ewl-main | 2 stations |');
+    expect(markdown).toContain(
+      '[Tampines](https://example.com/stations/EW2/index.md)',
+    );
+    expect(markdown).toContain('Crowding');
+  });
+
+  it('renders station Markdown with served lines, area facts, and recent issues', () => {
+    const markdown = getStationMarkdown(
+      {
+        data: {
+          stationId: 'EW2',
+          status: 'normal',
+          issueIdsRecent: ['issue-1'],
+          issueCountByType: { disruption: 1 },
+          communitySignals: [],
+        },
+        included: {
+          lines: {
+            EWL: {
+              id: 'EWL',
+              name: translations('East West Line'),
+            },
+            DTL: {
+              id: 'DTL',
+              name: translations('Downtown Line'),
+            },
+          },
+          stations: {
+            EW2: {
+              id: 'EW2',
+              name: translations('Tampines'),
+              townId: 'tampines',
+              landmarkIds: ['mall'],
+              memberships: [
+                {
+                  branchId: 'ewl-main',
+                  code: 'EW2',
+                  lineId: 'EWL',
+                  sequenceOrder: 2,
+                  startedAt: '1989-12-16',
+                  structureType: 'elevated',
+                },
+                {
+                  branchId: 'dtl-main',
+                  code: 'DT32',
+                  lineId: 'DTL',
+                  sequenceOrder: 32,
+                  startedAt: '2017-10-21',
+                  structureType: 'underground',
+                },
+              ],
+            },
+          },
+          issues: {
+            'issue-1': issue('issue-1', 'Signal fault'),
+          },
+          landmarks: {
+            mall: {
+              id: 'mall',
+              name: translations('Tampines Mall'),
+            },
+          },
+          towns: {
+            tampines: {
+              id: 'tampines',
+              name: translations('Tampines'),
+            },
+          },
+          operators: {},
+        },
+      } as unknown as Parameters<typeof getStationMarkdown>[0],
+      { rootUrl: 'https://example.com' },
+    );
+
+    expect(markdown).toContain('# Tampines Station (EW2)');
+    expect(markdown).toContain('Current status: Operational.');
+    expect(markdown).toContain('Town: Tampines');
+    expect(markdown).toContain('Nearby landmarks: Tampines Mall');
+    expect(markdown).toMatch(
+      /\| EW2\s+\| EWL\s+\| East West Line\s+\| elevated\s+\| 1989-12-16 \|/,
+    );
+    expect(markdown).toMatch(
+      /\| DT32 \| DTL\s+\| Downtown Line\s+\| underground \| 2017-10-21 \|/,
+    );
+    expect(markdown).toContain(
+      '[Signal fault](https://example.com/issues/issue-1/index.md)',
+    );
+  });
+
+  it('renders operator Markdown with line performance and affected lines', () => {
+    const markdown = getOperatorMarkdown(
+      {
+        data: {
+          operatorId: 'SMRT',
+          lineIds: ['EWL', 'NSL'],
+          aggregateUptimeRatio: 0.9975,
+          currentOperationalStatus: 'some_lines_disrupted',
+          linesAffected: ['EWL'],
+          totalIssuesByType: { disruption: 2 },
+          totalStationsOperated: 54,
+          issueIdsRecent: ['issue-1'],
+          timeScaleGraphsIssueCount: [],
+          timeScaleGraphsUptimeRatios: [],
+          linePerformanceComparison: [
+            {
+              lineId: 'EWL',
+              status: 'ongoing_disruption',
+              uptimeRatio: 0.995,
+              issueCount: 2,
+            },
+            {
+              lineId: 'NSL',
+              status: 'normal',
+              uptimeRatio: 1,
+              issueCount: 0,
+            },
+          ],
+          totalDowntimeDurationSeconds: 900,
+          downtimeDurationByIssueType: { disruption: 900 },
+          yearsOfOperation: 39,
+          dateCount: 90,
+        },
+        included: {
+          lines: {
+            EWL: {
+              id: 'EWL',
+              name: translations('East West Line'),
+            },
+            NSL: {
+              id: 'NSL',
+              name: translations('North South Line'),
+            },
+          },
+          stations: {},
+          issues: {
+            'issue-1': issue('issue-1', 'Power fault'),
+          },
+          landmarks: {},
+          towns: {},
+          operators: {
+            SMRT: {
+              id: 'SMRT',
+              name: translations('SMRT Trains'),
+              foundedAt: '1987-08-06',
+            },
+          },
+        },
+      } as unknown as Parameters<typeof getOperatorMarkdown>[0],
+      { rootUrl: 'https://example.com' },
+    );
+
+    expect(markdown).toContain('# SMRT Trains');
+    expect(markdown).toContain('Current status: Some lines disrupted.');
+    expect(markdown).toContain('Aggregate uptime: 99.75%');
+    expect(markdown).toContain('Total recent downtime: 15m');
+    expect(markdown).toMatch(
+      /\| EWL\s+\| East West Line\s+\| Disruption\s+\| 99\.5%\s+\| 2\s+\| \/lines\/EWL\/index\.md \|/,
+    );
+    expect(markdown).toContain(
+      '[East West Line](https://example.com/lines/EWL/index.md)',
+    );
+    expect(markdown).toContain(
+      '[Power fault](https://example.com/issues/issue-1/index.md)',
+    );
+  });
 });
 
 function translations(value: string) {
@@ -159,5 +416,22 @@ function translations(value: string) {
     'zh-Hans': null,
     ms: null,
     ta: null,
+  };
+}
+
+function issue(
+  id: string,
+  title: string,
+  type: 'disruption' | 'maintenance' | 'infra' = 'disruption',
+) {
+  return {
+    id,
+    title: translations(title),
+    type,
+    durationSeconds: 300,
+    lineIds: ['EWL'],
+    branchesAffected: [],
+    intervals: [],
+    subtypes: [],
   };
 }

--- a/docs/plans/active/markdown-for-agents.md
+++ b/docs/plans/active/markdown-for-agents.md
@@ -150,6 +150,10 @@ Exit criteria:
 - 2026-06-11: Started Phase 4 discovery by adding `/llms.txt` to
   `public/robots.txt`. Kept Markdown URLs out of the XML sitemap for now so the
   curated agent entry point remains the expansion surface.
+- 2026-06-12: Expanded Markdown content tests for line, station, and operator
+  builders so the Phase 3 entity formats are covered alongside overview and
+  issue Markdown. Missing-entity behavior remains delegated to the shared
+  read-model server functions used by the HTML routes.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Add direct Markdown content-builder coverage for line, station, and operator pages.
- Assert key agent-facing output for facts, links, tables, affected entities, and community report signals.
- Update the markdown-for-agents plan progress log with the Phase 3 coverage follow-up.

## Validation

- `npm run test:run -- app/util/agentMarkdownContent.test.ts`
- `npm run verify`

Note: the first sandboxed `npm run verify` reached typecheck, lint, and format, then failed at `db:generate:check` because `tsx` could not create its IPC pipe in the sandbox (`listen EPERM`). The same command passed when rerun with escalation.