### PR TITLE
perf: defer advisory details hydration

### DIFF
--- a/app/components/CurrentAdvisoriesSection.tsx
+++ b/app/components/CurrentAdvisoriesSection.tsx
@@ -198,7 +198,8 @@ export const CurrentAdvisoriesSection: React.FC<Props> = (props) => {
         <Suspense
           fallback={
             <CurrentAdvisoriesDetailsSkeleton
-              issues={[...issuesActiveNow, ...issuesActiveToday]}
+              issuesActiveNow={issuesActiveNow}
+              issuesActiveToday={issuesActiveToday}
             />
           }
         >
@@ -213,22 +214,31 @@ export const CurrentAdvisoriesSection: React.FC<Props> = (props) => {
   );
 };
 
-function CurrentAdvisoriesDetailsSkeleton(props: { issues: Issue[] }) {
+function CurrentAdvisoriesDetailsSkeleton(props: {
+  issuesActiveNow: Issue[];
+  issuesActiveToday: Issue[];
+}) {
   return (
     <div
       id="current-advisories-details"
       className="mt-4 flex flex-col space-y-3"
     >
-      {props.issues.map((issue) => (
-        <div
-          key={issue.id}
-          className="flex flex-col rounded-xl border border-gray-300 bg-white px-4 py-3 shadow-sm sm:px-6 sm:py-4 dark:border-gray-600 dark:bg-gray-800"
-        >
-          <div className="h-5 w-44 rounded bg-gray-200 dark:bg-gray-700" />
-          <div className="mt-3 h-4 w-full max-w-xl rounded bg-gray-200 dark:bg-gray-700" />
-          <div className="mt-2 h-4 w-2/3 rounded bg-gray-200 dark:bg-gray-700" />
-        </div>
+      {props.issuesActiveNow.map((issue) => (
+        <CurrentAdvisoriesDetailsSkeletonCard key={`now-${issue.id}`} />
       ))}
+      {props.issuesActiveToday.map((issue) => (
+        <CurrentAdvisoriesDetailsSkeletonCard key={`today-${issue.id}`} />
+      ))}
+    </div>
+  );
+}
+
+function CurrentAdvisoriesDetailsSkeletonCard() {
+  return (
+    <div className="flex flex-col rounded-xl border border-gray-300 bg-white px-4 py-3 shadow-sm sm:px-6 sm:py-4 dark:border-gray-600 dark:bg-gray-800">
+      <div className="h-5 w-44 rounded bg-gray-200 dark:bg-gray-700" />
+      <div className="mt-3 h-4 w-full max-w-xl rounded bg-gray-200 dark:bg-gray-700" />
+      <div className="mt-2 h-4 w-2/3 rounded bg-gray-200 dark:bg-gray-700" />
     </div>
   );
 }

--- a/app/components/CurrentAdvisoriesSection.tsx
+++ b/app/components/CurrentAdvisoriesSection.tsx
@@ -8,18 +8,16 @@ import {
   ExclamationTriangleIcon,
 } from '@heroicons/react/24/outline';
 import classNames from 'classnames';
-import { DateTime } from 'luxon';
-import { Collapsible } from 'radix-ui';
-import { useMemo } from 'react';
+import { lazy, Suspense, useMemo, useState } from 'react';
 import { defineMessage, FormattedMessage } from 'react-intl';
 import type { Issue } from '~/types';
-import { IssueCard } from '~/components/IssueCard';
 import { LineBar } from '~/components/LineBar';
-import type { IssueCardContext } from './IssueCard/types';
 
-const ISSUE_CARD_CONTEXT_NOW: IssueCardContext = {
-  type: 'now',
-};
+const CurrentAdvisoriesDetails = lazy(() =>
+  import('./CurrentAdvisoriesSection/Details').then((module) => ({
+    default: module.CurrentAdvisoriesDetails,
+  })),
+);
 
 const ISSUE_TYPES = [
   {
@@ -59,6 +57,7 @@ interface Props {
 
 export const CurrentAdvisoriesSection: React.FC<Props> = (props) => {
   const { issuesActiveNow, issuesActiveToday, lineOperationalCount } = props;
+  const [detailsOpen, setDetailsOpen] = useState(false);
 
   const { issueCountsByType, issueLineIdsByType } = useMemo(() => {
     const countsByType: Partial<Record<IssueType, number>> = {};
@@ -84,18 +83,10 @@ export const CurrentAdvisoriesSection: React.FC<Props> = (props) => {
     };
   }, [issuesActiveNow, issuesActiveToday]);
 
-  const issueCardContextToday = useMemo<IssueCardContext>(() => {
-    return {
-      type: 'history.days',
-      date: DateTime.now().toISODate(),
-      days: 1,
-    };
-  }, []);
-
   const activeIssueCount = issuesActiveNow.length + issuesActiveToday.length;
 
   return (
-    <Collapsible.Root>
+    <>
       <div className="rounded-2xl border border-gray-200 bg-white p-3 shadow-sm sm:p-4 dark:border-gray-700 dark:bg-gray-800">
         <div className="flex flex-col gap-3 sm:gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div className="flex-1 shrink space-y-3">
@@ -172,60 +163,72 @@ export const CurrentAdvisoriesSection: React.FC<Props> = (props) => {
 
           {activeIssueCount > 0 && (
             <div className="flex w-full shrink-0 justify-center gap-2 sm:w-auto lg:justify-start">
-              <Collapsible.Trigger className="group w-36 shrink-0 rounded-lg bg-accent-light px-3 py-2 font-medium text-sm text-white transition-all duration-200 hover:bg-accent-light/80 hover:shadow-md sm:rounded-xl sm:px-4 sm:py-2.5 dark:bg-accent-dark dark:hover:bg-accent-dark/80">
-                <div className="flex items-center justify-center gap-x-2 group-data-[state=open]:hidden sm:justify-between">
-                  <FormattedMessage
-                    id="general.show_details"
-                    defaultMessage="Show details"
-                  />
-                  <ChevronDownIcon className="size-4" />
+              <button
+                type="button"
+                aria-expanded={detailsOpen}
+                aria-controls="current-advisories-details"
+                className="w-36 shrink-0 rounded-lg bg-accent-light px-3 py-2 font-medium text-sm text-white transition-all duration-200 hover:bg-accent-light/80 hover:shadow-md sm:rounded-xl sm:px-4 sm:py-2.5 dark:bg-accent-dark dark:hover:bg-accent-dark/80"
+                onClick={() => setDetailsOpen((isOpen) => !isOpen)}
+              >
+                <div className="flex items-center justify-center gap-x-2 sm:justify-between">
+                  {detailsOpen ? (
+                    <>
+                      <FormattedMessage
+                        id="general.hide_details"
+                        defaultMessage="Hide details"
+                      />
+                      <ChevronUpIcon className="size-4" />
+                    </>
+                  ) : (
+                    <>
+                      <FormattedMessage
+                        id="general.show_details"
+                        defaultMessage="Show details"
+                      />
+                      <ChevronDownIcon className="size-4" />
+                    </>
+                  )}
                 </div>
-                <div className="flex items-center justify-center gap-x-2 group-data-[state=closed]:hidden sm:justify-between">
-                  <FormattedMessage
-                    id="general.hide_details"
-                    defaultMessage="Hide details"
-                  />
-                  <ChevronUpIcon className="size-4" />
-                </div>
-              </Collapsible.Trigger>
+              </button>
             </div>
           )}
         </div>
       </div>
-      {activeIssueCount > 0 && (
-        <Collapsible.Content asChild>
-          <div className="mt-4 flex flex-col space-y-3">
-            {issuesActiveNow.map((issue) => (
-              <IssueCard
-                key={issue.id}
-                issue={issue}
-                className="!w-auto"
-                context={ISSUE_CARD_CONTEXT_NOW}
-              />
-            ))}
-            {issuesActiveToday.map((issue) => (
-              <IssueCard
-                key={issue.id}
-                issue={issue}
-                className="!w-auto"
-                context={issueCardContextToday}
-              />
-            ))}
-            <Collapsible.Trigger asChild>
-              <button
-                type="button"
-                className="inline-flex items-center gap-x-2 self-center rounded-lg border border-gray-300 bg-white px-4 py-2 font-medium text-gray-700 text-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-accent-light focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:focus:ring-accent-dark dark:hover:bg-gray-700"
-              >
-                <FormattedMessage
-                  id="general.hide_details"
-                  defaultMessage="Hide details"
-                />
-                <ChevronUpIcon className="size-4" />
-              </button>
-            </Collapsible.Trigger>
-          </div>
-        </Collapsible.Content>
+      {activeIssueCount > 0 && detailsOpen && (
+        <Suspense
+          fallback={
+            <CurrentAdvisoriesDetailsSkeleton
+              issues={[...issuesActiveNow, ...issuesActiveToday]}
+            />
+          }
+        >
+          <CurrentAdvisoriesDetails
+            issuesActiveNow={issuesActiveNow}
+            issuesActiveToday={issuesActiveToday}
+            onClose={() => setDetailsOpen(false)}
+          />
+        </Suspense>
       )}
-    </Collapsible.Root>
+    </>
   );
 };
+
+function CurrentAdvisoriesDetailsSkeleton(props: { issues: Issue[] }) {
+  return (
+    <div
+      id="current-advisories-details"
+      className="mt-4 flex flex-col space-y-3"
+    >
+      {props.issues.map((issue) => (
+        <div
+          key={issue.id}
+          className="flex flex-col rounded-xl border border-gray-300 bg-white px-4 py-3 shadow-sm sm:px-6 sm:py-4 dark:border-gray-600 dark:bg-gray-800"
+        >
+          <div className="h-5 w-44 rounded bg-gray-200 dark:bg-gray-700" />
+          <div className="mt-3 h-4 w-full max-w-xl rounded bg-gray-200 dark:bg-gray-700" />
+          <div className="mt-2 h-4 w-2/3 rounded bg-gray-200 dark:bg-gray-700" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/components/CurrentAdvisoriesSection/Details.tsx
+++ b/app/components/CurrentAdvisoriesSection/Details.tsx
@@ -1,0 +1,64 @@
+import { ChevronUpIcon } from '@heroicons/react/24/outline';
+import { DateTime } from 'luxon';
+import { useMemo } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { IssueCard } from '~/components/IssueCard';
+import type { Issue } from '~/types';
+import type { IssueCardContext } from '../IssueCard/types';
+
+const ISSUE_CARD_CONTEXT_NOW: IssueCardContext = {
+  type: 'now',
+};
+
+interface Props {
+  issuesActiveNow: Issue[];
+  issuesActiveToday: Issue[];
+  onClose: () => void;
+}
+
+export function CurrentAdvisoriesDetails(props: Props) {
+  const { issuesActiveNow, issuesActiveToday, onClose } = props;
+
+  const issueCardContextToday = useMemo<IssueCardContext>(() => {
+    return {
+      type: 'history.days',
+      date: DateTime.now().toISODate(),
+      days: 1,
+    };
+  }, []);
+
+  return (
+    <div
+      id="current-advisories-details"
+      className="mt-4 flex flex-col space-y-3"
+    >
+      {issuesActiveNow.map((issue) => (
+        <IssueCard
+          key={issue.id}
+          issue={issue}
+          className="!w-auto"
+          context={ISSUE_CARD_CONTEXT_NOW}
+        />
+      ))}
+      {issuesActiveToday.map((issue) => (
+        <IssueCard
+          key={issue.id}
+          issue={issue}
+          className="!w-auto"
+          context={issueCardContextToday}
+        />
+      ))}
+      <button
+        type="button"
+        className="inline-flex items-center gap-x-2 self-center rounded-lg border border-gray-300 bg-white px-4 py-2 font-medium text-gray-700 text-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-accent-light focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:focus:ring-accent-dark dark:hover:bg-gray-700"
+        onClick={onClose}
+      >
+        <FormattedMessage
+          id="general.hide_details"
+          defaultMessage="Hide details"
+        />
+        <ChevronUpIcon className="size-4" />
+      </button>
+    </div>
+  );
+}

--- a/app/components/CurrentAdvisoriesSection/Details.tsx
+++ b/app/components/CurrentAdvisoriesSection/Details.tsx
@@ -34,7 +34,7 @@ export function CurrentAdvisoriesDetails(props: Props) {
     >
       {issuesActiveNow.map((issue) => (
         <IssueCard
-          key={issue.id}
+          key={`now-${issue.id}`}
           issue={issue}
           className="!w-auto"
           context={ISSUE_CARD_CONTEXT_NOW}
@@ -42,7 +42,7 @@ export function CurrentAdvisoriesDetails(props: Props) {
       ))}
       {issuesActiveToday.map((issue) => (
         <IssueCard
-          key={issue.id}
+          key={`today-${issue.id}`}
           issue={issue}
           className="!w-auto"
           context={issueCardContextToday}

--- a/docs/plans/active/production-performance.md
+++ b/docs/plans/active/production-performance.md
@@ -370,6 +370,12 @@ underlying compute and payload costs so uncached requests are also fast.
   runtime `ViewportSchema` from `useViewport`. The home and operator route
   entries still use the viewport hook, but the production build no longer pulls
   the `zod` chunk through that hook.
+- 2026-06-13: Continued Phase 5 home hydration cleanup by splitting the
+  collapsed current-advisory issue details into a lazy `Details` chunk and
+  replacing the eager Radix Collapsible dependency with local button state. A
+  production build emits separate client assets for `Details` and `IssueCard`,
+  keeping advisory detail cards out of the initial home route bundle until the
+  user opens the section.
 
 ## Validation
 


### PR DESCRIPTION
## Summary

- Split the home page current-advisory issue details into a lazy `Details` component.
- Replaced the eager Radix Collapsible wrapper with local button state for the collapsed-by-default details section.
- Updated the production performance plan progress notes for this Phase 5 hydration cleanup.

## Impact

The home route can render its advisory summary without eagerly loading `IssueCard` and the advisory details implementation. Those details load only when a user opens the section.

## Validation

- `npm run verify`
- `npm run build`
- Browser smoke test on `http://127.0.0.1:3000/`: opened and closed current advisory details successfully. The only browser error observed was the existing local PostHog token warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Advisory details are now lazily loaded on demand, improving initial page load and hydration.

* **User Experience**
  * Advisory section gains a manual Show/Hide toggle with accessible state and a loading skeleton while details load.

* **Documentation**
  * Updated performance progress notes documenting the home-page hydration improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->