### PR TITLE
perf: defer community signals hydration

### DIFF
--- a/app/components/ProfileWidgetSkeletons.tsx
+++ b/app/components/ProfileWidgetSkeletons.tsx
@@ -20,3 +20,21 @@ export function ProfileSystemMapCardSkeleton() {
     </div>
   );
 }
+
+export function CommunitySignalsSectionSkeleton() {
+  return (
+    <section className="rounded-2xl border border-amber-200 bg-amber-50 p-4 dark:border-amber-900/70 dark:bg-amber-950/30">
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 size-9 shrink-0 animate-pulse rounded-lg bg-amber-100 dark:bg-amber-900/70" />
+        <div className="min-w-0 flex-1">
+          <div className="h-5 w-40 animate-pulse rounded-md bg-amber-100 dark:bg-amber-900/70" />
+          <div className="mt-2 h-4 w-full max-w-md animate-pulse rounded-md bg-amber-100 dark:bg-amber-900/70" />
+        </div>
+      </div>
+      <div className="mt-4 grid gap-3 md:grid-cols-2">
+        <div className="h-28 animate-pulse rounded-lg border border-amber-200 bg-white dark:border-amber-900 dark:bg-gray-900/70" />
+        <div className="hidden h-28 animate-pulse rounded-lg border border-amber-200 bg-white md:block dark:border-amber-900 dark:bg-gray-900/70" />
+      </div>
+    </section>
+  );
+}

--- a/app/routes/{-$lang}/index.tsx
+++ b/app/routes/{-$lang}/index.tsx
@@ -1,10 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { createFileRoute, Link, notFound } from '@tanstack/react-router';
 import { DateTime } from 'luxon';
-import { useMemo } from 'react';
+import { lazy, useMemo } from 'react';
 import { createIntl, FormattedMessage } from 'react-intl';
+import { DeferredViewportWidget } from '~/components/DeferredViewportWidget';
 import { LineSummaryBlock } from '~/components/LineSummaryBlock';
-import { CommunitySignalsSection } from '~/components/CommunitySignalsSection';
+import { CommunitySignalsSectionSkeleton } from '~/components/ProfileWidgetSkeletons';
 import { HOME_OVERVIEW_INITIAL_DATE_COUNT, LANGUAGES } from '~/constants';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
 import { useCrowdReportsFeatureEnabled } from '~/contexts/CrowdReportsFeature';
@@ -16,6 +17,12 @@ import { countOperationalLineSummaries } from '../../components/CurrentAdvisorie
 import { assert } from '../../util/assert';
 import { HomeLineSummariesSkeleton } from './components/HomeLineSummariesSkeleton';
 import { sortLineSummariesWithFutureServiceLast } from './helpers/sortLineSummaries';
