### PR TITLE
perf: defer profile recent issues hydration

### DIFF
--- a/app/components/ProfileWidgetSkeletons.tsx
+++ b/app/components/ProfileWidgetSkeletons.tsx
@@ -38,3 +38,15 @@ export function CommunitySignalsSectionSkeleton() {
     </section>
   );
 }
+
+export function ProfileRecentIssuesSectionSkeleton() {
+  return (
+    <section className="rounded-lg border border-gray-200 bg-gray-50 p-6 dark:border-gray-700 dark:bg-gray-800/50">
+      <div className="h-6 w-36 animate-pulse rounded-md bg-gray-200 dark:bg-gray-700" />
+      <div className="mt-4 space-y-3">
+        <div className="h-24 animate-pulse rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800" />
+        <div className="h-24 animate-pulse rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800" />
+      </div>
+    </section>
+  );
+}

--- a/app/routes/{-$lang}/lines/$lineId/index.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/index.tsx
@@ -12,6 +12,7 @@ import { DeferredViewportWidget } from '~/components/DeferredViewportWidget';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
 import {
   CommunitySignalsSectionSkeleton,
+  ProfileRecentIssuesSectionSkeleton,
   ProfileSystemMapCardSkeleton,
   ProfileTrendCardSkeleton,
 } from '~/components/ProfileWidgetSkeletons';
@@ -27,7 +28,6 @@ import { CurrentStatusCard } from './components/CurrentStatusCard';
 import { LineSchematicCard } from './components/LineSchematicCard';
 import { NextMaintenanceCard } from './components/NextMaintenanceCard';
 import { QuickFactsCard } from './components/QuickFactsCard';
-import { RecentIssuesSection } from './components/RecentIssuesSection';
 import { StationInterchangesCard } from './components/StationInterchangesCard';
 import { UptimeCard } from './components/UptimeCard';
 
@@ -49,6 +49,11 @@ const UptimeRatioTrendCards = lazy(() =>
 const CommunitySignalsSection = lazy(() =>
   import('~/components/CommunitySignalsSection').then((module) => ({
     default: module.CommunitySignalsSection,
+  })),
+);
+const RecentIssuesSection = lazy(() =>
+  import('./components/RecentIssuesSection').then((module) => ({
+    default: module.RecentIssuesSection,
   })),
 );
 
@@ -380,7 +385,12 @@ function ComponentPage() {
           </DeferredViewportWidget>
         )}
 
-        <RecentIssuesSection issueIds={lineProfile.issueIdsRecent} />
+        <DeferredViewportWidget
+          className="md:col-span-12"
+          fallback={<ProfileRecentIssuesSectionSkeleton />}
+        >
+          <RecentIssuesSection issueIds={lineProfile.issueIdsRecent} />
+        </DeferredViewportWidget>
 
         <DeferredViewportWidget
           className="md:col-span-12 lg:col-span-8"

--- a/app/routes/{-$lang}/operators/$operatorId/index.tsx
+++ b/app/routes/{-$lang}/operators/$operatorId/index.tsx
@@ -10,7 +10,10 @@ import {
 } from 'react-intl';
 import { DeferredViewportWidget } from '~/components/DeferredViewportWidget';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
-import { ProfileTrendCardSkeleton } from '~/components/ProfileWidgetSkeletons';
+import {
+  ProfileRecentIssuesSectionSkeleton,
+  ProfileTrendCardSkeleton,
+} from '~/components/ProfileWidgetSkeletons';
 import { buildIssueTypeCountString } from '~/helpers/buildIssueTypeCountString';
 import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
 import { getDateCountForViewport } from '~/helpers/getDateCountForViewport';
@@ -19,7 +22,6 @@ import { useHydrated } from '~/hooks/useHydrated';
 import { useViewport } from '~/hooks/useViewport';
 import { getOperatorProfileFn } from '~/util/operator.functions';
 import { assert } from '../../../../util/assert';
-import { RecentIssuesSection } from '../../lines/$lineId/components/RecentIssuesSection';
 import { OperatorCurrentStatusCard } from './components/OperatorCurrentStatusCard';
 import { OperatorLinePerformanceCard } from './components/OperatorLinePerformanceCard';
 import { OperatorQuickFactsCard } from './components/OperatorQuickFactsCard';
