### PR TITLE
perf: split system map route bundle

### DIFF
--- a/app/routes/{-$lang}/system-map.tsx
+++ b/app/routes/{-$lang}/system-map.tsx
@@ -1,15 +1,20 @@
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { DateTime } from 'luxon';
-import { useMemo } from 'react';
+import { lazy, Suspense, useMemo } from 'react';
 import { createIntl, FormattedMessage, useIntl } from 'react-intl';
 import type { IssueAffectedBranch } from '~/types';
 import { CurrentAdvisoriesSection } from '~/components/CurrentAdvisoriesSection';
 import { countOperationalLineSummaries } from '~/components/CurrentAdvisoriesSection/helpers';
-import { StationMap } from '~/components/StationMap';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
 import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
 import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 import { getSystemMapFn } from '~/util/system-map.functions';
+
+const StationMap = lazy(() =>
+  import('~/components/StationMap').then((module) => ({
+    default: module.StationMap,
+  })),
+);
 
 export const Route = createFileRoute('/{-$lang}/system-map')({
   component: SystemMapPage,
@@ -130,13 +135,15 @@ function SystemMapPage() {
         />
 
         <div className="flex flex-col bg-gray-100 p-4 dark:bg-gray-800">
-          <StationMap
-            currentDate={DateTime.now().toISODate()}
-            mode={{
-              type: 'network',
-              branchesAffected,
-            }}
-          />
+          <Suspense fallback={<SystemMapSkeleton />}>
+            <StationMap
+              currentDate={DateTime.now().toISODate()}
+              mode={{
+                type: 'network',
+                branchesAffected,
+              }}
+            />
+          </Suspense>
 
           <div className="mt-2 flex bg-gray-50 px-4 py-2.5 dark:bg-gray-900">
             <div className="grid grow grid-cols-1 gap-x-4 gap-y-1.5 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
@@ -168,5 +175,11 @@ function SystemMapPage() {
         </div>
       </div>
     </IncludedEntitiesContext.Provider>
+  );
+}
+
+function SystemMapSkeleton() {
+  return (
+    <div className="h-[60vh] min-h-96 animate-pulse bg-gray-200 dark:bg-gray-700" />
   );
 }

--- a/docs/plans/active/production-performance.md
+++ b/docs/plans/active/production-performance.md
@@ -406,6 +406,11 @@ underlying compute and payload costs so uncached requests are also fast.
   plain text, while explicit `Accept: text/markdown` requests for non-Markdown
   routes return 406 plain text. Canonical Markdown routes still pass through
   their route handlers and keep public Markdown cache headers.
+- 2026-06-14: Continued Phase 5 route preload cleanup for `/system-map`. The
+  system-map route now lazy-loads the shared `StationMap` component behind a
+  stable map-sized skeleton. A production build keeps `StationMap` and its
+  generated snapshot dependencies in the route's dynamic import set instead of
+  the eager system-map component imports.
 
 ## Validation
 


### PR DESCRIPTION
## Summary

- Lazy-load the shared `StationMap` component on `/system-map` behind a stable map-sized skeleton.
- Keep the generated station-map snapshot assets in the system-map route's dynamic import set instead of eager route imports.
- Record the Phase 5 progress note in the production performance plan.

## Impact

This reduces the eager `/system-map` route component import set while preserving the route's primary map UI after hydration.

## Validation

- `npm run build`
- `npm run verify` (rerun outside the sandbox after `tsx` IPC was blocked by sandboxing)
- Browser check on `http://localhost:3002/system-map`: heading rendered, SVG map present, line links present, skeleton gone after hydration.