### PR TITLE
test: lock markdown discovery surface

### DIFF
--- a/app/util/sitemap.functions.test.ts
+++ b/app/util/sitemap.functions.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import { buildSitemapPaths } from './sitemap.functions';
+
+vi.mock('@tanstack/react-start', () => ({
+  createServerFn: () => ({
+    handler: (handler: unknown) => handler,
+  }),
+}));
+
+vi.mock('./db.queries', () => ({
+  getSitemapData: vi.fn(),
+}));
+
+describe('agent Markdown discovery', () => {
+  it('advertises llms.txt through robots.txt', () => {
+    const robotsTxt = readFileSync(
+      new URL('../../public/robots.txt', import.meta.url),
+      'utf8',
+    );
+
+    expect(robotsTxt).toContain('LLMS: https://www.mrtdown.org/llms.txt');
+  });
+
+  it('keeps Markdown routes discoverable through llms.txt instead of the XML sitemap', () => {
+    const paths = buildSitemapPaths({
+      lineIds: ['EWL'],
+      stationIds: ['EW1'],
+      operatorIds: ['SMRT'],
+      issueIds: ['issue-1'],
+      monthEarliest: '2026-04-01',
+      monthLatest: '2026-05-01',
+    });
+
+    expect(paths).toEqual(
+      expect.arrayContaining([
+        '/',
+        '/lines/EWL',
+        '/stations/EW1',
+        '/operators/SMRT',
+        '/issues/issue-1',
+        '/history/2026/04',
+        '/history/2026/05',
+      ]),
+    );
+    expect(paths).not.toContain('/llms.txt');
+    expect(paths).not.toContain('/index.md');
+    expect(paths).not.toContain('/lines/EWL/index.md');
+    expect(paths).not.toContain('/stations/EW1/index.md');
+    expect(paths).not.toContain('/operators/SMRT/index.md');
+    expect(paths).not.toContain('/issues/issue-1/index.md');
+    expect(paths.every((path) => !path.endsWith('.md'))).toBe(true);
+  });
+});

--- a/app/util/sitemap.functions.ts
+++ b/app/util/sitemap.functions.ts
@@ -6,6 +6,15 @@ import { LANGUAGES_NON_DEFAULT } from '~/constants';
 import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
 import { getSitemapData } from './db.queries';
 
