### PR TITLE
chore: extend route timing probes

### DIFF
--- a/app/scripts/checkRouteTimings.ts
+++ b/app/scripts/checkRouteTimings.ts
@@ -1,20 +1,97 @@
-const DEFAULT_ROUTES = [
+type ProbeGroup = 'html' | 'markdown';
+
+type RouteProbe = {
+  group: ProbeGroup;
+  label: string;
+  route: string;
+  accept: string;
+};
+
+const HTML_PROBES = [
   '/',
   '/?viewport=md',
   '/?viewport=lg',
   '/statistics',
   '/about',
-] as const;
+].map(
+  (route) =>
+    ({
+      group: 'html',
+      label: route,
+      route,
+      accept: 'text/html',
+    }) satisfies RouteProbe,
+);
 
-type TimingResult = {
+const MARKDOWN_PROBES = [
+  {
+    label: 'llms.txt',
+    route: '/llms.txt',
+    accept: 'text/plain, text/markdown;q=0.9, */*;q=0.1',
+  },
+  {
+    label: 'overview index.md',
+    route: '/index.md',
+    accept: 'text/markdown',
+  },
+  {
+    label: 'line index.md',
+    route: '/lines/BPLRT/index.md',
+    accept: 'text/markdown',
+  },
+  {
+    label: 'station index.md',
+    route: '/stations/BKP/index.md',
+    accept: 'text/markdown',
+  },
+  {
+    label: 'operator index.md',
+    route: '/operators/SMRT_TRAINS/index.md',
+    accept: 'text/markdown',
+  },
+  {
+    label: 'line .md alias attempt',
+    route: '/lines/BPLRT.md',
+    accept: 'text/markdown',
+  },
+  {
+    label: 'station .md alias attempt',
+    route: '/stations/BKP.md',
+    accept: 'text/markdown',
+  },
+  {
+    label: 'HTML route with Markdown Accept',
+    route: '/lines/BPLRT',
+    accept: 'text/markdown',
+  },
+].map(
+  (probe) =>
+    ({
+      group: 'markdown',
+      ...probe,
+    }) satisfies RouteProbe,
+);
+
+const DEFAULT_PROBES = [...HTML_PROBES, ...MARKDOWN_PROBES] as const;
+
+type ProbeTiming = {
+  group: ProbeGroup;
+  label: string;
   route: string;
   status: number;
   ttfbMs: number;
+  totalMs: number;
   bytes: number;
+  contentType: string;
   cacheControl: string;
   cfCacheStatus: string;
+  appCache: string;
   serverTiming: string;
   render: string;
+};
+
+type TimingResult = ProbeTiming & {
+  sample: number;
 };
 
 function getBaseUrl() {
@@ -27,28 +104,67 @@ function getBaseUrl() {
   return baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
 }
 
+function getProbeGroups() {
+  const raw = process.env.PROBES ?? 'all';
+  const groups = raw
+    .split(',')
+    .map((group) => group.trim())
+    .filter((group) => group !== '');
+
+  if (groups.includes('all')) {
+    return new Set<ProbeGroup>(['html', 'markdown']);
+  }
+
+  const selectedGroups = new Set<ProbeGroup>();
+  for (const group of groups) {
+    if (group !== 'html' && group !== 'markdown') {
+      throw new Error(
+        'PROBES must be "all", "html", "markdown", or a comma list.',
+      );
+    }
+    selectedGroups.add(group);
+  }
+
+  if (selectedGroups.size === 0) {
+    throw new Error('PROBES must select at least one probe group.');
+  }
+
+  return selectedGroups;
+}
+
+function getSelectedProbes() {
+  const groups = getProbeGroups();
+  return DEFAULT_PROBES.filter((probe) => groups.has(probe.group));
+}
+
 async function timeRoute(
   baseUrl: string,
-  route: string,
-): Promise<TimingResult> {
+  probe: RouteProbe,
+): Promise<ProbeTiming> {
   const startedAt = performance.now();
-  const response = await fetch(`${baseUrl}${route}`, {
+  const response = await fetch(`${baseUrl}${probe.route}`, {
     headers: {
-      accept: 'text/html',
+      accept: probe.accept,
       'accept-encoding': 'br, gzip, deflate',
     },
     redirect: 'follow',
   });
   const ttfbMs = performance.now() - startedAt;
   const bytes = (await response.arrayBuffer()).byteLength;
+  const totalMs = performance.now() - startedAt;
 
   return {
-    route,
+    group: probe.group,
+    label: probe.label,
+    route: probe.route,
     status: response.status,
     ttfbMs: Number(ttfbMs.toFixed(1)),
+    totalMs: Number(totalMs.toFixed(1)),
     bytes,
+    contentType: response.headers.get('content-type') ?? '',
     cacheControl: response.headers.get('cache-control') ?? '',
     cfCacheStatus: response.headers.get('cf-cache-status') ?? '',
+    appCache: response.headers.get('x-mrtdown-cache') ?? '',
     serverTiming: response.headers.get('server-timing') ?? '',
     render: response.headers.get('x-mrtdown-render') ?? '',
   };
@@ -56,6 +172,7 @@ async function timeRoute(
 
 async function main() {
   const baseUrl = getBaseUrl();
+  const probes = getSelectedProbes();
   const sampleCountRaw = Number.parseInt(process.env.SAMPLES ?? '3', 10);
   if (!Number.isFinite(sampleCountRaw) || sampleCountRaw <= 0) {
     throw new Error('SAMPLES must be a positive integer.');
@@ -64,18 +181,27 @@ async function main() {
   const results: TimingResult[] = [];
 
   for (let sample = 0; sample < sampleCount; sample++) {
-    for (const route of DEFAULT_ROUTES) {
-      results.push(await timeRoute(baseUrl, route));
+    for (const probe of probes) {
+      results.push({
+        ...(await timeRoute(baseUrl, probe)),
+        sample: sample + 1,
+      });
     }
   }
 
   console.table(
     results.map((result) => ({
+      sample: result.sample,
+      group: result.group,
+      label: result.label,
       route: result.route,
       status: result.status,
       ttfbMs: result.ttfbMs,
+      totalMs: result.totalMs,
       bytes: result.bytes,
-      cache: result.cfCacheStatus,
+      contentType: result.contentType,
+      cfCache: result.cfCacheStatus,
+      appCache: result.appCache,
       render: result.render,
       cacheControl: result.cacheControl,
       serverTiming: result.serverTiming,

--- a/docs/plans/active/production-performance.md
+++ b/docs/plans/active/production-performance.md
@@ -384,6 +384,22 @@ underlying compute and payload costs so uncached requests are also fast.
   production build emits separate client assets for `Details` and `IssueCard`,
   keeping advisory detail cards out of the initial home route bundle until the
   user opens the section.
+- 2026-06-13: Continued Phase 0 repeatable production checks by extending
+  `npm run perf:routes` beyond public HTML routes. The script now samples
+  `/llms.txt`, `/index.md`, representative line/station/operator `index.md`
+  routes, `.md` alias attempts, and a regular HTML route with
+  `Accept: text/markdown`; results include sample number, TTFB, total time,
+  response bytes, content type, Cloudflare cache status, app cache marker,
+  render source, cache-control, and server-timing headers. Use
+  `PROBES=html`, `PROBES=markdown`, or `PROBES=all` to scope a run.
+- 2026-06-13: Ran `SAMPLES=1 PROBES=markdown npm run perf:routes --`
+  against production after the script update. `/llms.txt`, `/index.md`, and
+  representative line/station/operator `index.md` routes returned 200
+  `text/markdown` responses with `X-MRTDown-Cache: public-markdown`.
+  Unsupported `.md` alias attempts and `/lines/BPLRT` with
+  `Accept: text/markdown` currently return 500 JSON responses in production,
+  so a follow-up should decide whether those should normalize to 404/406 before
+  adding alias support.
 
 ## Validation
 
@@ -408,6 +424,8 @@ curl --compressed -L -s -D /tmp/mrtdown-statistics.headers \
   https://www.mrtdown.org/statistics
 
 wc -c /tmp/mrtdown-statistics.html /tmp/mrtdown-statistics.headers
+
+SAMPLES=2 PROBES=all npm run perf:routes -- https://www.mrtdown.org
 ```
 
 ## Open Questions


### PR DESCRIPTION
## Summary

- Extend `npm run perf:routes` to support HTML and Markdown probe groups via `PROBES=html|markdown|all`.
- Add repeatable Markdown surface probes for `/llms.txt`, `/index.md`, representative entity `index.md` routes, `.md` alias attempts, and HTML routes requested with `Accept: text/markdown`.
- Record the production smoke-test result in the active performance plan, including the current 500 JSON behavior for unsupported Markdown alias/content-negotiation attempts.

## Validation

- `npm run verify`
- `SAMPLES=1 PROBES=markdown npm run perf:routes -- https://www.mrtdown.org`