@@ -36,6 +38,13 @@ const UptimeRatioTrendCards = lazy(() =>
   import('../../lines/$lineId/components/UptimeRatioTrendCards').then(
     (module) => ({
       default: module.UptimeRatioTrendCards,
+    }),
+  ),
+);
+const RecentIssuesSection = lazy(() =>
+  import('../../lines/$lineId/components/RecentIssuesSection').then(
+    (module) => ({
+      default: module.RecentIssuesSection,
     }),
   ),
 );
@@ -325,7 +334,12 @@ function OperatorPage() {
           </DeferredViewportWidget>
         )}
 
-        <RecentIssuesSection issueIds={operatorProfile.issueIdsRecent} />
+        <DeferredViewportWidget
+          className="md:col-span-12"
+          fallback={<ProfileRecentIssuesSectionSkeleton />}
+        >
+          <RecentIssuesSection issueIds={operatorProfile.issueIdsRecent} />
+        </DeferredViewportWidget>
 
         <DeferredViewportWidget
           className="md:col-span-12 lg:col-span-8"

--- a/app/routes/{-$lang}/stations/$stationId.tsx
+++ b/app/routes/{-$lang}/stations/$stationId.tsx
@@ -11,10 +11,10 @@ import {
   useIntl,
 } from 'react-intl';
 import { DeferredViewportWidget } from '~/components/DeferredViewportWidget';
-import type { IncludedEntities, Station } from '~/types';
-import { IssueCard } from '~/components/IssueCard';
-import type { IssueCardContext } from '~/components/IssueCard/types';
-import { CommunitySignalsSectionSkeleton } from '~/components/ProfileWidgetSkeletons';
+import {
+  CommunitySignalsSectionSkeleton,
+  ProfileRecentIssuesSectionSkeleton,
+} from '~/components/ProfileWidgetSkeletons';
 import { StationBar } from '~/components/StationBar';
 import { LineTypeLabels, StationStructureTypeLabels } from '~/constants';
 import { useCrowdReportsFeatureEnabled } from '~/contexts/CrowdReportsFeature';
@@ -23,12 +23,18 @@ import { buildIssueTypeCountString } from '~/helpers/buildIssueTypeCountString';
 import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
 import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 import { useHydrated } from '~/hooks/useHydrated';
+import type { IncludedEntities, Station } from '~/types';
 import { getStationProfileFn } from '~/util/station.functions';
 import { assert } from '../../../util/assert';
 
 const CommunitySignalsSection = lazy(() =>
   import('~/components/CommunitySignalsSection').then((module) => ({
     default: module.CommunitySignalsSection,
+  })),
+);
+const RecentIssuesSection = lazy(() =>
+  import('./$stationId/components/RecentIssuesSection').then((module) => ({
+    default: module.RecentIssuesSection,
   })),
 );
 
@@ -239,14 +245,6 @@ function StationPage() {
       return true;
     });
   }, [station.memberships]);
