### PR TITLE
perf: share deferred viewport widgets

### DIFF
--- a/app/components/DeferredViewportWidget.tsx
+++ b/app/components/DeferredViewportWidget.tsx
@@ -1,0 +1,50 @@
+import { Suspense, useEffect, useRef, useState } from 'react';
+import type React from 'react';
+
+interface DeferredViewportWidgetProps {
+  children: React.ReactNode;
+  className: string;
+  fallback: React.ReactNode;
+  rootMargin?: string;
+}
+
+export function DeferredViewportWidget(props: DeferredViewportWidgetProps) {
+  const { children, className, fallback, rootMargin = '600px 0px' } = props;
+  const [shouldRender, setShouldRender] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (shouldRender) {
+      return;
+    }
+
+    const container = containerRef.current;
+    if (container == null || !('IntersectionObserver' in window)) {
+      setShouldRender(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setShouldRender(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin },
+    );
+
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [rootMargin, shouldRender]);
+
+  return (
+    <div className={className} ref={containerRef}>
+      {shouldRender ? (
+        <Suspense fallback={fallback}>{children}</Suspense>
+      ) : (
+        fallback
+      )}
+    </div>
+  );
+}

--- a/app/components/ProfileWidgetSkeletons.tsx
+++ b/app/components/ProfileWidgetSkeletons.tsx
@@ -1,0 +1,22 @@
+export function ProfileTrendCardSkeleton() {
+  return (
+    <div className="flex min-h-96 flex-col rounded-lg border border-gray-300 p-6 shadow-lg dark:border-gray-700">
+      <div className="h-6 w-56 animate-pulse rounded-md bg-gray-200 dark:bg-gray-800" />
+      <div className="mt-3 h-10 w-40 animate-pulse rounded-md bg-gray-200 dark:bg-gray-800" />
+      <div className="mt-3 h-5 w-32 animate-pulse rounded-md bg-gray-200 dark:bg-gray-800" />
+      <div className="mt-4 h-48 animate-pulse rounded-md bg-gray-200 dark:bg-gray-800" />
+      <div className="mt-4 h-10 w-60 animate-pulse rounded-md bg-gray-200 dark:bg-gray-800" />
+    </div>
+  );
+}
+
+export function ProfileSystemMapCardSkeleton() {
+  return (
+    <div className="flex min-h-96 flex-col rounded-lg border border-gray-300 p-6 shadow-lg dark:border-gray-700">
+      <div className="mb-2 h-6 w-28 animate-pulse rounded-md bg-gray-200 dark:bg-gray-800" />
+      <div className="min-h-0 flex-1 bg-gray-100 p-3 dark:bg-gray-800">
+        <div className="h-full min-h-80 animate-pulse rounded-md bg-gray-200 dark:bg-gray-700" />
+      </div>
+    </div>
+  );
+}

--- a/app/routes/{-$lang}/lines/$lineId/index.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/index.tsx
@@ -1,8 +1,7 @@
 import type { IssueType } from '@mrtdown/core';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { DateTime } from 'luxon';
