### PR TITLE
test: cover crowd report form options

### DIFF
--- a/app/util/report.functions.test.ts
+++ b/app/util/report.functions.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildCrowdReportFormOptions } from './report.functions';
+
+vi.mock('cloudflare:workers', () => ({
+  env: {},
+}));
+
+vi.mock('@tanstack/react-start', () => ({
+  createServerFn: () => ({
+    handler: (handler: unknown) => handler,
+  }),
+}));
+
+function name(en: string) {
+  return { en } as never;
+}
+
+describe('buildCrowdReportFormOptions', () => {
+  it('builds station search metadata and guided line choices', () => {
+    const options = buildCrowdReportFormOptions({
+      referenceDate: '2026-06-17',
+      lines: [
+        { id: 'BPLRT', name: name('Bukit Panjang LRT'), color: '#748477' },
+        { id: 'DTL', name: name('Downtown Line'), color: '#005ec4' },
+      ],
+      stations: [
+        { id: 'BP6', name: name('Bukit Panjang') },
+        { id: 'DT1', name: name('Bukit Panjang') },
+      ],
+      stationCodes: [
+        { stationId: 'BP6', lineId: 'BPLRT', code: 'BP6' },
+        { stationId: 'BP6', lineId: 'BPLRT', code: 'BP6' },
+        { stationId: 'BP6', lineId: 'DTL', code: 'DT1' },
+      ],
+      services: [],
+      serviceRevisions: [],
+      servicePathEntries: [],
+    });
+
+    expect(options.stations).toEqual([
+      {
+        id: 'BP6',
+        name: name('Bukit Panjang'),
+        codes: ['BP6', 'DT1'],
+        codePills: [
+          { lineId: 'BPLRT', code: 'BP6' },
+          { lineId: 'DTL', code: 'DT1' },
+        ],
+        lineIds: ['BPLRT', 'DTL'],
+      },
+      {
+        id: 'DT1',
+        name: name('Bukit Panjang'),
+        codes: [],
+        codePills: [],
+        lineIds: [],
+      },
+    ]);
+  });
+
+  it('derives train direction choices and affected-stop paths from the active service revision', () => {
+    const options = buildCrowdReportFormOptions({
+      referenceDate: '2026-06-17',
+      lines: [
+        { id: 'BPLRT', name: name('Bukit Panjang LRT'), color: '#748477' },
+      ],
+      stations: [
+        { id: 'BP1', name: name('Choa Chu Kang') },
+        { id: 'BP6', name: name('Bukit Panjang') },
+        { id: 'BP13', name: name('Senja') },
+        { id: 'BP14', name: name('Ten Mile Junction') },
+      ],
+      stationCodes: [],
+      services: [{ id: 'svc-bplrt', lineId: 'BPLRT' }],
+      serviceRevisions: [
+        {
+          id: 'legacy',
+          serviceId: 'svc-bplrt',
+          start_at: '2010-01-01',
+          end_at: '2025-12-31',
+          updated_at: '2025-12-31T00:00:00.000Z',
+        },
+        {
+          id: 'current',
+          serviceId: 'svc-bplrt',
+          start_at: '2026-01-01',
+          end_at: '2026-12-31',
+          updated_at: '2026-01-01T00:00:00.000Z',
+        },
+        {
+          id: 'future',
+          serviceId: 'svc-bplrt',
+          start_at: '2027-01-01',
+          end_at: null,
+          updated_at: '2026-06-01T00:00:00.000Z',
+        },
+      ],
+      servicePathEntries: [
+        {
+          serviceRevisionId: 'legacy',
+          serviceId: 'svc-bplrt',
+          stationId: 'BP1',
+          pathIndex: 0,
+        },
+        {
+          serviceRevisionId: 'legacy',
+          serviceId: 'svc-bplrt',
+          stationId: 'BP14',
+          pathIndex: 1,
+        },
+        {
+          serviceRevisionId: 'current',
+          serviceId: 'svc-bplrt',
+          stationId: 'BP1',
+          pathIndex: 0,
+        },
+        {
+          serviceRevisionId: 'current',
+          serviceId: 'svc-bplrt',
+          stationId: 'BP6',
+          pathIndex: 1,
+        },
+        {
+          serviceRevisionId: 'current',
+          serviceId: 'svc-bplrt',
+          stationId: 'BP13',
+          pathIndex: 2,
+        },
+        {
+          serviceRevisionId: 'future',
+          serviceId: 'svc-bplrt',
+          stationId: 'BP14',
+          pathIndex: 0,
+        },
+        {
+          serviceRevisionId: 'future',
+          serviceId: 'svc-bplrt',
+          stationId: 'BP13',
+          pathIndex: 1,
+        },
+      ],
+    });
+
+    expect(options.lineStationPaths.BPLRT).toEqual([['BP1', 'BP6', 'BP13']]);
+    expect(
+      options.lineDirections.BPLRT?.map((option) => option.stationId),
+    ).toEqual(['BP1', 'BP13']);
+  });
+
+  it('deduplicates matching line paths and direction terminals across services', () => {
+    const options = buildCrowdReportFormOptions({
+      referenceDate: '2026-06-17',
+      lines: [{ id: 'CCL', name: name('Circle Line'), color: '#fa9e0d' }],
+      stations: [
+        { id: 'CC1', name: name('Dhoby Ghaut') },
+        { id: 'CC29', name: name('HarbourFront') },
+      ],
+      stationCodes: [],
+      services: [
+        { id: 'svc-ccl-main', lineId: 'CCL' },
+        { id: 'svc-ccl-alt', lineId: 'CCL' },
+      ],
+      serviceRevisions: [
+        {
+          id: 'current',
+          serviceId: 'svc-ccl-main',
+          start_at: '2020-01-01',
+          end_at: null,
+          updated_at: '2026-01-01T00:00:00.000Z',
+        },
+        {
+          id: 'current',
+          serviceId: 'svc-ccl-alt',
+          start_at: '2020-01-01',
+          end_at: null,
+          updated_at: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+      servicePathEntries: [
+        {
+          serviceRevisionId: 'current',
+          serviceId: 'svc-ccl-main',
+          stationId: 'CC1',
+          pathIndex: 0,
+        },
+        {
+          serviceRevisionId: 'current',
+          serviceId: 'svc-ccl-main',
+          stationId: 'CC29',
+          pathIndex: 1,
+        },
+        {
+          serviceRevisionId: 'current',
+          serviceId: 'svc-ccl-alt',
+          stationId: 'CC1',
+          pathIndex: 0,
+        },
+        {
+          serviceRevisionId: 'current',
+          serviceId: 'svc-ccl-alt',
+          stationId: 'CC29',
+          pathIndex: 1,
+        },
+      ],
+    });
+
+    expect(options.lineStationPaths.CCL).toEqual([['CC1', 'CC29']]);
+    expect(
+      options.lineDirections.CCL?.map((option) => option.stationId),
+    ).toEqual(['CC1', 'CC29']);
+  });
+});

--- a/app/util/report.functions.ts
+++ b/app/util/report.functions.ts
@@ -1,4 +1,5 @@
 import { env } from 'cloudflare:workers';
+import type { Translations } from '@mrtdown/core';
 import { createServerFn } from '@tanstack/react-start';
 import { and, asc, eq, inArray } from 'drizzle-orm';
 import { DateTime } from 'luxon';
@@ -17,98 +18,67 @@ import {
 } from './crowdReportFeatureFlag';
 import { selectServiceRevisionForReferenceDate } from './serviceRevisions';
 
-export const getCrowdReportFormOptionsFn = createServerFn({
-  method: 'GET',
-}).handler(async () => {
-  if (
-    !isCrowdReportsFeatureEnabled(env as CrowdReportFeatureEnv, {
-      isLocalDev: import.meta.env.DEV,
-    })
-  ) {
-    throw new Response('Not Found', {
-      status: 404,
-      statusText: 'Not Found',
-    });
-  }
+type CrowdReportFormLineRow = {
+  id: string;
+  name: Translations;
+  color: string;
+};
 
-  const db = getDb();
-  const referenceDate =
-    DateTime.now().setZone('Asia/Singapore').toISODate() ??
-    new Date().toISOString().slice(0, 10);
-  const [
-    lines,
-    stations,
-    stationCodes,
-    services,
-    serviceRevisionsWithPathRows,
-  ] = await Promise.all([
-    db
-      .select({
-        id: linesTable.id,
-        name: linesTable.name,
-        color: linesTable.color,
-      })
-      .from(linesTable)
-      .orderBy(asc(linesTable.id)),
-    db
-      .select({
-        id: stationsTable.id,
-        name: stationsTable.name,
-      })
-      .from(stationsTable)
-      .orderBy(asc(stationsTable.id)),
-    db
-      .select({
-        lineId: stationCodesTable.line_id,
-        stationId: stationCodesTable.station_id,
-        code: stationCodesTable.code,
-      })
-      .from(stationCodesTable)
-      .orderBy(asc(stationCodesTable.code)),
-    db
-      .select({
-        id: servicesTable.id,
-        lineId: servicesTable.line_id,
-      })
-      .from(servicesTable)
-      .orderBy(asc(servicesTable.id)),
-    db
-      .select({
-        id: serviceRevisionsTable.id,
-        serviceId: serviceRevisionsTable.service_id,
-        start_at: serviceRevisionsTable.start_at,
-        end_at: serviceRevisionsTable.end_at,
-        updated_at: serviceRevisionsTable.updated_at,
-      })
-      .from(serviceRevisionsTable)
-      .innerJoin(
-        serviceRevisionPathStationEntriesTable,
-        and(
-          eq(
-            serviceRevisionPathStationEntriesTable.service_revision_id,
-            serviceRevisionsTable.id,
-          ),
-          eq(
-            serviceRevisionPathStationEntriesTable.service_id,
-            serviceRevisionsTable.service_id,
-          ),
-        ),
-      )
-      .orderBy(serviceRevisionsTable.service_id, serviceRevisionsTable.id),
-  ]);
+type CrowdReportFormStationRow = {
+  id: string;
+  name: Translations;
+};
 
+type CrowdReportFormStationCodeRow = {
+  lineId: string;
+  stationId: string;
+  code: string;
+};
+
+type CrowdReportFormServiceRow = {
+  id: string;
+  lineId: string;
+};
+
+type CrowdReportFormServiceRevisionRow = {
+  id: string;
+  serviceId: string;
+  start_at: string | null;
+  end_at: string | null;
+  updated_at: Date | string;
+};
+
+type CrowdReportFormPathEntryRow = {
+  serviceRevisionId: string;
+  serviceId: string;
+  stationId: string;
+  pathIndex: number;
+};
+
+type BuildCrowdReportFormOptionsInput = {
+  referenceDate: string;
+  lines: CrowdReportFormLineRow[];
+  stations: CrowdReportFormStationRow[];
+  stationCodes: CrowdReportFormStationCodeRow[];
+  services: CrowdReportFormServiceRow[];
+  serviceRevisions: CrowdReportFormServiceRevisionRow[];
+  servicePathEntries: CrowdReportFormPathEntryRow[];
+};
+
+export function buildCrowdReportFormOptions({
+  referenceDate,
+  lines,
+  stations,
+  stationCodes,
+  services,
+  serviceRevisions,
+  servicePathEntries,
+}: BuildCrowdReportFormOptionsInput) {
   const stationById = Object.fromEntries(
     stations.map((station) => [station.id, station]),
   );
-  const serviceRevisionByKey = new Map<
-    string,
-    (typeof serviceRevisionsWithPathRows)[number]
-  >();
-  for (const revision of serviceRevisionsWithPathRows) {
-    serviceRevisionByKey.set(`${revision.serviceId}::${revision.id}`, revision);
-  }
-  const revisionsByServiceId = Array.from(serviceRevisionByKey.values()).reduce<
-    Record<string, (typeof serviceRevisionsWithPathRows)[number][]>
+  const revisionsByServiceId = serviceRevisions.reduce<
+    Record<string, CrowdReportFormServiceRevisionRow[]>
   >((acc, revision) => {
     acc[revision.serviceId] ??= [];
     acc[revision.serviceId].push(revision);
@@ -126,39 +96,13 @@ export const getCrowdReportFormOptionsFn = createServerFn({
       .filter(
         (
           entry,
-        ): entry is readonly [
-          string,
-          (typeof serviceRevisionsWithPathRows)[number],
-        ] => entry != null,
+        ): entry is readonly [string, CrowdReportFormServiceRevisionRow] =>
+          entry != null,
       ),
   );
 
-  const latestRevisionIds = [
-    ...new Set(
-      Object.values(latestRevisionByServiceId).map((revision) => revision.id),
-    ),
-  ];
-  const servicePathEntries =
-    latestRevisionIds.length > 0
-      ? await db
-          .select({
-            serviceRevisionId:
-              serviceRevisionPathStationEntriesTable.service_revision_id,
-            serviceId: serviceRevisionPathStationEntriesTable.service_id,
-            stationId: serviceRevisionPathStationEntriesTable.station_id,
-            pathIndex: serviceRevisionPathStationEntriesTable.path_index,
-          })
-          .from(serviceRevisionPathStationEntriesTable)
-          .where(
-            inArray(
-              serviceRevisionPathStationEntriesTable.service_revision_id,
-              latestRevisionIds,
-            ),
-          )
-      : [];
-
   const servicePathEntriesByRevisionKey = servicePathEntries.reduce<
-    Record<string, typeof servicePathEntries>
+    Record<string, CrowdReportFormPathEntryRow[]>
   >((acc, entry) => {
     const key = `${entry.serviceRevisionId}::${entry.serviceId}`;
     acc[key] ??= [];
@@ -168,7 +112,7 @@ export const getCrowdReportFormOptionsFn = createServerFn({
 
   const directionsByLineId: Record<
     string,
-    Array<{ stationId: string; name: (typeof stations)[number]['name'] }>
+    Array<{ stationId: string; name: CrowdReportFormStationRow['name'] }>
   > = {};
   const directionKeysByLineId: Record<string, Set<string>> = {};
   const stationPathsByLineId: Record<string, string[][]> = {};
@@ -275,4 +219,140 @@ export const getCrowdReportFormOptionsFn = createServerFn({
       lineIds: stationLineIdsByStationId[station.id] ?? [],
     })),
   };
+}
+
+export const getCrowdReportFormOptionsFn = createServerFn({
+  method: 'GET',
+}).handler(async () => {
+  if (
+    !isCrowdReportsFeatureEnabled(env as CrowdReportFeatureEnv, {
+      isLocalDev: import.meta.env.DEV,
+    })
+  ) {
+    throw new Response('Not Found', {
+      status: 404,
+      statusText: 'Not Found',
+    });
+  }
+
+  const db = getDb();
+  const referenceDate =
+    DateTime.now().setZone('Asia/Singapore').toISODate() ??
+    new Date().toISOString().slice(0, 10);
+  const [
+    lines,
+    stations,
+    stationCodes,
+    services,
+    serviceRevisionsWithPathRows,
+  ] = await Promise.all([
+    db
+      .select({
+        id: linesTable.id,
+        name: linesTable.name,
+        color: linesTable.color,
+      })
+      .from(linesTable)
+      .orderBy(asc(linesTable.id)),
+    db
+      .select({
+        id: stationsTable.id,
+        name: stationsTable.name,
+      })
+      .from(stationsTable)
+      .orderBy(asc(stationsTable.id)),
+    db
+      .select({
+        lineId: stationCodesTable.line_id,
+        stationId: stationCodesTable.station_id,
+        code: stationCodesTable.code,
+      })
+      .from(stationCodesTable)
+      .orderBy(asc(stationCodesTable.code)),
+    db
+      .select({
+        id: servicesTable.id,
+        lineId: servicesTable.line_id,
+      })
+      .from(servicesTable)
+      .orderBy(asc(servicesTable.id)),
+    db
+      .select({
+        id: serviceRevisionsTable.id,
+        serviceId: serviceRevisionsTable.service_id,
+        start_at: serviceRevisionsTable.start_at,
+        end_at: serviceRevisionsTable.end_at,
+        updated_at: serviceRevisionsTable.updated_at,
+      })
+      .from(serviceRevisionsTable)
+      .innerJoin(
+        serviceRevisionPathStationEntriesTable,
+        and(
+          eq(
+            serviceRevisionPathStationEntriesTable.service_revision_id,
+            serviceRevisionsTable.id,
+          ),
+          eq(
+            serviceRevisionPathStationEntriesTable.service_id,
+            serviceRevisionsTable.service_id,
+          ),
+        ),
+      )
+      .orderBy(serviceRevisionsTable.service_id, serviceRevisionsTable.id),
+  ]);
+
+  const serviceRevisionByKey = new Map<
+    string,
+    (typeof serviceRevisionsWithPathRows)[number]
+  >();
+  for (const revision of serviceRevisionsWithPathRows) {
+    serviceRevisionByKey.set(`${revision.serviceId}::${revision.id}`, revision);
+  }
+  const serviceRevisions = Array.from(serviceRevisionByKey.values());
+  const revisionsByServiceId = serviceRevisions.reduce<
+    Record<string, typeof serviceRevisions>
+  >((acc, revision) => {
+    acc[revision.serviceId] ??= [];
+    acc[revision.serviceId].push(revision);
+    return acc;
+  }, {});
+  const selectedServiceRevisions = Object.values(revisionsByServiceId)
+    .map((revisions) =>
+      selectServiceRevisionForReferenceDate(revisions, referenceDate),
+    )
+    .filter((revision): revision is (typeof serviceRevisions)[number] => {
+      return revision != null;
+    });
+
+  const latestRevisionIds = [
+    ...new Set(selectedServiceRevisions.map((revision) => revision.id)),
+  ];
+  const servicePathEntries =
+    latestRevisionIds.length > 0
+      ? await db
+          .select({
+            serviceRevisionId:
+              serviceRevisionPathStationEntriesTable.service_revision_id,
+            serviceId: serviceRevisionPathStationEntriesTable.service_id,
+            stationId: serviceRevisionPathStationEntriesTable.station_id,
+            pathIndex: serviceRevisionPathStationEntriesTable.path_index,
+          })
+          .from(serviceRevisionPathStationEntriesTable)
+          .where(
+            inArray(
+              serviceRevisionPathStationEntriesTable.service_revision_id,
+              latestRevisionIds,
+            ),
+          )
+      : [];
+
+  return buildCrowdReportFormOptions({
+    referenceDate,
+    lines,
+    stations,
+    stationCodes,
+    services,
+    serviceRevisions,
+    servicePathEntries,
+  });
 });

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -522,6 +522,10 @@ Exit criteria:
 - 2026-06-17: Cleaned the extracted report message catalog after removing
   public free-text notes and `Other` direction inputs, so localized report
   strings match the structured automated flow.
+- 2026-06-17: Added regression coverage for the public report form option
+  assembly by extracting the service-revision direction, station-code, and
+  affected-stop path derivation into a pure helper while keeping the server
+  function behavior unchanged.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Extract the crowd report form option assembly into a pure `buildCrowdReportFormOptions` helper while preserving the existing server function behavior.
- Add regression coverage for station search metadata, station-guided line choices, active service-revision train directions, affected-stop paths, and duplicate path/terminal handling.
- Update the active crowdsourced reports plan progress log.

## Validation

- `npm run verify`

Note: `db:generate:check` uses `tsx`, which needed to run outside the sandbox because the sandbox blocked its IPC pipe with `EPERM`. The final full verification run passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite covering station metadata aggregation, direction and path derivation, and deduplication scenarios.

* **Refactor**
  * Restructured form option assembly logic into a reusable helper function for improved code organization and maintainability.

* **Documentation**
  * Updated progress tracking with regression coverage details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->