### PR TITLE
fix: normalize markdown negotiation responses

### DIFF
--- a/app/server.ts
+++ b/app/server.ts
@@ -12,6 +12,7 @@ import {
   type CrowdReportFeatureEnv,
   isCrowdReportsFeatureEnabled,
 } from './util/crowdReportFeatureFlag';
+import { getUnsupportedAgentMarkdownResponse } from './util/agentMarkdown';
 import {
   addSentryAnonymousUserCookie,
   getSentryAnonymousUser,
@@ -26,6 +27,20 @@ async function appFetch(request: Request, _env: Env, ctx: ExecutionContext) {
     id: sentryAnonymousUser.sentryUserId,
     ip_address: null,
   });
+  const unsupportedMarkdownResponse =
+    getUnsupportedAgentMarkdownResponse(request);
+  if (unsupportedMarkdownResponse != null) {
+    const elapsedMs = performance.now() - startedAt;
+    return addSentryAnonymousUserCookie(
+      addResponseInstrumentationHeaders(
+        unsupportedMarkdownResponse,
+        elapsedMs,
+        'worker',
+      ),
+      sentryAnonymousUser,
+    );
+  }
+
   const shouldUsePublicHtmlCache = !shouldBypassPublicHtmlCacheForCrowdReports(
     request,
     _env,

--- a/app/util/agentMarkdown.test.ts
+++ b/app/util/agentMarkdown.test.ts
@@ -6,6 +6,7 @@ import {
   formatMarkdownDate,
   formatMarkdownDateTime,
   formatMarkdownDurationSeconds,
+  getUnsupportedAgentMarkdownResponse,
   markdownTable,
   serializeAgentMarkdown,
 } from './agentMarkdown';
@@ -150,3 +151,77 @@ describe('createPublicMarkdownResponse', () => {
     expect(response.headers.get('x-mrtdown-cache')).toBeNull();
   });
 });