+interface SitemapPathData {
+  lineIds: string[];
+  stationIds: string[];
+  operatorIds: string[];
+  issueIds: string[];
+  monthEarliest: string;
+  monthLatest: string;
+}
+
 function buildEntries(path: string, rootUrl: string): Element {
   return {
     type: 'element',
@@ -54,55 +63,7 @@ function buildEntries(path: string, rootUrl: string): Element {
 
 export const getSitemapFn = createServerFn({ method: 'GET' }).handler(
   async () => {
-    const {
-      lineIds,
-      stationIds,
-      operatorIds,
-      issueIds,
-      monthEarliest,
-      monthLatest,
-    } = await getSitemapData();
-    const paths: string[] = [
-      '/',
-      '/history',
-      '/statistics',
-      '/system-map',
-      '/about',
-    ];
-
-    for (const lineId of lineIds) {
-      paths.push(`/lines/${lineId}`);
-    }
-    for (const stationId of stationIds) {
-      paths.push(`/stations/${stationId}`);
-    }
-    for (const operatorId of operatorIds) {
-      paths.push(`/operators/${operatorId}`);
-    }
-    for (const issueId of issueIds) {
-      paths.push(`/issues/${issueId}`);
-    }
-
-    const monthEarliestDateTime = DateTime.fromISO(monthEarliest);
-    const monthLatestDateTime = DateTime.fromISO(monthLatest);
-    const interval = Interval.fromDateTimes(
-      monthEarliestDateTime,
-      monthLatestDateTime.plus({ month: 1 }),
-    );
-    for (const monthInterval of interval.splitBy({ month: 1 })) {
-      const monthDateTime = monthInterval.start;
-      if (monthDateTime == null) {
-        continue;
-      }
-
-      if (!paths.includes(`/history/${monthDateTime.toFormat('yyyy')}`)) {
-        paths.push(`/history/${monthDateTime.toFormat('yyyy')}`);
-      }
-
-      paths.push(
-        `/history/${monthDateTime.toFormat('yyyy')}/${monthDateTime.toFormat('MM')}`,
-      );
-    }
+    const paths = buildSitemapPaths(await getSitemapData());
 
     const elementUrlSet: Element = {
       type: 'element',
@@ -114,7 +75,7 @@ export const getSitemapFn = createServerFn({ method: 'GET' }).handler(
       children: paths.map((path) => {
         return buildEntries(
           path,
-          process.env.ROOT_URL ?? 'http://localhost:3000',
+          import.meta.env.VITE_ROOT_URL ?? 'http://localhost:3000',
         );
       }),
     };
@@ -127,3 +88,56 @@ export const getSitemapFn = createServerFn({ method: 'GET' }).handler(
     return toXml(root);
   },
 );
+
+export function buildSitemapPaths({
+  lineIds,
+  stationIds,
+  operatorIds,
+  issueIds,
+  monthEarliest,
+  monthLatest,
+}: SitemapPathData) {
+  const paths: string[] = [
+    '/',
+    '/history',
+    '/statistics',
+    '/system-map',
+    '/about',
+  ];
+
+  for (const lineId of lineIds) {
+    paths.push(`/lines/${lineId}`);
+  }
+  for (const stationId of stationIds) {
+    paths.push(`/stations/${stationId}`);
+  }
+  for (const operatorId of operatorIds) {
+    paths.push(`/operators/${operatorId}`);
+  }
+  for (const issueId of issueIds) {
+    paths.push(`/issues/${issueId}`);
+  }
+
+  const monthEarliestDateTime = DateTime.fromISO(monthEarliest);
+  const monthLatestDateTime = DateTime.fromISO(monthLatest);
+  const interval = Interval.fromDateTimes(
+    monthEarliestDateTime,
+    monthLatestDateTime.plus({ month: 1 }),
+  );
+  for (const monthInterval of interval.splitBy({ month: 1 })) {
+    const monthDateTime = monthInterval.start;
+    if (monthDateTime == null) {
+      continue;
+    }
+
+    if (!paths.includes(`/history/${monthDateTime.toFormat('yyyy')}`)) {
+      paths.push(`/history/${monthDateTime.toFormat('yyyy')}`);
+    }
+
+    paths.push(
+      `/history/${monthDateTime.toFormat('yyyy')}/${monthDateTime.toFormat('MM')}`,
+    );
+  }
+
+  return paths;
+}

--- a/docs/plans/active/markdown-for-agents.md
+++ b/docs/plans/active/markdown-for-agents.md
@@ -158,6 +158,10 @@ Exit criteria:
   Phase 3 entity Markdown routes. The tests cover read-model delegation,
   cacheable `text/markdown` responses, and preservation of read-model 404
   responses for missing entities.
+- 2026-06-13: Added discovery tests that assert `/llms.txt` is advertised from
+  `public/robots.txt` and that Markdown routes stay out of the XML sitemap.
+  Production traffic inspection for `/llms.txt`, `index.md`, `.md`, and
+  `Accept: text/markdown` remains the open Phase 4 follow-up.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Extract sitemap path construction into a testable helper while preserving the existing XML output shape.
- Add discovery coverage that confirms `/llms.txt` is advertised from `robots.txt` and Markdown URLs stay out of the XML sitemap.
- Record the Phase 4 Markdown-for-agents progress and remaining production traffic inspection follow-up.

## Validation

- `npm run test:run -- app/util/sitemap.functions.test.ts`
- `npm run verify`