### PR TITLE
fix(crowd-reports): restrict unknown directions to train reports

### DIFF
--- a/app/util/crowdReports.test.ts
+++ b/app/util/crowdReports.test.ts
@@ -573,6 +573,25 @@ describe('validateCrowdReportSubmission', () => {
     }
   });
 
+  it('rejects explicit unknown direction markers outside on-train reports', () => {
+    const result = validateCrowdReportSubmission(
+      {
+        reportScope: 'line',
+        lineIds: ['BPLRT'],
+        directionUnknown: true,
+        effect: 'delay',
+      },
+      NOW,
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.issues).toContain(
+        'directionUnknown is only allowed for train reports',
+      );
+    }
+  });
+
   it('requires station context for station-scoped reports', () => {
     const result = validateCrowdReportSubmission(
       {

--- a/app/util/crowdReports.ts
+++ b/app/util/crowdReports.ts
@@ -426,6 +426,12 @@ export function validateCrowdReportSubmission(
   ) {
     issues.push('directionUnknown cannot be combined with directionStationId');
   }
+  if (
+    parsed.data.reportScope !== 'train' &&
+    parsed.data.directionUnknown === true
+  ) {
+    issues.push('directionUnknown is only allowed for train reports');
+  }
 
   const observedAt = parsed.data.observedAt
     ? DateTime.fromISO(parsed.data.observedAt, { setZone: true })

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -510,6 +510,9 @@ Exit criteria:
   plus a structured direction or explicit unknown-direction marker, and
   structured storage summaries record scope and unknown direction without
   reporter prose.
+- 2026-06-16: Continued public report API contract hardening by rejecting
+  explicit unknown-direction markers outside on-train reports, keeping line and
+  station reports aligned with the public form's implicit no-direction path.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Reject `directionUnknown: true` for non-train crowd report scopes at the public API boundary.
- Add regression coverage for line-scoped submissions that try to send the explicit unknown-direction marker.
- Update the active crowdsourced reports plan progress log.

## Why

The public form only uses the explicit unknown-direction marker for on-train reports, where users must choose a direction, destination, or Not sure. Line and station reports already represent an omitted direction by leaving direction fields unset, so accepting the marker there created an API path the UI does not expose.

## Validation

- `npm run test:run -- app/util/crowdReports.test.ts`
- `npm run verify`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for crowd-sourced reports to properly reject submissions with unknown-direction markers when reporting for lines or stations (only permitted for train reports).

* **Tests**
  * Added test coverage for the unknown-direction marker validation logic.

* **Documentation**
  * Updated progress notes regarding report API validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->