### PR TITLE
fix(issues): avoid duplicate affected branch pills

### DIFF
--- a/app/util/db.queries.test.ts
+++ b/app/util/db.queries.test.ts
@@ -6,6 +6,7 @@ import {
   deriveServiceScopeStationIds,
   parseStatisticsSnapshotPayload,
   selectIncludedEntities,
+  selectServiceBranchSourceEvents,
   type SystemAnalytics,
 } from './db.queries';
 
@@ -205,6 +206,30 @@ describe('deriveServiceScopeStationIds', () => {
         },
       ]),
     ).toEqual(BRANCH_STATION_IDS);
+  });
+});
+
+describe('selectServiceBranchSourceEvents', () => {
+  it('uses service scope events as the source of affected branch pills', () => {
+    const events = [
+      { id: 'periods', type: 'periods.set' },
+      { id: 'causes', type: 'causes.set' },
+      { id: 'scopes', type: 'service_scopes.set' },
+      { id: 'effects', type: 'service_effects.set' },
+    ] as const;
+
+    expect(selectServiceBranchSourceEvents(events)).toEqual([
+      { id: 'scopes', type: 'service_scopes.set' },
+    ]);
+  });
+
+  it('falls back to all state events for legacy issues without service scopes', () => {
+    const events = [
+      { id: 'periods', type: 'periods.set' },
+      { id: 'effects', type: 'service_effects.set' },
+    ] as const;
+
+    expect(selectServiceBranchSourceEvents(events)).toEqual(events);
   });
 });
 

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -173,6 +173,23 @@ export function deriveServiceScopeStationIds(
   return scopedStationIds.length > 0 ? scopedStationIds : [...branchStationIds];
 }
 
+type ImpactEventStateRow = Pick<
+  typeof impactEventsTable.$inferSelect,
+  'id' | 'type'
+>;
+
+export function selectServiceBranchSourceEvents<T extends ImpactEventStateRow>(
+  selectedStateEvents: readonly T[],
+) {
+  const serviceScopeEvents = selectedStateEvents.filter(
+    (event) => event.type === 'service_scopes.set',
+  );
+
+  return serviceScopeEvents.length > 0
+    ? serviceScopeEvents
+    : selectedStateEvents;
+}
+
 type CommunitySignalOptions = {
   includeCommunitySignals?: boolean;
 };
@@ -1641,22 +1658,6 @@ async function buildDataset(
         causeSet.add(cause.type as Issue['subtypes'][number]);
       }
 
-      for (const serviceRef of serviceRowsByImpactEventId[event.id] ?? []) {
-        const branch = branchByServiceId[serviceRef.service_id];
-        const service = serviceById[serviceRef.service_id];
-        if (branch == null || service == null) {
-          continue;
-        }
-        serviceBranches.set(branch.id, {
-          lineId: service.line_id,
-          branchId: branch.id,
-          stationIds: deriveServiceScopeStationIds(
-            branch.stationIds,
-            serviceScopeRowsByServiceId.get(serviceRef.service_id) ?? [],
-          ),
-        });
-      }
-
       for (const facilityRef of facilityRowsByImpactEventId[event.id] ?? []) {
         const station = stationsById[facilityRef.station_id];
         if (station == null) {
@@ -1695,6 +1696,24 @@ async function buildDataset(
             });
           }
         }
+      }
+    }
+
+    for (const event of selectServiceBranchSourceEvents(selectedStateEvents)) {
+      for (const serviceRef of serviceRowsByImpactEventId[event.id] ?? []) {
+        const branch = branchByServiceId[serviceRef.service_id];
+        const service = serviceById[serviceRef.service_id];
+        if (branch == null || service == null) {
+          continue;
+        }
+        serviceBranches.set(branch.id, {
+          lineId: service.line_id,
+          branchId: branch.id,
+          stationIds: deriveServiceScopeStationIds(
+            branch.stationIds,
+            serviceScopeRowsByServiceId.get(serviceRef.service_id) ?? [],
+          ),
+        });
       }
     }
 


### PR DESCRIPTION
## Summary

- Treat `service_scopes.set` as the authoritative service event for issue affected branch pills when scope data is present.
- Keep the legacy fallback for issues that do not have service scope events.
- Add unit coverage for selecting the service branch source event.

## Root Cause

The read-model assembly was adding affected service branches from every selected service-state event. Scoped issues could therefore render the correct scoped span plus extra full-span branches from other events like `service_effects.set`.

## Validation

- `npm run verify`