### PR TITLE
fix: parse SQL timestamps in agent Markdown

### DIFF
--- a/app/util/agentMarkdown.test.ts
+++ b/app/util/agentMarkdown.test.ts
@@ -105,6 +105,9 @@ describe('agent Markdown serialization', () => {
 
   it('formats dates, datetimes, and durations consistently for agent routes', () => {
     expect(formatMarkdownDate('2026-05-31T23:30:00+08:00')).toBe('2026-05-31');
+    expect(formatMarkdownDateTime('2026-06-10 01:00:00+00')).toBe(
+      '2026-06-10T09:00:00+08:00',
+    );
     expect(
       formatMarkdownDateTime(
         DateTime.fromISO('2026-05-31T23:30:00+08:00', { setZone: true }),

--- a/app/util/agentMarkdown.ts
+++ b/app/util/agentMarkdown.ts
@@ -155,6 +155,10 @@ function parseMarkdownDate(
     dateTime = DateTime.fromJSDate(value);
   } else {
     dateTime = DateTime.fromISO(value, { setZone: true });
+
+    if (!dateTime.isValid) {
+      dateTime = DateTime.fromSQL(value, { setZone: true });
+    }
   }
 
   if (!dateTime.isValid) {

--- a/docs/plans/active/markdown-for-agents.md
+++ b/docs/plans/active/markdown-for-agents.md
@@ -166,6 +166,10 @@ Exit criteria:
   Lighthouse flagged it as invalid. `/llms.txt` remains available at the
   conventional root URL, and robots discovery is limited to the standard XML
   sitemap directive.
+- 2026-06-13: Local route validation found issue Markdown could crash on
+  PostgreSQL-style timestamp strings such as `2026-06-10 01:00:00+00`.
+  Updated the shared Markdown date parser to accept SQL timestamp strings and
+  added regression coverage.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Add a SQL timestamp fallback to the shared agent Markdown date parser.
- Cover the PostgreSQL-style timestamp shape that local route validation exposed.
- Record the finding in the active Markdown-for-agents plan.

## Why

Local validation of the issue Markdown route found that read-model timestamps can arrive as PostgreSQL-style strings such as `2026-06-10 01:00:00+00`. The Markdown formatter only parsed ISO strings, so issue Markdown could throw and return a 500 for otherwise valid issue data.

## Validation

- `npm run test:run -- agentMarkdown agentMarkdownContent agentMarkdownRoutes llmsTxt sitemap.functions`
- `npm run verify`
- Local route check confirmed `/issues/2026-06-10-isl-platform-screen-door-renewal/index.md` returned `200 OK`, `text/markdown; charset=utf-8`, and public Markdown cache headers after the fix.