### PR TITLE
perf: remove unused viewport schema

### DIFF
--- a/app/hooks/useViewport.ts
+++ b/app/hooks/useViewport.ts
@@ -1,8 +1,6 @@
 import { useLayoutEffect, useState } from 'react';
-import z from 'zod';
 
-export const ViewportSchema = z.enum(['xs', 'sm', 'md', 'lg', 'xl', '2xl']);
-export type Viewport = z.infer<typeof ViewportSchema>;
+export type Viewport = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
 
 function computeViewport(width: number): Viewport {
   if (width >= 1536) {

--- a/docs/plans/active/production-performance.md
+++ b/docs/plans/active/production-performance.md
@@ -366,6 +366,10 @@ underlying compute and payload costs so uncached requests are also fast.
   recent-issues chunks, keeping `IssueCard` out of the initial profile route
   render and keeping the shared line/operator recent-issues Radix Collapsible
   dependency behind the viewport gate.
+- 2026-06-13: Continued Phase 5 route preload cleanup by removing the unused
+  runtime `ViewportSchema` from `useViewport`. The home and operator route
+  entries still use the viewport hook, but the production build no longer pulls
+  the `zod` chunk through that hook.
 
 ## Validation
 


### PR DESCRIPTION
## Summary

- Remove the unused runtime `ViewportSchema` export from `useViewport`.
- Keep the viewport type as a TypeScript union so route code keeps the same behavior without importing `zod` through the viewport hook.
- Update the production performance plan progress notes with the preload cleanup.

## Impact

Home and operator route entries still use `useViewport`, but the production build manifest no longer shows the viewport hook pulling in the `zod` chunk through that path.

## Validation

- `npm run build`
- `npm run verify`

Note: the first sandboxed `npm run verify` attempt reached typecheck, lint, and format, then failed at `db:generate:check` because `tsx` could not bind its local IPC pipe (`listen EPERM`). Rerunning the same command outside the sandbox passed.