### PR TITLE
perf: preserve system map SEO rendering

### DIFF
--- a/app/components/StationMap/index.tsx
+++ b/app/components/StationMap/index.tsx
@@ -14,6 +14,25 @@ import { MapApr2025 } from './components/MapApr2025';
 import { Timeline } from './components/Timeline';
 import { segmentText } from './helpers/segmentText';
 
+type MapSnapshotId =
+  | '2012-01'
+  | '2017-11'
+  | '2019-12'
+  | '2024-11'
+  | '2025-04'
+  | '2027-12'
+  | '2029-12'
+  | '2030-12'
+  | '2032-12';
+
+export type StationMapSnapshotComponent = React.ElementType<{
+  ref?: React.Ref<SVGSVGElement>;
+}>;
+
+export type StationMapSnapshotComponents = Partial<
+  Record<MapSnapshotId, StationMapSnapshotComponent>
+>;
+
 const MapDec2032 = lazy(() =>
   import('./components/MapDec2032').then((module) => ({
     default: module.MapDec2032,
@@ -77,10 +96,11 @@ export type StationMapMode =
 interface Props {
   currentDate?: string;
   mode: StationMapMode;
+  snapshotComponents?: StationMapSnapshotComponents;
 }
 
 export const StationMap: React.FC<Props> = (props) => {
-  const { currentDate, mode } = props;
+  const { currentDate, mode, snapshotComponents } = props;
 
   const intl = useIntl();
   const navigate = useNavigate();
@@ -451,6 +471,27 @@ export const StationMap: React.FC<Props> = (props) => {
   const showAffectedStationsSummary =
     mode.type === 'network' && mode.showAffectedStationsSummary !== false;
 
+  const renderSnapshot = (
+    snapshotId: MapSnapshotId,
+    DefaultComponent: StationMapSnapshotComponent,
+  ) => {
+    const SnapshotComponent = snapshotComponents?.[snapshotId];
+
+    if (SnapshotComponent != null) {
+      return <SnapshotComponent ref={setRef} />;
+    }
+
+    if (snapshotId === '2025-04') {
+      return <DefaultComponent ref={setRef} />;
+    }
+
+    return (
+      <Suspense fallback={<StationMapSnapshotFallback />}>
+        <DefaultComponent ref={setRef} />
+      </Suspense>
+    );
+  };
+
   return (
     <div className="flex flex-col fill-gray-800 dark:fill-gray-50">
       {/* Tailwind Class trappers */}
@@ -461,47 +502,31 @@ export const StationMap: React.FC<Props> = (props) => {
         <div className="relative overflow-hidden">
           <div className="overflow-auto">
             <Tabs.Content value="2032-12">
-              <Suspense fallback={<StationMapSnapshotFallback />}>
-                <MapDec2032 ref={setRef} />
-              </Suspense>
+              {renderSnapshot('2032-12', MapDec2032)}
             </Tabs.Content>
             <Tabs.Content value="2030-12">
-              <Suspense fallback={<StationMapSnapshotFallback />}>
-                <MapDec2030 ref={setRef} />
-              </Suspense>
+              {renderSnapshot('2030-12', MapDec2030)}
             </Tabs.Content>
             <Tabs.Content value="2029-12">
-              <Suspense fallback={<StationMapSnapshotFallback />}>
-                <MapDec2029 ref={setRef} />
-              </Suspense>
+              {renderSnapshot('2029-12', MapDec2029)}
             </Tabs.Content>
             <Tabs.Content value="2027-12">
-              <Suspense fallback={<StationMapSnapshotFallback />}>
-                <MapDec2027 ref={setRef} />
-              </Suspense>
+              {renderSnapshot('2027-12', MapDec2027)}
             </Tabs.Content>
             <Tabs.Content value="2025-04">
-              <MapApr2025 ref={setRef} />
+              {renderSnapshot('2025-04', MapApr2025)}
             </Tabs.Content>
             <Tabs.Content value="2024-11">
-              <Suspense fallback={<StationMapSnapshotFallback />}>
-                <MapNov2024 ref={setRef} />
-              </Suspense>
+              {renderSnapshot('2024-11', MapNov2024)}
             </Tabs.Content>
             <Tabs.Content value="2019-12">
-              <Suspense fallback={<StationMapSnapshotFallback />}>
-                <MapDec2019 ref={setRef} />
-              </Suspense>
+              {renderSnapshot('2019-12', MapDec2019)}
             </Tabs.Content>
             <Tabs.Content value="2017-11">
-              <Suspense fallback={<StationMapSnapshotFallback />}>
-                <MapNov2017 ref={setRef} />
-              </Suspense>
+              {renderSnapshot('2017-11', MapNov2017)}
             </Tabs.Content>
             <Tabs.Content value="2012-01">
-              <Suspense fallback={<StationMapSnapshotFallback />}>
-                <MapJan2012 ref={setRef} />
-              </Suspense>
+              {renderSnapshot('2012-01', MapJan2012)}
             </Tabs.Content>
           </div>
           <ZoomControls svgRef={ref} initialZoom={1} />

--- a/app/routes/{-$lang}/system-map.tsx
+++ b/app/routes/{-$lang}/system-map.tsx
@@ -5,11 +5,35 @@ import { createIntl, FormattedMessage, useIntl } from 'react-intl';
 import type { IssueAffectedBranch } from '~/types';
 import { CurrentAdvisoriesSection } from '~/components/CurrentAdvisoriesSection';
 import { countOperationalLineSummaries } from '~/components/CurrentAdvisoriesSection/helpers';
-import { StationMap } from '~/components/StationMap';
+import {
+  StationMap,
+  type StationMapSnapshotComponents,
+} from '~/components/StationMap';
+import { MapApr2025 } from '~/components/StationMap/components/MapApr2025';
+import { MapDec2019 } from '~/components/StationMap/components/MapDec2019';
+import { MapDec2027 } from '~/components/StationMap/components/MapDec2027';
+import { MapDec2029 } from '~/components/StationMap/components/MapDec2029';
+import { MapDec2030 } from '~/components/StationMap/components/MapDec2030';
+import { MapDec2032 } from '~/components/StationMap/components/MapDec2032';
+import { MapJan2012 } from '~/components/StationMap/components/MapJan2012';
+import { MapNov2017 } from '~/components/StationMap/components/MapNov2017';
+import { MapNov2024 } from '~/components/StationMap/components/MapNov2024';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
 import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
 import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 import { getSystemMapFn } from '~/util/system-map.functions';
+
+const SYSTEM_MAP_SNAPSHOTS = {
+  '2012-01': MapJan2012,
+  '2017-11': MapNov2017,
+  '2019-12': MapDec2019,
+  '2024-11': MapNov2024,
+  '2025-04': MapApr2025,
+  '2027-12': MapDec2027,
+  '2029-12': MapDec2029,
+  '2030-12': MapDec2030,
+  '2032-12': MapDec2032,
+} satisfies StationMapSnapshotComponents;
 
 export const Route = createFileRoute('/{-$lang}/system-map')({
   component: SystemMapPage,
@@ -132,6 +156,7 @@ function SystemMapPage() {
         <div className="flex flex-col bg-gray-100 p-4 dark:bg-gray-800">
           <StationMap
             currentDate={DateTime.now().toISODate()}
+            snapshotComponents={SYSTEM_MAP_SNAPSHOTS}
             mode={{
               type: 'network',
               branchesAffected,

--- a/docs/plans/active/production-performance.md
+++ b/docs/plans/active/production-performance.md
@@ -406,6 +406,11 @@ underlying compute and payload costs so uncached requests are also fast.
   plain text, while explicit `Accept: text/markdown` requests for non-Markdown
   routes return 406 plain text. Canonical Markdown routes still pass through
   their route handlers and keep public Markdown cache headers.
+- 2026-06-15: Clarified the Phase 5 map-bundle strategy for SEO. The public
+  `/system-map` route now passes eager generated snapshot components into
+  `StationMap` so timeline map content does not depend on React Suspense
+  fallbacks, while supporting profile widgets can continue using the default
+  deferred snapshot imports behind their viewport gate.
 
 ## Validation
 


### PR DESCRIPTION
## Summary

- Add an eager snapshot override to `StationMap` so callers can choose whether generated map snapshots render through Suspense.
- Wire the public `/system-map` route to use eager concrete snapshot imports for SEO-sensitive map content.
- Record the Phase 5 performance-plan decision that profile widgets can stay deferred while the public map route avoids Suspense fallbacks.

## Validation

- `npm run verify` passed. The first sandboxed run failed at `db:generate:check` because `tsx` could not create its IPC pipe (`listen EPERM`), then the same command passed outside the sandbox.
- `npm run build` passed and confirmed `/system-map` eagerly imports historical/future snapshots while `LineSystemMapCard` keeps only the shared `StationMap` import.