-
-  const issueCardContext = useMemo<IssueCardContext>(() => {
-    return {
-      type: 'history.days',
-      date: DateTime.now().startOf('day').minus({ days: 30 }).toISODate(),
-      days: 30,
-    };
-  }, []);
 
   return (
     <IncludedEntitiesContext.Provider value={included}>
@@ -497,44 +495,12 @@ function StationPage() {
           </div>
         </div>
 
-        {/* Recent Issues Section */}
-        <div className="overflow-hidden rounded-3xl border border-gray-200 bg-white shadow-lg dark:border-gray-600/60 dark:bg-gray-800">
-          <div className="p-4 sm:p-6">
-            <h2 className="font-semibold text-base text-gray-900 dark:text-gray-100">
-              <FormattedMessage
-                id="station.recent_issues"
-                defaultMessage="Recent Issues"
-              />
-            </h2>
-
-            <div className="mt-4 space-y-3">
-              {stationProfile.issueIdsRecent.length > 0 ? (
-                stationProfile.issueIdsRecent.map((issueId) => {
-                  const issue = included.issues[issueId];
-
-                  return (
-                    <IssueCard
-                      key={issue.id}
-                      issue={issue}
-                      className="!w-auto"
-                      context={issueCardContext}
-                    />
-                  );
-                })
-              ) : (
-                <div className="flex flex-col items-center justify-center py-8 text-center">
-                  <InformationCircleIcon className="h-12 w-12 text-gray-400 dark:text-gray-500" />
-                  <p className="mt-3 text-gray-600 dark:text-gray-400">
-                    <FormattedMessage
-                      id="station.no_recent_issues"
-                      defaultMessage="No recent issues reported for this station"
-                    />
-                  </p>
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
+        <DeferredViewportWidget
+          className="block"
+          fallback={<ProfileRecentIssuesSectionSkeleton />}
+        >
+          <RecentIssuesSection issueIds={stationProfile.issueIdsRecent} />
+        </DeferredViewportWidget>
       </div>
     </IncludedEntitiesContext.Provider>
   );

--- a/app/routes/{-$lang}/stations/$stationId/components/RecentIssuesSection.tsx
+++ b/app/routes/{-$lang}/stations/$stationId/components/RecentIssuesSection.tsx
@@ -1,0 +1,64 @@
+import { InformationCircleIcon } from '@heroicons/react/24/outline';
+import { DateTime } from 'luxon';
+import { useMemo } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { IssueCard } from '~/components/IssueCard';
+import type { IssueCardContext } from '~/components/IssueCard/types';
+import { useIncludedEntities } from '~/contexts/IncludedEntities';
+
+interface Props {
+  issueIds: string[];
+}
+
+export const RecentIssuesSection: React.FC<Props> = (props) => {
+  const { issueIds } = props;
+  const { issues } = useIncludedEntities();
+
+  const issueCardContext = useMemo<IssueCardContext>(() => {
+    return {
+      type: 'history.days',
+      date: DateTime.now().startOf('day').minus({ days: 30 }).toISODate(),
+      days: 30,
+    };
+  }, []);
+
+  return (
+    <div className="overflow-hidden rounded-3xl border border-gray-200 bg-white shadow-lg dark:border-gray-600/60 dark:bg-gray-800">
+      <div className="p-4 sm:p-6">
+        <h2 className="font-semibold text-base text-gray-900 dark:text-gray-100">
+          <FormattedMessage
+            id="station.recent_issues"
+            defaultMessage="Recent Issues"
+          />
+        </h2>
+
+        <div className="mt-4 space-y-3">
+          {issueIds.length > 0 ? (
+            issueIds.map((issueId) => {
+              const issue = issues[issueId];
+
+              return (
+                <IssueCard
+                  key={issue.id}
+                  issue={issue}
+                  className="!w-auto"
+                  context={issueCardContext}
+                />
+              );
+            })
+          ) : (
+            <div className="flex flex-col items-center justify-center py-8 text-center">
+              <InformationCircleIcon className="h-12 w-12 text-gray-400 dark:text-gray-500" />
+              <p className="mt-3 text-gray-600 dark:text-gray-400">
+                <FormattedMessage
+                  id="station.no_recent_issues"
+                  defaultMessage="No recent issues reported for this station"
+                />
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/docs/plans/active/production-performance.md
+++ b/docs/plans/active/production-performance.md
@@ -360,6 +360,12 @@ underlying compute and payload costs so uncached requests are also fast.
   `CommunitySignalsSection` client/server chunk, and the home, line, and
   station route component entries list it only as a dynamic import instead of
   an eager route dependency.
+- 2026-06-13: Continued Phase 5 profile route hydration cleanup by
+  lazy-loading recent-issues sections behind `DeferredViewportWidget` on line,
+  operator, and station profile routes. A production build now emits separate
+  recent-issues chunks, keeping `IssueCard` out of the initial profile route
+  render and keeping the shared line/operator recent-issues Radix Collapsible
+  dependency behind the viewport gate.
 
 ## Validation
 


### PR DESCRIPTION
## Summary

- Lazy-load recent issues sections on line, operator, and station profile routes behind `DeferredViewportWidget`.
- Move the station recent issues block into a route-local lazy component.
- Add a shared recent-issues skeleton and update the production performance plan progress notes.

## Impact

This keeps `IssueCard` out of the initial profile route render and keeps the shared line/operator recent-issues Collapsible dependency behind the viewport gate, reducing upfront profile hydration work while preserving existing page behavior.

## Validation

- `npm run build`
- `npm run verify`