### PR TITLE
fix: harden crowd report direction markers

### DIFF
--- a/app/util/crowdReports.test.ts
+++ b/app/util/crowdReports.test.ts
@@ -536,6 +536,25 @@ describe('validateCrowdReportSubmission', () => {
     }
   });
 
+  it('omits false unknown-direction markers from normalized on-train reports', () => {
+    const result = validateCrowdReportSubmission(
+      {
+        reportScope: 'train',
+        lineIds: ['BPLRT'],
+        directionStationId: 'BP6',
+        directionUnknown: false,
+        effect: 'delay',
+      },
+      NOW,
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.directionUnknown).toBeUndefined();
+      expect(result.data.directionText).toBe('towards:BP6');
+    }
+  });
+
   it('requires explicit direction context for on-train reports', () => {
     const result = validateCrowdReportSubmission(
       {
@@ -599,6 +618,25 @@ describe('validateCrowdReportSubmission', () => {
         reportScope: 'line',
         lineIds: ['BPLRT'],
         directionUnknown: true,
+        effect: 'delay',
+      },
+      NOW,
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.issues).toContain(
+        'directionUnknown is only allowed for train reports',
+      );
+    }
+  });
+
+  it('rejects false unknown-direction fields outside on-train reports', () => {
+    const result = validateCrowdReportSubmission(
+      {
+        reportScope: 'line',
+        lineIds: ['BPLRT'],
+        directionUnknown: false,
         effect: 'delay',
       },
       NOW,

--- a/app/util/crowdReports.ts
+++ b/app/util/crowdReports.ts
@@ -434,7 +434,7 @@ export function validateCrowdReportSubmission(
   }
   if (
     parsed.data.reportScope !== 'train' &&
-    parsed.data.directionUnknown === true
+    parsed.data.directionUnknown != null
   ) {
     issues.push('directionUnknown is only allowed for train reports');
   }
@@ -477,8 +477,8 @@ export function validateCrowdReportSubmission(
       ...(parsed.data.directionStationId != null
         ? { directionStationId: parsed.data.directionStationId }
         : {}),
-      ...(parsed.data.directionUnknown != null
-        ? { directionUnknown: parsed.data.directionUnknown }
+      ...(parsed.data.directionUnknown === true
+        ? { directionUnknown: true }
         : {}),
       directionText: parsed.data.directionStationId
         ? `towards:${parsed.data.directionStationId}`

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -516,6 +516,9 @@ Exit criteria:
 - 2026-06-17: Continued public report API contract hardening by rejecting
   structured direction-station submissions outside on-train reports, matching
   the public form's train-only direction picker.
+- 2026-06-17: Continued train-direction contract hardening by rejecting any
+  submitted `directionUnknown` field outside on-train reports and normalizing
+  only true unknown-direction markers into persisted report data.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Reject any submitted `directionUnknown` field outside on-train crowd reports.
- Normalize accepted report payloads so only `directionUnknown: true` is preserved.
- Add regression coverage for false unknown-direction markers and update the active crowdsourced reports plan log.

## Validation

- `npm run verify`

Note: the first sandboxed verify attempt failed at `db:generate:check` because `tsx` could not create its IPC pipe (`listen EPERM`). The same command was rerun outside the sandbox and passed: typecheck, lint, format, migration drift check, and 214 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for crowdsourced transit reports to more strictly enforce direction information handling and ensure only valid direction data is persisted.

* **Documentation**
  * Updated project documentation to reflect validation improvements for crowdsourced reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->