-import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react';
-import type React from 'react';
+import { lazy, useMemo } from 'react';
 import {
   createIntl,
   FormattedDate,
@@ -10,7 +9,12 @@ import {
   useIntl,
 } from 'react-intl';
 import { CommunitySignalsSection } from '~/components/CommunitySignalsSection';
+import { DeferredViewportWidget } from '~/components/DeferredViewportWidget';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
+import {
+  ProfileSystemMapCardSkeleton,
+  ProfileTrendCardSkeleton,
+} from '~/components/ProfileWidgetSkeletons';
 import { useCrowdReportsFeatureEnabled } from '~/contexts/CrowdReportsFeature';
 import { buildIssueTypeCountString } from '~/helpers/buildIssueTypeCountString';
 import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
@@ -351,32 +355,32 @@ function ComponentPage() {
 
         <QuickFactsCard line={line} branches={branches} />
 
-        <DeferredLineWidget
+        <DeferredViewportWidget
           className="md:col-span-4"
-          fallback={<LineSystemMapCardSkeleton />}
+          fallback={<ProfileSystemMapCardSkeleton />}
         >
           <LineSystemMapCard line={line} branches={branches} />
-        </DeferredLineWidget>
+        </DeferredViewportWidget>
 
         {lineProfile.lineSummary.status !== 'future_service' && (
-          <DeferredLineWidget
+          <DeferredViewportWidget
             className="md:col-span-12 lg:col-span-8"
-            fallback={<TrendCardSkeleton />}
+            fallback={<ProfileTrendCardSkeleton />}
           >
             <UptimeRatioTrendCards
               graphs={lineProfile.timeScaleGraphsUptimeRatios}
             />
-          </DeferredLineWidget>
+          </DeferredViewportWidget>
         )}
 
         <RecentIssuesSection issueIds={lineProfile.issueIdsRecent} />
 
-        <DeferredLineWidget
+        <DeferredViewportWidget
           className="md:col-span-12 lg:col-span-8"
-          fallback={<TrendCardSkeleton />}
+          fallback={<ProfileTrendCardSkeleton />}
         >
           <CountTrendCards graphs={lineProfile.timeScaleGraphsIssueCount} />
-        </DeferredLineWidget>
+        </DeferredViewportWidget>
 
         <StationInterchangesCard
           lineId={lineId}
@@ -384,75 +388,5 @@ function ComponentPage() {
         />
       </div>
     </IncludedEntitiesContext.Provider>
-  );
-}
-
-interface DeferredLineWidgetProps {
-  children: React.ReactNode;
-  className: string;
-  fallback: React.ReactNode;
-}
-
-function DeferredLineWidget(props: DeferredLineWidgetProps) {
-  const { children, className, fallback } = props;
-  const [shouldRender, setShouldRender] = useState(false);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (shouldRender) {
-      return;
-    }
-
-    const container = containerRef.current;
-    if (container == null || !('IntersectionObserver' in window)) {
-      setShouldRender(true);
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          setShouldRender(true);
-          observer.disconnect();
-        }
-      },
-      { rootMargin: '600px 0px' },
-    );
-
-    observer.observe(container);
-    return () => observer.disconnect();
-  }, [shouldRender]);
-
-  return (
-    <div className={className} ref={containerRef}>
-      {shouldRender ? (
-        <Suspense fallback={fallback}>{children}</Suspense>
-      ) : (
-        fallback
-      )}
-    </div>
-  );
-}
-
-function TrendCardSkeleton() {
-  return (
-    <div className="flex min-h-96 flex-col rounded-lg border border-gray-300 p-6 shadow-lg dark:border-gray-700">
-      <div className="h-6 w-56 animate-pulse rounded-md bg-gray-200 dark:bg-gray-800" />
-      <div className="mt-3 h-10 w-40 animate-pulse rounded-md bg-gray-200 dark:bg-gray-800" />
-      <div className="mt-3 h-5 w-32 animate-pulse rounded-md bg-gray-200 dark:bg-gray-800" />
-      <div className="mt-4 h-48 animate-pulse rounded-md bg-gray-200 dark:bg-gray-800" />
-      <div className="mt-4 h-10 w-60 animate-pulse rounded-md bg-gray-200 dark:bg-gray-800" />
-    </div>
-  );
-}
-
-function LineSystemMapCardSkeleton() {
-  return (
-    <div className="flex min-h-96 flex-col rounded-lg border border-gray-300 p-6 shadow-lg dark:border-gray-700">
-      <div className="mb-2 h-6 w-28 animate-pulse rounded-md bg-gray-200 dark:bg-gray-800" />
-      <div className="min-h-0 flex-1 bg-gray-100 p-3 dark:bg-gray-800">
-        <div className="h-full min-h-80 animate-pulse rounded-md bg-gray-200 dark:bg-gray-700" />
-      </div>
-    </div>
   );
 }