+
+describe('agent Markdown request negotiation', () => {
+  it.each([
+    '/index.md',
+    '/llms.txt',
+    '/lines/BPLRT/index.md',
+    '/stations/BKP/index.md',
+    '/operators/SMRT_TRAINS/index.md',
+    '/issues/issue-1/index.md',
+  ])('lets canonical Markdown route %s pass through', (pathname) => {
+    expect(
+      getUnsupportedAgentMarkdownResponse(
+        request(pathname, { headers: { accept: 'text/markdown' } }),
+      ),
+    ).toBeNull();
+  });
+
+  it.each(['/lines/BPLRT.md', '/stations/BKP.md'])(
+    'returns 404 for unsupported Markdown alias %s',
+    async (pathname) => {
+      const response = getUnsupportedAgentMarkdownResponse(
+        request(pathname, { headers: { accept: 'text/markdown' } }),
+      );
+
+      expect(response?.status).toBe(404);
+      expect(response?.headers.get('content-type')).toBe(
+        'text/plain; charset=utf-8',
+      );
+      await expect(response?.text()).resolves.toBe('Markdown route not found');
+    },
+  );
+
+  it('returns 406 when Markdown is explicitly preferred for an HTML route', async () => {
+    const response = getUnsupportedAgentMarkdownResponse(
+      request('/lines/BPLRT', { headers: { accept: 'text/markdown' } }),
+    );
+
+    expect(response?.status).toBe(406);
+    expect(response?.headers.get('content-type')).toBe(
+      'text/plain; charset=utf-8',
+    );
+    await expect(response?.text()).resolves.toBe(
+      'Markdown is not available for this route',
+    );
+  });
+
+  it('does not affect normal HTML requests', () => {
+    expect(
+      getUnsupportedAgentMarkdownResponse(
+        request('/lines/BPLRT', {
+          headers: {
+            accept:
+              'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+          },
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('does not affect non-GET and non-HEAD requests', () => {
+    expect(
+      getUnsupportedAgentMarkdownResponse(
+        request('/lines/BPLRT.md', {
+          method: 'POST',
+          headers: { accept: 'text/markdown' },
+        }),
+      ),
+    ).toBeNull();
+  });
+});
+
+function request(pathname: string, init?: RequestInit) {
+  return new Request(`https://www.mrtdown.org${pathname}`, init);
+}

--- a/app/util/agentMarkdown.test.ts
+++ b/app/util/agentMarkdown.test.ts
@@ -197,6 +197,31 @@ describe('agent Markdown request negotiation', () => {
     );
   });
 
+  it('respects specific Accept ranges before wildcard fallbacks', async () => {
+    const response = getUnsupportedAgentMarkdownResponse(
+      request('/lines/BPLRT', {
+        headers: {
+          accept: 'text/markdown;q=0.8, text/html;q=0, */*;q=1',
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(406);
+    await expect(response?.text()).resolves.toBe(
+      'Markdown is not available for this route',
+    );
+  });
+
+  it('does not reject API routes that can satisfy another accepted content type', () => {
+    expect(
+      getUnsupportedAgentMarkdownResponse(
+        request('/api/issues-day', {
+          headers: { accept: 'application/json, text/markdown' },
+        }),
+      ),
+    ).toBeNull();
+  });
+
   it('does not affect normal HTML requests', () => {
     expect(
       getUnsupportedAgentMarkdownResponse(

--- a/app/util/agentMarkdown.ts
+++ b/app/util/agentMarkdown.ts
@@ -9,6 +9,15 @@ export const PUBLIC_MARKDOWN_CACHE_CONTROL =
 export const MARKDOWN_CONTENT_TYPE = 'text/markdown; charset=utf-8';
 
 const DEFAULT_MARKDOWN_TIMEZONE = 'Asia/Singapore';
+const HTML_CONTENT_TYPES = ['text/html', 'application/xhtml+xml'];
+const CANONICAL_MARKDOWN_PATH_PATTERNS = [
+  /^\/index\.md$/,
+  /^\/llms\.txt$/,
+  /^\/issues\/[^/]+\/index\.md$/,
+  /^\/lines\/[^/]+\/index\.md$/,
+  /^\/operators\/[^/]+\/index\.md$/,
+  /^\/stations\/[^/]+\/index\.md$/,
+];
 
 type MarkdownDateInput = Date | DateTime | string;
 
@@ -124,6 +133,33 @@ export function createPublicMarkdownResponse(
   });
 }
 
+export function getUnsupportedAgentMarkdownResponse(request: Request) {
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    return null;
+  }
+
+  const pathname = new URL(request.url).pathname;
+  if (isCanonicalAgentMarkdownPath(pathname)) {
+    return null;
+  }
+
+  if (pathname.endsWith('.md')) {
+    return new Response('Markdown route not found', {
+      status: 404,
+      headers: { 'content-type': 'text/plain; charset=utf-8' },
+    });
+  }
+
+  if (prefersMarkdown(request.headers.get('accept'))) {
+    return new Response('Markdown is not available for this route', {
+      status: 406,
+      headers: { 'content-type': 'text/plain; charset=utf-8' },
+    });
+  }
+
+  return null;
+}
+
 function tableRow(cells: string[]): TableRow {
   return {
     type: 'tableRow',
@@ -166,4 +202,59 @@ function parseMarkdownDate(
   }
 
   return dateTime.setZone(zone);
+}
+
+function isCanonicalAgentMarkdownPath(pathname: string) {
+  return CANONICAL_MARKDOWN_PATH_PATTERNS.some((pattern) =>
+    pattern.test(pathname),
+  );
+}
+
+function prefersMarkdown(acceptHeader: string | null) {
+  if (acceptHeader == null || acceptHeader === '') {
+    return false;
+  }
+
+  const markdownQuality = getAcceptedQuality(acceptHeader, 'text/markdown');
+  if (markdownQuality <= 0) {
+    return false;
+  }
+
+  const htmlQuality = Math.max(
+    ...HTML_CONTENT_TYPES.map((contentType) =>
+      getAcceptedQuality(acceptHeader, contentType),
+    ),
+  );
+  return markdownQuality > htmlQuality;
+}
+
+function getAcceptedQuality(acceptHeader: string, contentType: string) {
+  const [targetType, targetSubtype] = contentType.toLowerCase().split('/');
+  let quality = 0;
+
+  for (const rawEntry of acceptHeader.split(',')) {
+    const [rawMediaRange = '', ...rawParameters] = rawEntry
+      .trim()
+      .toLowerCase()
+      .split(';');
+    const [rangeType, rangeSubtype] = rawMediaRange.trim().split('/');
+    if (
+      (rangeType !== targetType && rangeType !== '*') ||
+      (rangeSubtype !== targetSubtype && rangeSubtype !== '*')
+    ) {
+      continue;
+    }
+
+    const qParameter = rawParameters
+      .map((parameter) => parameter.trim())
+      .find((parameter) => parameter.startsWith('q='));
+    const parsedQuality =
+      qParameter == null ? 1 : Number.parseFloat(qParameter.slice('q='.length));
+    quality = Math.max(
+      quality,
+      Number.isFinite(parsedQuality) ? parsedQuality : 0,
+    );
+  }
+
+  return quality;
 }

--- a/app/util/agentMarkdown.ts
+++ b/app/util/agentMarkdown.ts
@@ -2,6 +2,7 @@ import { DateTime } from 'luxon';
 import { gfmToMarkdown } from 'mdast-util-gfm';
 import { toMarkdown } from 'mdast-util-to-markdown';
 import type { Root, RootContent, Table, TableCell, TableRow } from 'mdast';
+import { isCacheablePublicHtmlPath } from './publicHtmlCache';
 
 export const PUBLIC_MARKDOWN_CACHE_CONTROL =
   'public, max-age=0, s-maxage=60, stale-while-revalidate=300';
@@ -9,7 +10,7 @@ export const PUBLIC_MARKDOWN_CACHE_CONTROL =
 export const MARKDOWN_CONTENT_TYPE = 'text/markdown; charset=utf-8';
 
 const DEFAULT_MARKDOWN_TIMEZONE = 'Asia/Singapore';
-const HTML_CONTENT_TYPES = ['text/html', 'application/xhtml+xml'];
+const PUBLIC_HTML_CONTENT_TYPE = 'text/html';
 const CANONICAL_MARKDOWN_PATH_PATTERNS = [
   /^\/index\.md$/,
   /^\/llms\.txt$/,
@@ -150,7 +151,10 @@ export function getUnsupportedAgentMarkdownResponse(request: Request) {
     });
   }
 
-  if (prefersMarkdown(request.headers.get('accept'))) {
+  if (
+    isCacheablePublicHtmlPath(pathname) &&
+    prefersMarkdown(request.headers.get('accept'))
+  ) {
     return new Response('Markdown is not available for this route', {
       status: 406,
       headers: { 'content-type': 'text/plain; charset=utf-8' },
@@ -220,16 +224,16 @@ function prefersMarkdown(acceptHeader: string | null) {
     return false;
   }
 
-  const htmlQuality = Math.max(
-    ...HTML_CONTENT_TYPES.map((contentType) =>
-      getAcceptedQuality(acceptHeader, contentType),
-    ),
+  const htmlQuality = getAcceptedQuality(
+    acceptHeader,
+    PUBLIC_HTML_CONTENT_TYPE,
   );
   return markdownQuality > htmlQuality;
 }
 
 function getAcceptedQuality(acceptHeader: string, contentType: string) {
   const [targetType, targetSubtype] = contentType.toLowerCase().split('/');
+  let specificity = -1;
   let quality = 0;
 
   for (const rawEntry of acceptHeader.split(',')) {
@@ -250,10 +254,26 @@ function getAcceptedQuality(acceptHeader: string, contentType: string) {
       .find((parameter) => parameter.startsWith('q='));
     const parsedQuality =
       qParameter == null ? 1 : Number.parseFloat(qParameter.slice('q='.length));
-    quality = Math.max(
-      quality,
-      Number.isFinite(parsedQuality) ? parsedQuality : 0,
-    );
+    const rangeSpecificity =
+      rangeType === targetType && rangeSubtype === targetSubtype
+        ? 2
+        : rangeType === targetType
+          ? 1
+          : 0;
+    if (rangeSpecificity < specificity) {
+      continue;
+    }
+
+    const normalizedQuality = Number.isFinite(parsedQuality)
+      ? parsedQuality
+      : 0;
+    if (rangeSpecificity > specificity) {
+      specificity = rangeSpecificity;
+      quality = normalizedQuality;
+      continue;
+    }
+
+    quality = Math.max(quality, normalizedQuality);
   }
 
   return quality;

--- a/app/util/publicHtmlCache.ts
+++ b/app/util/publicHtmlCache.ts
@@ -44,7 +44,7 @@ function stripLocaleSegment(pathname: string) {
   return rest.length > 0 ? `/${rest.join('/')}` : '/';
 }
 
-function isCacheablePublicPath(pathname: string) {
+export function isCacheablePublicHtmlPath(pathname: string) {
   const publicPath = stripLocaleSegment(pathname);
   return (
     CACHEABLE_ROUTES.has(publicPath) ||
@@ -66,7 +66,7 @@ export function isPublicHtmlCacheLookupRequest(request: Request) {
   return (
     request.method === 'GET' &&
     !hasCacheBypassDirective(request) &&
-    isCacheablePublicPath(new URL(request.url).pathname)
+    isCacheablePublicHtmlPath(new URL(request.url).pathname)
   );
 }
 
@@ -104,7 +104,7 @@ export function shouldCachePublicHtml(request: Request, response: Response) {
     return false;
   }
 
-  return isCacheablePublicPath(new URL(request.url).pathname);
+  return isCacheablePublicHtmlPath(new URL(request.url).pathname);
 }
 
 export function applyPublicHtmlCacheHeaders(

--- a/docs/plans/active/production-performance.md
+++ b/docs/plans/active/production-performance.md
@@ -401,6 +401,11 @@ underlying compute and payload costs so uncached requests are also fast.
   `Accept: text/markdown` currently return 500 JSON responses in production,
   so a follow-up should decide whether those should normalize to 404/406 before
   adding alias support.
+- 2026-06-13: Normalized unsupported Markdown request surfaces before they
+  reach the TanStack router. Non-canonical `.md` alias attempts now return 404
+  plain text, while explicit `Accept: text/markdown` requests for non-Markdown
+  routes return 406 plain text. Canonical Markdown routes still pass through
+  their route handlers and keep public Markdown cache headers.
 
 ## Validation
 


### PR DESCRIPTION
## Summary

- Add a server-side guard for unsupported agent Markdown request surfaces before TanStack routing runs.
- Return plain-text 404 responses for non-canonical `.md` alias attempts.
- Return plain-text 406 responses when `Accept: text/markdown` explicitly prefers Markdown for routes that do not expose Markdown.
- Record the perf-plan progress note for the Markdown route traffic cleanup.

## Why

The production route timing probe found unsupported `.md` aliases and HTML routes requested with `Accept: text/markdown` returning 500 JSON responses. These are expected misses, so they should fail cleanly without going through the app router error path.

## Validation

- `npm run test:run -- app/util/agentMarkdown.test.ts`
- `npm run verify`

Note: the sandboxed verify run hit a `tsx` IPC permission error under `/var/folders`; rerunning `npm run verify` outside the sandbox passed.