### PR TITLE
fix: harden crowd report direction validation

### DIFF
--- a/app/util/crowdReports.test.ts
+++ b/app/util/crowdReports.test.ts
@@ -442,6 +442,24 @@ describe('validateCrowdReportSubmission', () => {
       expect(result.issues).toContain('Unrecognized key: "directionText"');
     }
   });
+
+  it('requires exactly one affected line when a direction station is submitted', () => {
+    const result = validateCrowdReportSubmission(
+      {
+        lineIds: ['BPLRT', 'CCL'],
+        directionStationId: 'BP6',
+        effect: 'delay',
+      },
+      NOW,
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.issues).toContain(
+        'directionStationId requires exactly one affected line',
+      );
+    }
+  });
 });
 
 describe('assessCrowdReportAutomationPolicy', () => {
@@ -662,6 +680,25 @@ describe('findMissingCrowdReportReferences', () => {
     await expect(
       findMissingCrowdReportReferences(fake.db as never, {
         lineIds: ['BPLRT'],
+        stationIds: [],
+        directionStationId: 'BP6',
+      }),
+    ).resolves.toEqual({
+      lineIds: [],
+      stationIds: [],
+      directionStationIds: ['BP6'],
+    });
+  });
+
+  it('rejects a direction station when multiple affected lines are selected', async () => {
+    const fake = makeFakeReferenceDb([
+      [{ id: 'BPLRT' }, { id: 'CCL' }],
+      [{ id: 'BP6' }],
+    ]);
+
+    await expect(
+      findMissingCrowdReportReferences(fake.db as never, {
+        lineIds: ['BPLRT', 'CCL'],
         stationIds: [],
         directionStationId: 'BP6',
       }),

--- a/app/util/crowdReports.ts
+++ b/app/util/crowdReports.ts
@@ -394,6 +394,9 @@ export function validateCrowdReportSubmission(
   if (lineIds.length === 0 && stationIds.length === 0) {
     issues.push('At least one affected line or station is required');
   }
+  if (parsed.data.directionStationId != null && lineIds.length !== 1) {
+    issues.push('directionStationId requires exactly one affected line');
+  }
 
   const observedAt = parsed.data.observedAt
     ? DateTime.fromISO(parsed.data.observedAt, { setZone: true })
@@ -755,7 +758,7 @@ async function findInvalidDirectionStationIds(
   if (submission.directionStationId == null) {
     return [];
   }
-  if (submission.lineIds.length === 0) {
+  if (submission.lineIds.length !== 1) {
     return [submission.directionStationId];
   }
 

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -499,6 +499,9 @@ Exit criteria:
 - 2026-06-14: Tightened the public API boundary so reports require a structured
   effect and direction is submitted as a direction station ID, then derived into
   a fixed `towards:{stationId}` token for duplicate detection and dispatch.
+- 2026-06-14: Continued structured direction hardening by rejecting
+  direction-station submissions unless exactly one affected line is selected,
+  matching the public form's single-line direction picker.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Reject public crowd-report submissions that include a direction station unless exactly one affected line is selected.
- Apply the same guard in reference validation so ambiguous multi-line direction payloads cannot reach the structured `towards:{stationId}` path.
- Add regression coverage and update the active crowdsourced reports plan log.

## Validation

- `npm run test:run -- app/util/crowdReports.test.ts`
- `npm run verify`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for crowd-sourced reports: direction and station information now requires exactly one affected line to be selected, preventing invalid submissions and aligning with the form interface.

* **Tests**
  * Added comprehensive test coverage for direction-station validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->