--- a/app/routes/{-$lang}/operators/$operatorId/index.tsx
+++ b/app/routes/{-$lang}/operators/$operatorId/index.tsx
@@ -1,15 +1,16 @@
 import type { IssueType } from '@mrtdown/core';
 import { useQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
-import { lazy, Suspense, useEffect, useRef, useState } from 'react';
-import type React from 'react';
+import { lazy } from 'react';
 import {
   createIntl,
   FormattedDate,
   FormattedMessage,
   useIntl,
 } from 'react-intl';
+import { DeferredViewportWidget } from '~/components/DeferredViewportWidget';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
+import { ProfileTrendCardSkeleton } from '~/components/ProfileWidgetSkeletons';
 import { buildIssueTypeCountString } from '~/helpers/buildIssueTypeCountString';
 import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
 import { getDateCountForViewport } from '~/helpers/getDateCountForViewport';
@@ -314,84 +315,25 @@ function OperatorPage() {
         />
 
         {operatorProfile.aggregateUptimeRatio != null && (
-          <DeferredOperatorWidget
+          <DeferredViewportWidget
             className="md:col-span-12 lg:col-span-8"
-            fallback={<TrendCardSkeleton />}
+            fallback={<ProfileTrendCardSkeleton />}
           >
             <UptimeRatioTrendCards
               graphs={operatorProfile.timeScaleGraphsUptimeRatios}
             />
-          </DeferredOperatorWidget>
+          </DeferredViewportWidget>
         )}
 
         <RecentIssuesSection issueIds={operatorProfile.issueIdsRecent} />
 
-        <DeferredOperatorWidget
+        <DeferredViewportWidget
           className="md:col-span-12 lg:col-span-8"
-          fallback={<TrendCardSkeleton />}
+          fallback={<ProfileTrendCardSkeleton />}
         >
           <CountTrendCards graphs={operatorProfile.timeScaleGraphsIssueCount} />
-        </DeferredOperatorWidget>
+        </DeferredViewportWidget>
       </div>
     </IncludedEntitiesContext.Provider>
-  );
-}
-
-interface DeferredOperatorWidgetProps {
-  children: React.ReactNode;
-  className: string;
-  fallback: React.ReactNode;
-}
-
-function DeferredOperatorWidget(props: DeferredOperatorWidgetProps) {
-  const { children, className, fallback } = props;
-  const [shouldRender, setShouldRender] = useState(false);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (shouldRender) {
-      return;
-    }
-
-    const container = containerRef.current;
-    if (container == null || !('IntersectionObserver' in window)) {
-      setShouldRender(true);
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          setShouldRender(true);
-          observer.disconnect();
-        }
-      },
-      { rootMargin: '600px 0px' },
-    );
-
-    observer.observe(container);
-    return () => observer.disconnect();
-  }, [shouldRender]);
-
-  return (
-    <div className={className} ref={containerRef}>
-      {shouldRender ? (
-        <Suspense fallback={fallback}>{children}</Suspense>
-      ) : (
-        fallback
-      )}
-    </div>
-  );
-}
-
-function TrendCardSkeleton() {
-  return (
-    <div className="flex min-h-96 flex-col rounded-lg border border-gray-300 p-6 shadow-lg dark:border-gray-700">
-      <div className="h-6 w-56 animate-pulse rounded-md bg-gray-200 dark:bg-gray-800" />
-      <div className="mt-3 h-10 w-40 animate-pulse rounded-md bg-gray-200 dark:bg-gray-800" />
-      <div className="mt-3 h-5 w-32 animate-pulse rounded-md bg-gray-200 dark:bg-gray-800" />
-      <div className="mt-4 h-48 animate-pulse rounded-md bg-gray-200 dark:bg-gray-800" />
-      <div className="mt-4 h-10 w-60 animate-pulse rounded-md bg-gray-200 dark:bg-gray-800" />
-    </div>
   );
 }