+
+const CommunitySignalsSection = lazy(() =>
+  import('~/components/CommunitySignalsSection').then((module) => ({
+    default: module.CommunitySignalsSection,
+  })),
+);
 
 export const Route = createFileRoute('/{-$lang}/')({
   component: HomePage,
@@ -189,8 +196,13 @@ function HomePage() {
           lineOperationalCount={lineOperationalCount}
         />
 
-        {crowdReportsEnabled && (
-          <CommunitySignalsSection signals={overview.communitySignals} />
+        {crowdReportsEnabled && overview.communitySignals.length > 0 && (
+          <DeferredViewportWidget
+            className="block"
+            fallback={<CommunitySignalsSectionSkeleton />}
+          >
+            <CommunitySignalsSection signals={overview.communitySignals} />
+          </DeferredViewportWidget>
         )}
 
         {crowdReportsEnabled && (

--- a/app/routes/{-$lang}/lines/$lineId/index.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/index.tsx
@@ -8,10 +8,10 @@ import {
   FormattedMessage,
   useIntl,
 } from 'react-intl';
-import { CommunitySignalsSection } from '~/components/CommunitySignalsSection';
 import { DeferredViewportWidget } from '~/components/DeferredViewportWidget';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
 import {
+  CommunitySignalsSectionSkeleton,
   ProfileSystemMapCardSkeleton,
   ProfileTrendCardSkeleton,
 } from '~/components/ProfileWidgetSkeletons';
@@ -44,6 +44,11 @@ const LineSystemMapCard = lazy(() =>
 const UptimeRatioTrendCards = lazy(() =>
   import('./components/UptimeRatioTrendCards').then((module) => ({
     default: module.UptimeRatioTrendCards,
+  })),
+);
+const CommunitySignalsSection = lazy(() =>
+  import('~/components/CommunitySignalsSection').then((module) => ({
+    default: module.CommunitySignalsSection,
   })),
 );
 
@@ -339,11 +344,13 @@ function ComponentPage() {
 
         <CurrentStatusCard lineSummary={lineProfile.lineSummary} />
 
-        {crowdReportsEnabled && (
-          <CommunitySignalsSection
-            signals={lineProfile.communitySignals}
+        {crowdReportsEnabled && lineProfile.communitySignals.length > 0 && (
+          <DeferredViewportWidget
             className="md:col-span-12"
-          />
+            fallback={<CommunitySignalsSectionSkeleton />}
+          >
+            <CommunitySignalsSection signals={lineProfile.communitySignals} />
+          </DeferredViewportWidget>
         )}
 
         <NextMaintenanceCard

--- a/app/routes/{-$lang}/stations/$stationId.tsx
+++ b/app/routes/{-$lang}/stations/$stationId.tsx
@@ -2,7 +2,7 @@ import { InformationCircleIcon, MapPinIcon } from '@heroicons/react/24/outline';
 import type { IssueType } from '@mrtdown/core';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { DateTime } from 'luxon';
-import { useMemo } from 'react';
+import { lazy, useMemo } from 'react';
 import {
   createIntl,
   FormattedDate,
@@ -10,10 +10,11 @@ import {
   type IntlShape,
   useIntl,
 } from 'react-intl';
-import { CommunitySignalsSection } from '~/components/CommunitySignalsSection';
+import { DeferredViewportWidget } from '~/components/DeferredViewportWidget';
 import type { IncludedEntities, Station } from '~/types';
 import { IssueCard } from '~/components/IssueCard';
 import type { IssueCardContext } from '~/components/IssueCard/types';
+import { CommunitySignalsSectionSkeleton } from '~/components/ProfileWidgetSkeletons';
 import { StationBar } from '~/components/StationBar';
 import { LineTypeLabels, StationStructureTypeLabels } from '~/constants';
 import { useCrowdReportsFeatureEnabled } from '~/contexts/CrowdReportsFeature';
@@ -24,6 +25,12 @@ import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 import { useHydrated } from '~/hooks/useHydrated';
 import { getStationProfileFn } from '~/util/station.functions';
 import { assert } from '../../../util/assert';
+
+const CommunitySignalsSection = lazy(() =>
+  import('~/components/CommunitySignalsSection').then((module) => ({
+    default: module.CommunitySignalsSection,
+  })),
+);
 
 function computeStationStrings(
   intl: IntlShape,
@@ -328,8 +335,15 @@ function StationPage() {
           </div>
         </div>
 
-        {crowdReportsEnabled && (
-          <CommunitySignalsSection signals={stationProfile.communitySignals} />
+        {crowdReportsEnabled && stationProfile.communitySignals.length > 0 && (
+          <DeferredViewportWidget
+            className="block"
+            fallback={<CommunitySignalsSectionSkeleton />}
+          >
+            <CommunitySignalsSection
+              signals={stationProfile.communitySignals}
+            />
+          </DeferredViewportWidget>
         )}
 
         {/* Station Details Section */}

--- a/docs/plans/active/production-performance.md
+++ b/docs/plans/active/production-performance.md
@@ -354,6 +354,12 @@ underlying compute and payload costs so uncached requests are also fast.
   `LineSystemMapCard`, and generated `StationMap` assets as dynamic imports
   rather than route preloads; route preloads now include only the small shared
   deferred wrapper.
+- 2026-06-13: Continued Phase 5 profile route hydration cleanup by lazy-loading
+  the optional `CommunitySignalsSection` behind `DeferredViewportWidget` on
+  home, line, and station routes. A production build now emits a separate
+  `CommunitySignalsSection` client/server chunk, and the home, line, and
+  station route component entries list it only as a dynamic import instead of
+  an eager route dependency.
 
 ## Validation
 


### PR DESCRIPTION
## Summary

- Lazy-load the optional `CommunitySignalsSection` on home, line, and station routes behind `DeferredViewportWidget`.
- Add a shared community signals skeleton so the deferred panel has a stable placeholder.
- Update the production performance plan with the Phase 5 chunk-splitting progress note.

## Impact

This keeps community report UI code out of the initial home, line profile, and station profile route component chunks unless the optional section is actually rendered near the viewport.

## Validation

- `npm run build`
- Manifest check confirmed home, line, and station route entries list `CommunitySignalsSection` as dynamic only, not eager.
- `npm run verify` passed: typecheck, lint, format, migration drift check, and 172 tests. The final verify run used elevated permissions because `tsx` needs to create its IPC pipe under `/var/folders` for the Drizzle migration check.