--- a/app/routes/{-$lang}/statistics/components/StatisticsGrid/index.tsx
+++ b/app/routes/{-$lang}/statistics/components/StatisticsGrid/index.tsx
@@ -1,5 +1,5 @@
-import { lazy, Suspense, useEffect, useRef, useState } from 'react';
-import type React from 'react';
+import { lazy } from 'react';
+import { DeferredViewportWidget } from '~/components/DeferredViewportWidget';
 import type { SystemAnalytics } from '~/util/db.queries';
 import {
   BarChartCardSkeleton,
@@ -48,78 +48,46 @@ export const StatisticsGrid: React.FC<Props> = (props) => {
 
   return (
     <div className="grid grid-cols-1 gap-4 text-gray-800 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6 dark:text-gray-200">
-      <DeferredStatisticsCard fallback={<TrendCardSkeleton />}>
+      <DeferredViewportWidget
+        className="col-span-6"
+        fallback={<TrendCardSkeleton />}
+      >
         <CountTrendCards graphs={statistics.timeScaleChartsIssueCount} />
-      </DeferredStatisticsCard>
-      <DeferredStatisticsCard fallback={<HeatmapCardSkeleton />}>
+      </DeferredViewportWidget>
+      <DeferredViewportWidget
+        className="col-span-6"
+        fallback={<HeatmapCardSkeleton />}
+      >
         <DisruptionsHeatmap chart={statistics.chartRollingYearHeatmap} />
-      </DeferredStatisticsCard>
-      <DeferredStatisticsCard
+      </DeferredViewportWidget>
+      <DeferredViewportWidget
+        className="col-span-6"
         fallback={<BarChartCardSkeleton barCount={8} heightClassName="h-64" />}
       >
         <LinesIssueCountCard chart={statistics.chartTotalIssueCountByLine} />
-      </DeferredStatisticsCard>
-      <DeferredStatisticsCard fallback={<LongestDisruptionsCardSkeleton />}>
+      </DeferredViewportWidget>
+      <DeferredViewportWidget
+        className="col-span-6"
+        fallback={<LongestDisruptionsCardSkeleton />}
+      >
         <LongestDisruptionsCard
           issueIds={statistics.issueIdsDisruptionLongest}
         />
-      </DeferredStatisticsCard>
-      <DeferredStatisticsCard
+      </DeferredViewportWidget>
+      <DeferredViewportWidget
+        className="col-span-6"
         fallback={<BarChartCardSkeleton barCount={15} heightClassName="h-72" />}
       >
         <StationsIssueCountCard
           chart={statistics.chartTotalIssueCountByStation}
         />
-      </DeferredStatisticsCard>
-      <DeferredStatisticsCard fallback={<TrendCardSkeleton />}>
+      </DeferredViewportWidget>
+      <DeferredViewportWidget
+        className="col-span-6"
+        fallback={<TrendCardSkeleton />}
+      >
         <DurationTrendCards graphs={statistics.timeScaleChartsIssueDuration} />
-      </DeferredStatisticsCard>
+      </DeferredViewportWidget>
     </div>
   );
 };
-
-interface DeferredStatisticsCardProps {
-  children: React.ReactNode;
-  fallback: React.ReactNode;
-}
-
-function DeferredStatisticsCard(props: DeferredStatisticsCardProps) {
-  const { children, fallback } = props;
-  const [shouldRender, setShouldRender] = useState(false);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (shouldRender) {
-      return;
-    }
-
-    const container = containerRef.current;
-    if (container == null || !('IntersectionObserver' in window)) {
-      setShouldRender(true);
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          setShouldRender(true);
-          observer.disconnect();
-        }
-      },
-      { rootMargin: '600px 0px' },
-    );
-
-    observer.observe(container);
-    return () => observer.disconnect();
-  }, [shouldRender]);
-
-  return (
-    <div className="col-span-6" ref={containerRef}>
-      {shouldRender ? (
-        <Suspense fallback={fallback}>{children}</Suspense>
-      ) : (
-        fallback
-      )}
-    </div>
-  );
-}

--- a/docs/plans/active/production-performance.md
+++ b/docs/plans/active/production-performance.md
@@ -347,6 +347,13 @@ underlying compute and payload costs so uncached requests are also fast.
   sit behind the separate `LongestDisruptionsCard` chunk. Tightened the
   TanStack route-file ignore pattern so support `helpers`, `components`,
   `hooks`, and test files are not scanned as route files during builds.
+- 2026-06-12: Continued Phase 5 hydration cleanup by extracting the repeated
+  viewport-gated `Suspense` wrapper used by statistics, line, and operator
+  routes into `DeferredViewportWidget`, and by sharing the profile chart/map
+  skeletons. A production build keeps statistics chart cards, line trend cards,
+  `LineSystemMapCard`, and generated `StationMap` assets as dynamic imports
+  rather than route preloads; route preloads now include only the small shared
+  deferred wrapper.
 
 ## Validation
 


### PR DESCRIPTION
## Summary

- Extract the repeated viewport-gated `Suspense` wrapper into `DeferredViewportWidget`.
- Share the profile chart/map skeletons used by line and operator routes.
- Switch statistics, line, and operator pages to the shared deferred wrapper while keeping heavy chart/map modules behind dynamic imports.
- Record the Phase 5 progress note in the production performance plan.

## Impact

This removes duplicated observer/Suspense code from route entries and keeps future deferred widgets using one lightweight implementation. Production build output still keeps statistics chart cards, line trend cards, `LineSystemMapCard`, and generated `StationMap` assets as dynamic imports instead of route preloads.

## Validation

- `npm run verify`
- `npm run build`
- inspected the production build manifest for route preloads and dynamic imports