### PR TITLE
feat: add community report evidence permalinks

### DIFF
--- a/app/routeTree.gen.ts
+++ b/app/routeTree.gen.ts
@@ -34,6 +34,7 @@ import { Route as Char123LangChar125IssuesIssueIdIndexRouteImport } from './rout
 import { Route as Char123LangChar125HistoryYearIndexRouteImport } from './routes/{-$lang}/history/$year/index'
 import { Route as Char123LangChar125HistoryPagePageNumRouteImport } from './routes/{-$lang}/history/page.$pageNum'
 import { Route as Char123LangChar125HistoryYearMonthRouteImport } from './routes/{-$lang}/history/$year/$month'
+import { Route as Char123LangChar125CommunityReportsKindSourceIdRouteImport } from './routes/{-$lang}/community-reports/$kind/$sourceId'
 import { Route as InternalApiTasksPullRouteImport } from './routes/internal.api.tasks.pull'
 import { Route as InternalApiTasksPublicHolidaysRouteImport } from './routes/internal.api.tasks.public-holidays'
 import { Route as InternalApiTasksFactsRouteImport } from './routes/internal.api.tasks.facts'
@@ -179,6 +180,12 @@ const Char123LangChar125HistoryYearMonthRoute =
     path: '/history/$year/$month',
     getParentRoute: () => Char123LangChar125Route,
   } as any)
+const Char123LangChar125CommunityReportsKindSourceIdRoute =
+  Char123LangChar125CommunityReportsKindSourceIdRouteImport.update({
+    id: '/community-reports/$kind/$sourceId',
+    path: '/community-reports/$kind/$sourceId',
+    getParentRoute: () => Char123LangChar125Route,
+  } as any)
 const InternalApiTasksPullRoute = InternalApiTasksPullRouteImport.update({
   id: '/internal/api/tasks/pull',
   path: '/internal/api/tasks/pull',
@@ -226,6 +233,7 @@ export interface FileRoutesByFullPath {
   '/internal/api/tasks/facts': typeof InternalApiTasksFactsRoute
   '/internal/api/tasks/public-holidays': typeof InternalApiTasksPublicHolidaysRoute
   '/internal/api/tasks/pull': typeof InternalApiTasksPullRoute
+  '/{-$lang}/community-reports/$kind/$sourceId': typeof Char123LangChar125CommunityReportsKindSourceIdRoute
   '/{-$lang}/history/$year/$month': typeof Char123LangChar125HistoryYearMonthRoute
   '/{-$lang}/history/page/$pageNum': typeof Char123LangChar125HistoryPagePageNumRoute
   '/{-$lang}/history/$year/': typeof Char123LangChar125HistoryYearIndexRoute
@@ -256,6 +264,7 @@ export interface FileRoutesByTo {
   '/internal/api/tasks/facts': typeof InternalApiTasksFactsRoute
   '/internal/api/tasks/public-holidays': typeof InternalApiTasksPublicHolidaysRoute
   '/internal/api/tasks/pull': typeof InternalApiTasksPullRoute
+  '/{-$lang}/community-reports/$kind/$sourceId': typeof Char123LangChar125CommunityReportsKindSourceIdRoute
   '/{-$lang}/history/$year/$month': typeof Char123LangChar125HistoryYearMonthRoute
   '/{-$lang}/history/page/$pageNum': typeof Char123LangChar125HistoryPagePageNumRoute
   '/{-$lang}/history/$year': typeof Char123LangChar125HistoryYearIndexRoute
@@ -288,6 +297,7 @@ export interface FileRoutesById {
   '/internal/api/tasks/facts': typeof InternalApiTasksFactsRoute
   '/internal/api/tasks/public-holidays': typeof InternalApiTasksPublicHolidaysRoute
   '/internal/api/tasks/pull': typeof InternalApiTasksPullRoute
+  '/{-$lang}/community-reports/$kind/$sourceId': typeof Char123LangChar125CommunityReportsKindSourceIdRoute
   '/{-$lang}/history/$year/$month': typeof Char123LangChar125HistoryYearMonthRoute
   '/{-$lang}/history/page/$pageNum': typeof Char123LangChar125HistoryPagePageNumRoute
   '/{-$lang}/history/$year/': typeof Char123LangChar125HistoryYearIndexRoute
@@ -321,6 +331,7 @@ export interface FileRouteTypes {
     | '/internal/api/tasks/facts'
     | '/internal/api/tasks/public-holidays'
     | '/internal/api/tasks/pull'
+    | '/{-$lang}/community-reports/$kind/$sourceId'
     | '/{-$lang}/history/$year/$month'
     | '/{-$lang}/history/page/$pageNum'
     | '/{-$lang}/history/$year/'
@@ -351,6 +362,7 @@ export interface FileRouteTypes {
     | '/internal/api/tasks/facts'
     | '/internal/api/tasks/public-holidays'
     | '/internal/api/tasks/pull'
+    | '/{-$lang}/community-reports/$kind/$sourceId'
     | '/{-$lang}/history/$year/$month'
     | '/{-$lang}/history/page/$pageNum'
     | '/{-$lang}/history/$year'
@@ -382,6 +394,7 @@ export interface FileRouteTypes {
     | '/internal/api/tasks/facts'
     | '/internal/api/tasks/public-holidays'
     | '/internal/api/tasks/pull'
+    | '/{-$lang}/community-reports/$kind/$sourceId'
     | '/{-$lang}/history/$year/$month'
     | '/{-$lang}/history/page/$pageNum'
     | '/{-$lang}/history/$year/'
@@ -584,6 +597,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof Char123LangChar125HistoryYearMonthRouteImport
       parentRoute: typeof Char123LangChar125Route
     }
+    '/{-$lang}/community-reports/$kind/$sourceId': {
+      id: '/{-$lang}/community-reports/$kind/$sourceId'
+      path: '/community-reports/$kind/$sourceId'
+      fullPath: '/{-$lang}/community-reports/$kind/$sourceId'
+      preLoaderRoute: typeof Char123LangChar125CommunityReportsKindSourceIdRouteImport
+      parentRoute: typeof Char123LangChar125Route
+    }
     '/internal/api/tasks/pull': {
       id: '/internal/api/tasks/pull'
       path: '/internal/api/tasks/pull'
@@ -625,6 +645,7 @@ interface Char123LangChar125RouteChildren {
   Char123LangChar125StatusLineIdRoute: typeof Char123LangChar125StatusLineIdRoute
   Char123LangChar125HistoryIndexRoute: typeof Char123LangChar125HistoryIndexRoute
   Char123LangChar125StatisticsIndexRoute: typeof Char123LangChar125StatisticsIndexRoute
+  Char123LangChar125CommunityReportsKindSourceIdRoute: typeof Char123LangChar125CommunityReportsKindSourceIdRoute
   Char123LangChar125HistoryYearMonthRoute: typeof Char123LangChar125HistoryYearMonthRoute
   Char123LangChar125HistoryPagePageNumRoute: typeof Char123LangChar125HistoryPagePageNumRoute
   Char123LangChar125HistoryYearIndexRoute: typeof Char123LangChar125HistoryYearIndexRoute
@@ -645,6 +666,8 @@ const Char123LangChar125RouteChildren: Char123LangChar125RouteChildren = {
   Char123LangChar125HistoryIndexRoute: Char123LangChar125HistoryIndexRoute,
   Char123LangChar125StatisticsIndexRoute:
     Char123LangChar125StatisticsIndexRoute,
+  Char123LangChar125CommunityReportsKindSourceIdRoute:
+    Char123LangChar125CommunityReportsKindSourceIdRoute,
   Char123LangChar125HistoryYearMonthRoute:
     Char123LangChar125HistoryYearMonthRoute,
   Char123LangChar125HistoryPagePageNumRoute:

--- a/app/routes/{-$lang}/community-reports/$kind/$sourceId.tsx
+++ b/app/routes/{-$lang}/community-reports/$kind/$sourceId.tsx
@@ -1,0 +1,447 @@
+import {
+  ChatBubbleLeftRightIcon,
+  CheckCircleIcon,
+  ClockIcon,
+  ExclamationTriangleIcon,
+  MapIcon,
+  MapPinIcon,
+} from '@heroicons/react/24/outline';
+import type { IngestContentCrowdReportEffect } from '@mrtdown/ingest-contracts';
+import { createFileRoute } from '@tanstack/react-router';
+import classNames from 'classnames';
+import {
+  createIntl,
+  defineMessages,
+  FormattedDate,
+  FormattedMessage,
+  type MessageDescriptor,
+  useIntl,
+} from 'react-intl';
+import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
+import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
+import { assert } from '~/util/assert';
+import {
+  getCrowdReportSourceFn,
+  type CrowdReportSource,
+} from '~/util/crowdReportSource.functions';
+
+type CrowdReportSourceKind = 'cluster' | 'report';
+
+const EFFECT_LABEL_MESSAGES = defineMessages({
+  delay: { id: 'report.effect.delay', defaultMessage: 'Delay' },
+  noService: {
+    id: 'report.effect.no_service',
+    defaultMessage: 'No service',
+  },
+  crowding: { id: 'report.effect.crowding', defaultMessage: 'Crowding' },
+  skippedStop: {
+    id: 'report.effect.skipped_stop',
+    defaultMessage: 'Train skipped stop',
+  },
+  unknown: { id: 'report.effect.unknown', defaultMessage: 'Not sure' },
+});
+
+const EFFECT_LABELS = {
+  delay: EFFECT_LABEL_MESSAGES.delay,
+  'no-service': EFFECT_LABEL_MESSAGES.noService,
+  crowding: EFFECT_LABEL_MESSAGES.crowding,
+  'skipped-stop': EFFECT_LABEL_MESSAGES.skippedStop,
+  unknown: EFFECT_LABEL_MESSAGES.unknown,
+} satisfies Record<IngestContentCrowdReportEffect, MessageDescriptor>;
+
+export const Route = createFileRoute(
+  '/{-$lang}/community-reports/$kind/$sourceId',
+)({
+  component: CommunityReportSourcePage,
+  loader: ({ params }) => {
+    if (!isCrowdReportSourceKind(params.kind)) {
+      throw new Response('Not Found', {
+        status: 404,
+        statusText: 'Not Found',
+      });
+    }
+
+    return getCrowdReportSourceFn({
+      data: {
+        kind: params.kind,
+        sourceId: params.sourceId,
+      },
+    });
+  },
+  async head(ctx) {
+    const { kind, sourceId, lang = 'en-SG' } = ctx.params;
+    assert(ctx.loaderData != null);
+    const source = ctx.loaderData;
+    const { default: messages } = await import(`../../../../lang/${lang}.json`);
+    const intl = createIntl({ locale: lang, messages });
+    const rootUrl = import.meta.env.VITE_ROOT_URL;
+    assert(rootUrl != null, 'VITE_ROOT_URL is not set');
+
+    const title = intl.formatMessage({
+      id: 'community_report_source.page_title',
+      defaultMessage: 'Community report evidence',
+    });
+    const description = intl.formatMessage(
+      {
+        id: 'community_report_source.page_description',
+        defaultMessage:
+          '{count, plural, one {A community report} other {# community reports}} about MRT or LRT service conditions.',
+      },
+      { count: source.reportCount },
+    );
+    const ogUrl = new URL(
+      buildLocaleAwareLink(
+        `/community-reports/${encodeURIComponent(kind)}/${encodeURIComponent(
+          sourceId,
+        )}`,
+        lang,
+      ),
+      rootUrl,
+    ).toString();
+
+    return {
+      meta: [
+        { title },
+        { name: 'description', content: description },
+        { property: 'og:title', content: title },
+        { property: 'og:description', content: description },
+        { property: 'og:type', content: 'website' },
+        { property: 'og:url', content: ogUrl },
+      ],
+    };
+  },
+});
+
+function getEffectLabel(effect: CrowdReportSource['effect']) {
+  return EFFECT_LABELS[effect ?? 'unknown'];
+}
+
+function isCrowdReportSourceKind(
+  value: string,
+): value is CrowdReportSourceKind {
+  return value === 'cluster' || value === 'report';
+}
+
+function SourceStatusBadge(props: { status: CrowdReportSource['status'] }) {
+  const { status } = props;
+  return (
+    <span
+      className={classNames(
+        'inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 font-medium text-xs',
+        {
+          'bg-emerald-100 text-emerald-900 dark:bg-emerald-900/60 dark:text-emerald-100':
+            status === 'dispatched',
+          'bg-amber-100 text-amber-900 dark:bg-amber-900/70 dark:text-amber-100':
+            status === 'accepted',
+        },
+      )}
+    >
+      {status === 'dispatched' ? (
+        <CheckCircleIcon className="size-3.5" />
+      ) : (
+        <ClockIcon className="size-3.5" />
+      )}
+      {status === 'dispatched' ? (
+        <FormattedMessage
+          id="community_report_source.status_dispatched"
+          defaultMessage="Dispatched"
+        />
+      ) : (
+        <FormattedMessage
+          id="community_report_source.status_accepted"
+          defaultMessage="Accepted"
+        />
+      )}
+    </span>
+  );
+}
+
+function FactCard(props: {
+  label: MessageDescriptor;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+      <dt className="font-medium text-gray-500 text-xs uppercase tracking-wide dark:text-gray-400">
+        <FormattedMessage {...props.label} />
+      </dt>
+      <dd className="mt-2 font-semibold text-gray-900 text-sm dark:text-gray-100">
+        {props.children}
+      </dd>
+    </div>
+  );
+}
+
+function CommunityReportSourcePage() {
+  const source = Route.useLoaderData();
+  const intl = useIntl();
+  const observedSameTime = source.observedStartAt === source.observedEndAt;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <section className="rounded-lg border border-amber-200 bg-amber-50 p-4 sm:p-6 dark:border-amber-900/70 dark:bg-amber-950/30">
+        <div className="flex items-start gap-3">
+          <span className="mt-0.5 inline-flex size-10 shrink-0 items-center justify-center rounded-lg bg-amber-100 text-amber-700 dark:bg-amber-900/70 dark:text-amber-200">
+            <ChatBubbleLeftRightIcon className="size-5" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <SourceStatusBadge status={source.status} />
+              <span className="rounded-md bg-white px-2.5 py-1 font-medium text-amber-900 text-xs dark:bg-gray-900/80 dark:text-amber-100">
+                {source.kind === 'cluster' ? (
+                  <FormattedMessage
+                    id="community_report_source.kind_cluster"
+                    defaultMessage="Report cluster"
+                  />
+                ) : (
+                  <FormattedMessage
+                    id="community_report_source.kind_report"
+                    defaultMessage="Single report"
+                  />
+                )}
+              </span>
+            </div>
+            <h1 className="mt-3 font-bold text-2xl text-gray-900 dark:text-gray-100">
+              <FormattedMessage
+                id="community_report_source.title"
+                defaultMessage="Community report evidence"
+              />
+            </h1>
+            <p className="mt-2 max-w-2xl text-gray-700 text-sm leading-6 dark:text-gray-300">
+              <FormattedMessage
+                id="community_report_source.description"
+                defaultMessage="Structured commuter reports shown separately from official operator advisories."
+              />
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <dl className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <FactCard
+          label={{
+            id: 'community_report_source.effect',
+            defaultMessage: 'Effect',
+          }}
+        >
+          <FormattedMessage {...getEffectLabel(source.effect)} />
+        </FactCard>
+        <FactCard
+          label={{
+            id: 'community_report_source.report_count',
+            defaultMessage: 'Reports',
+          }}
+        >
+          <FormattedMessage
+            id="community_report_source.report_count_value"
+            defaultMessage="{count, plural, one {# report} other {# reports}}"
+            values={{ count: source.reportCount }}
+          />
+        </FactCard>
+        <FactCard
+          label={{
+            id: 'community_report_source.observed',
+            defaultMessage: 'Observed',
+          }}
+        >
+          {observedSameTime ? (
+            <FormattedDate
+              value={source.observedStartAt}
+              dateStyle="medium"
+              timeStyle="short"
+            />
+          ) : (
+            <FormattedMessage
+              id="community_report_source.observed_range"
+              defaultMessage="{start} to {end}"
+              values={{
+                start: (
+                  <FormattedDate
+                    value={source.observedStartAt}
+                    dateStyle="medium"
+                    timeStyle="short"
+                  />
+                ),
+                end: (
+                  <FormattedDate
+                    value={source.observedEndAt}
+                    timeStyle="short"
+                  />
+                ),
+              }}
+            />
+          )}
+        </FactCard>
+        <FactCard
+          label={
+            source.dispatchedAt == null
+              ? {
+                  id: 'community_report_source.updated',
+                  defaultMessage: 'Updated',
+                }
+              : {
+                  id: 'community_report_source.dispatched_at',
+                  defaultMessage: 'Dispatched',
+                }
+          }
+        >
+          <FormattedDate
+            value={source.dispatchedAt ?? source.updatedAt}
+            dateStyle="medium"
+            timeStyle="short"
+          />
+        </FactCard>
+      </dl>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <article className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+          <div className="flex items-center gap-2">
+            <MapIcon className="size-5 text-gray-500 dark:text-gray-400" />
+            <h2 className="font-semibold text-base text-gray-900 dark:text-gray-100">
+              <FormattedMessage
+                id="community_report_source.lines"
+                defaultMessage="Affected lines"
+              />
+            </h2>
+          </div>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {source.lines.length > 0 ? (
+              source.lines.map((line) => (
+                <span
+                  key={line.id}
+                  className="inline-flex items-center gap-2 rounded-md border border-gray-200 bg-gray-50 px-2.5 py-1.5 font-medium text-gray-900 text-sm dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
+                >
+                  <span
+                    className="size-2.5 rounded-full"
+                    style={{ backgroundColor: line.color }}
+                  />
+                  {getLocalizedTranslation(line.name, intl.locale)}
+                </span>
+              ))
+            ) : (
+              <p className="text-gray-500 text-sm dark:text-gray-400">
+                <FormattedMessage
+                  id="community_report_source.no_lines"
+                  defaultMessage="No specific line was reported."
+                />
+              </p>
+            )}
+          </div>
+        </article>
+
+        <article className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+          <div className="flex items-center gap-2">
+            <MapPinIcon className="size-5 text-gray-500 dark:text-gray-400" />
+            <h2 className="font-semibold text-base text-gray-900 dark:text-gray-100">
+              <FormattedMessage
+                id="community_report_source.stations"
+                defaultMessage="Affected stations"
+              />
+            </h2>
+          </div>
+          {source.stations.length > 0 ? (
+            <p className="mt-3 text-gray-800 text-sm leading-6 dark:text-gray-200">
+              {source.stations
+                .map((station) =>
+                  getLocalizedTranslation(station.name, intl.locale),
+                )
+                .join(', ')}
+            </p>
+          ) : (
+            <p className="mt-3 text-gray-500 text-sm dark:text-gray-400">
+              <FormattedMessage
+                id="community_report_source.no_stations"
+                defaultMessage="No specific station was reported."
+              />
+            </p>
+          )}
+        </article>
+      </section>
+
+      <section className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+        <div className="flex items-center gap-2">
+          <ExclamationTriangleIcon className="size-5 text-gray-500 dark:text-gray-400" />
+          <h2 className="font-semibold text-base text-gray-900 dark:text-gray-100">
+            <FormattedMessage
+              id="community_report_source.details"
+              defaultMessage="Reported details"
+            />
+          </h2>
+        </div>
+        <dl className="mt-3 grid gap-3 sm:grid-cols-3">
+          <div>
+            <dt className="font-medium text-gray-500 text-xs uppercase tracking-wide dark:text-gray-400">
+              <FormattedMessage
+                id="community_report_source.direction"
+                defaultMessage="Direction"
+              />
+            </dt>
+            <dd className="mt-1 text-gray-900 text-sm dark:text-gray-100">
+              {source.directionText ?? (
+                <FormattedMessage
+                  id="community_report_source.not_provided"
+                  defaultMessage="Not provided"
+                />
+              )}
+            </dd>
+          </div>
+          <div>
+            <dt className="font-medium text-gray-500 text-xs uppercase tracking-wide dark:text-gray-400">
+              <FormattedMessage
+                id="community_report_source.delay"
+                defaultMessage="Delay"
+              />
+            </dt>
+            <dd className="mt-1 text-gray-900 text-sm dark:text-gray-100">
+              {source.delayMinutes == null ? (
+                <FormattedMessage
+                  id="community_report_source.not_provided"
+                  defaultMessage="Not provided"
+                />
+              ) : (
+                <FormattedMessage
+                  id="community_report_source.delay_minutes"
+                  defaultMessage="{minutes} min"
+                  values={{ minutes: source.delayMinutes }}
+                />
+              )}
+            </dd>
+          </div>
+          <div>
+            <dt className="font-medium text-gray-500 text-xs uppercase tracking-wide dark:text-gray-400">
+              <FormattedMessage
+                id="community_report_source.still_happening"
+                defaultMessage="Still happening"
+              />
+            </dt>
+            <dd className="mt-1 text-gray-900 text-sm dark:text-gray-100">
+              {source.stillHappening == null ? (
+                <FormattedMessage
+                  id="community_report_source.not_provided"
+                  defaultMessage="Not provided"
+                />
+              ) : source.stillHappening ? (
+                <FormattedMessage
+                  id="community_report_source.yes"
+                  defaultMessage="Yes"
+                />
+              ) : (
+                <FormattedMessage
+                  id="community_report_source.no"
+                  defaultMessage="No"
+                />
+              )}
+            </dd>
+          </div>
+        </dl>
+      </section>
+
+      <p className="text-gray-500 text-xs leading-5 dark:text-gray-400">
+        <FormattedMessage
+          id="community_report_source.privacy_note"
+          defaultMessage="This permalink includes structured public report fields only. Reporter metadata and abuse-control data are not published."
+        />
+      </p>
+    </div>
+  );
+}

--- a/app/routes/{-$lang}/community-reports/$kind/$sourceId.tsx
+++ b/app/routes/{-$lang}/community-reports/$kind/$sourceId.tsx
@@ -13,6 +13,7 @@ import {
   createIntl,
   defineMessages,
   FormattedDate,
+  FormattedList,
   FormattedMessage,
   type MessageDescriptor,
   useIntl,
@@ -72,7 +73,9 @@ export const Route = createFileRoute(
     const { kind, sourceId, lang = 'en-SG' } = ctx.params;
     assert(ctx.loaderData != null);
     const source = ctx.loaderData;
-    const { default: messages } = await import(`../../../../lang/${lang}.json`);
+    const { default: messages } = await import(
+      `../../../../../lang/${lang}.json`
+    );
     const intl = createIntl({ locale: lang, messages });
     const rootUrl = import.meta.env.VITE_ROOT_URL;
     assert(rootUrl != null, 'VITE_ROOT_URL is not set');
@@ -265,6 +268,7 @@ function CommunityReportSourcePage() {
                 end: (
                   <FormattedDate
                     value={source.observedEndAt}
+                    dateStyle="medium"
                     timeStyle="short"
                   />
                 ),
@@ -341,11 +345,12 @@ function CommunityReportSourcePage() {
           </div>
           {source.stations.length > 0 ? (
             <p className="mt-3 text-gray-800 text-sm leading-6 dark:text-gray-200">
-              {source.stations
-                .map((station) =>
+              <FormattedList
+                type="unit"
+                value={source.stations.map((station) =>
                   getLocalizedTranslation(station.name, intl.locale),
-                )
-                .join(', ')}
+                )}
+              />
             </p>
           ) : (
             <p className="mt-3 text-gray-500 text-sm dark:text-gray-400">

--- a/app/util/crowdReportDispatch.test.ts
+++ b/app/util/crowdReportDispatch.test.ts
@@ -280,7 +280,7 @@ describe('buildCrowdReportIngestPayload', () => {
       effect: 'delay',
       delayMinutes: 10,
       reportCount: 3,
-      url: 'https://mrtdown.example/report?communitySource=cluster%3Acluster-1',
+      url: 'https://mrtdown.example/community-reports/cluster/cluster-1',
     });
     expect(candidate.payload.content[0]).not.toHaveProperty('ipHash');
     expect(candidate.payload.content[0]).not.toHaveProperty(
@@ -352,7 +352,7 @@ describe('buildCrowdReportSourceUrl', () => {
   it('uses a stable public report URL with a non-PII community source id', () => {
     expect(
       buildCrowdReportSourceUrl('https://mrtdown.example', 'report', 'r1'),
-    ).toBe('https://mrtdown.example/report?communitySource=report%3Ar1');
+    ).toBe('https://mrtdown.example/community-reports/report/r1');
   });
 });
 
@@ -427,7 +427,7 @@ describe('getDispatchableCrowdReportCandidates', () => {
               observedAt: '2026-05-24T12:30:00.000+08:00',
               lineIds: ['BPLRT'],
               reportCount: 2,
-              url: 'https://mrtdown.example/report?communitySource=cluster%3Acluster-1',
+              url: 'https://mrtdown.example/community-reports/cluster/cluster-1',
             },
           ],
         }),
@@ -474,7 +474,7 @@ describe('getDispatchableCrowdReportCandidates', () => {
                 observedAt: '2026-05-24T12:30:00.000+08:00',
                 lineIds: ['BPLRT'],
                 reportCount: 1,
-                url: 'https://mrtdown.example/report?communitySource=cluster%3Acluster-1',
+                url: 'https://mrtdown.example/community-reports/cluster/cluster-1',
               },
             ],
           }),
@@ -510,7 +510,7 @@ describe('getDispatchableCrowdReportCandidates', () => {
                   observedAt: '2026-05-24T12:30:00.000+08:00',
                   lineIds: ['BPLRT'],
                   reportCount: 2,
-                  url: 'https://mrtdown.example/report?communitySource=cluster%3Acluster-1',
+                  url: 'https://mrtdown.example/community-reports/cluster/cluster-1',
                 },
               ],
             }),
@@ -564,7 +564,7 @@ describe('getDispatchableCrowdReportCandidates', () => {
                     observedAt: '2026-05-24T12:30:00.000+08:00',
                     lineIds: ['BPLRT'],
                     reportCount: 1,
-                    url: 'https://mrtdown.example/report?communitySource=cluster%3Acluster-1',
+                    url: 'https://mrtdown.example/community-reports/cluster/cluster-1',
                   },
                 ],
               }),
@@ -610,7 +610,7 @@ describe('dispatchCrowdReportPayloadToGitHub', () => {
           observedAt: '2026-05-24T12:30:00.000+08:00',
           lineIds: ['BPLRT'],
           reportCount: 1,
-          url: 'https://mrtdown.example/report?communitySource=report%3Areport-1',
+          url: 'https://mrtdown.example/community-reports/report/report-1',
         },
       ],
     });
@@ -660,7 +660,7 @@ describe('dispatchCrowdReportPayloadToGitHub', () => {
           observedAt: '2026-05-24T12:30:00.000+08:00',
           lineIds: ['BPLRT'],
           reportCount: 1,
-          url: 'https://mrtdown.example/report?communitySource=report%3Areport-1',
+          url: 'https://mrtdown.example/community-reports/report/report-1',
         },
       ],
     });
@@ -691,7 +691,7 @@ describe('dispatchCrowdReportPayloadToGitHub', () => {
           observedAt: '2026-05-24T12:30:00.000+08:00',
           lineIds: ['BPLRT'],
           reportCount: 1,
-          url: 'https://mrtdown.example/report?communitySource=report%3Areport-1',
+          url: 'https://mrtdown.example/community-reports/report/report-1',
         },
       ],
     });

--- a/app/util/crowdReportDispatch.ts
+++ b/app/util/crowdReportDispatch.ts
@@ -156,8 +156,10 @@ export function buildCrowdReportSourceUrl(
   kind: CrowdReportDispatchKind,
   id: string,
 ) {
-  const url = new URL('/report', rootUrl);
-  url.searchParams.set('communitySource', `${kind}:${id}`);
+  const url = new URL(
+    `/community-reports/${encodeURIComponent(kind)}/${encodeURIComponent(id)}`,
+    rootUrl,
+  );
   return url.toString();
 }
 

--- a/app/util/crowdReportSource.functions.test.ts
+++ b/app/util/crowdReportSource.functions.test.ts
@@ -1,0 +1,104 @@
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { describe, expect, it, vi } from 'vitest';
+import { getCrowdReportSource } from './crowdReportSource.functions';
+
+vi.mock('~/db', () => ({
+  getDb: vi.fn(),
+}));
+
+function name(value: string) {
+  return {
+    'en-SG': value,
+    'zh-Hans': null,
+    ms: null,
+    ta: null,
+  };
+}
+
+function makeFakeClusterSourceDb() {
+  const whereCalls: unknown[] = [];
+  const selectResults = [
+    [
+      {
+        id: 'cluster-1',
+        effect: 'delay',
+        status: 'dispatched',
+        windowStartAt: '2026-05-24T04:20:00.000Z',
+        windowEndAt: '2026-05-24T04:50:00.000Z',
+        dispatchedAt: '2026-05-24T04:55:00.000Z',
+        updatedAt: '2026-05-24T04:55:00.000Z',
+      },
+    ],
+    [{ id: 'BPLRT', name: name('Bukit Panjang LRT'), color: '#718472' }],
+    [{ id: 'BP6', name: name('Bukit Panjang') }],
+    [
+      {
+        observedAt: '2026-05-24T04:30:00.000Z',
+        directionText: 'towards:BP6',
+        delayMinutes: 10,
+        stillHappening: true,
+      },
+      {
+        observedAt: '2026-05-24T04:40:00.000Z',
+        directionText: null,
+        delayMinutes: null,
+        stillHappening: true,
+      },
+    ],
+  ];
+  let selectCount = 0;
+
+  return {
+    whereCalls,
+    db: {
+      select() {
+        const selectIndex = selectCount;
+        selectCount += 1;
+        return {
+          from() {
+            return this;
+          },
+          innerJoin() {
+            return this;
+          },
+          where(condition: unknown) {
+            whereCalls.push(condition);
+            return this;
+          },
+          orderBy() {
+            return Promise.resolve(selectResults[selectIndex]);
+          },
+          limit() {
+            return Promise.resolve(selectResults[selectIndex]);
+          },
+        };
+      },
+    },
+  };
+}
+
+describe('getCrowdReportSource', () => {
+  it('builds cluster evidence from ongoing reports only', async () => {
+    const fake = makeFakeClusterSourceDb();
+
+    const source = await getCrowdReportSource(fake.db as never, {
+      kind: 'cluster',
+      sourceId: 'cluster-1',
+    });
+
+    expect(source).toMatchObject({
+      kind: 'cluster',
+      id: 'cluster-1',
+      reportCount: 2,
+      observedStartAt: '2026-05-24T04:30:00.000Z',
+      observedEndAt: '2026-05-24T04:40:00.000Z',
+      stillHappening: true,
+    });
+
+    const dialect = new PgDialect();
+    const reportWhereSql = dialect.sqlToQuery(fake.whereCalls[3] as SQL).sql;
+
+    expect(reportWhereSql).toContain('"crowd_reports"."still_happening" =');
+  });
+});

--- a/app/util/crowdReportSource.functions.ts
+++ b/app/util/crowdReportSource.functions.ts
@@ -87,7 +87,6 @@ async function getClusterSource(
     .select({
       id: crowdReportClustersTable.id,
       effect: crowdReportClustersTable.effect,
-      reportCount: crowdReportClustersTable.report_count,
       status: crowdReportClustersTable.status,
       windowStartAt: crowdReportClustersTable.window_start_at,
       windowEndAt: crowdReportClustersTable.window_end_at,
@@ -150,10 +149,15 @@ async function getClusterSource(
             'duplicate',
             'dispatched',
           ]),
+          eq(crowdReportsTable.still_happening, true),
         ),
       )
       .orderBy(desc(crowdReportsTable.observed_at)),
   ]);
+
+  if (reports.length === 0) {
+    return null;
+  }
 
   const representative = reports[0];
   const observedValues = reports.map((report) => report.observedAt);
@@ -163,7 +167,7 @@ async function getClusterSource(
     id: cluster.id,
     status: cluster.status as CrowdReportSourceStatus,
     effect: cluster.effect,
-    reportCount: Math.max(cluster.reportCount, reports.length),
+    reportCount: reports.length,
     observedStartAt:
       observedValues.length > 0
         ? observedValues.reduce((earliest, value) =>

--- a/app/util/crowdReportSource.functions.ts
+++ b/app/util/crowdReportSource.functions.ts
@@ -1,0 +1,286 @@
+import type { Translations } from '@mrtdown/core';
+import { createServerFn } from '@tanstack/react-start';
+import { and, asc, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
+import { z } from 'zod';
+import { getDb } from '~/db';
+import {
+  crowdReportClusterLinesTable,
+  crowdReportClustersTable,
+  crowdReportClusterStationsTable,
+  crowdReportLinesTable,
+  crowdReportsTable,
+  crowdReportStationsTable,
+  linesTable,
+  stationsTable,
+} from '~/db/schema';
+import type { CrowdReportEffect } from './crowdReports';
+
+const CrowdReportSourceKindSchema = z.enum(['cluster', 'report']);
+
+const RequestSchema = z.object({
+  kind: CrowdReportSourceKindSchema,
+  sourceId: z.string().trim().min(1).max(128),
+});
+
+type AppDb = ReturnType<typeof getDb>;
+type CrowdReportSourceKind = z.infer<typeof CrowdReportSourceKindSchema>;
+type CrowdReportSourceStatus = 'accepted' | 'dispatched';
+
+export type CrowdReportSourceLine = {
+  id: string;
+  name: Translations;
+  color: string;
+};
+
+export type CrowdReportSourceStation = {
+  id: string;
+  name: Translations;
+};
+
+export type CrowdReportSource = {
+  kind: CrowdReportSourceKind;
+  id: string;
+  status: CrowdReportSourceStatus;
+  effect: CrowdReportEffect | null;
+  reportCount: number;
+  observedStartAt: string;
+  observedEndAt: string;
+  updatedAt: string;
+  dispatchedAt: string | null;
+  directionText: string | null;
+  delayMinutes: number | null;
+  stillHappening: boolean | null;
+  lines: CrowdReportSourceLine[];
+  stations: CrowdReportSourceStation[];
+};
+
+function toIsoString(value: Date | string | null) {
+  if (value == null) {
+    return null;
+  }
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function hasClusterScopeSql(clusterId: string) {
+  return orSql(
+    sql`exists (select 1 from ${crowdReportClusterLinesTable} where ${crowdReportClusterLinesTable.cluster_id} = ${clusterId})`,
+    sql`exists (select 1 from ${crowdReportClusterStationsTable} where ${crowdReportClusterStationsTable.cluster_id} = ${clusterId})`,
+  );
+}
+
+function hasReportScopeSql(reportId: string) {
+  return orSql(
+    sql`exists (select 1 from ${crowdReportLinesTable} where ${crowdReportLinesTable.report_id} = ${reportId})`,
+    sql`exists (select 1 from ${crowdReportStationsTable} where ${crowdReportStationsTable.report_id} = ${reportId})`,
+  );
+}
+
+function orSql(left: ReturnType<typeof sql>, right: ReturnType<typeof sql>) {
+  return sql`(${left} or ${right})`;
+}
+
+async function getClusterSource(
+  db: AppDb,
+  sourceId: string,
+): Promise<CrowdReportSource | null> {
+  const [cluster] = await db
+    .select({
+      id: crowdReportClustersTable.id,
+      effect: crowdReportClustersTable.effect,
+      reportCount: crowdReportClustersTable.report_count,
+      status: crowdReportClustersTable.status,
+      windowStartAt: crowdReportClustersTable.window_start_at,
+      windowEndAt: crowdReportClustersTable.window_end_at,
+      dispatchedAt: crowdReportClustersTable.dispatched_at,
+      updatedAt: crowdReportClustersTable.updated_at,
+    })
+    .from(crowdReportClustersTable)
+    .where(
+      and(
+        eq(crowdReportClustersTable.id, sourceId),
+        inArray(crowdReportClustersTable.status, ['accepted', 'dispatched']),
+        hasClusterScopeSql(sourceId),
+      ),
+    )
+    .limit(1);
+
+  if (cluster == null) {
+    return null;
+  }
+
+  const [lines, stations, reports] = await Promise.all([
+    db
+      .select({
+        id: linesTable.id,
+        name: linesTable.name,
+        color: linesTable.color,
+      })
+      .from(crowdReportClusterLinesTable)
+      .innerJoin(
+        linesTable,
+        eq(crowdReportClusterLinesTable.line_id, linesTable.id),
+      )
+      .where(eq(crowdReportClusterLinesTable.cluster_id, cluster.id))
+      .orderBy(asc(linesTable.id)),
+    db
+      .select({
+        id: stationsTable.id,
+        name: stationsTable.name,
+      })
+      .from(crowdReportClusterStationsTable)
+      .innerJoin(
+        stationsTable,
+        eq(crowdReportClusterStationsTable.station_id, stationsTable.id),
+      )
+      .where(eq(crowdReportClusterStationsTable.cluster_id, cluster.id))
+      .orderBy(asc(stationsTable.id)),
+    db
+      .select({
+        observedAt: crowdReportsTable.observed_at,
+        directionText: crowdReportsTable.direction_text,
+        delayMinutes: crowdReportsTable.delay_minutes,
+        stillHappening: crowdReportsTable.still_happening,
+      })
+      .from(crowdReportsTable)
+      .where(
+        and(
+          eq(crowdReportsTable.cluster_id, cluster.id),
+          inArray(crowdReportsTable.status, [
+            'accepted',
+            'duplicate',
+            'dispatched',
+          ]),
+        ),
+      )
+      .orderBy(desc(crowdReportsTable.observed_at)),
+  ]);
+
+  const representative = reports[0];
+  const observedValues = reports.map((report) => report.observedAt);
+
+  return {
+    kind: 'cluster',
+    id: cluster.id,
+    status: cluster.status as CrowdReportSourceStatus,
+    effect: cluster.effect,
+    reportCount: Math.max(cluster.reportCount, reports.length),
+    observedStartAt:
+      observedValues.length > 0
+        ? observedValues.reduce((earliest, value) =>
+            value < earliest ? value : earliest,
+          )
+        : cluster.windowStartAt,
+    observedEndAt:
+      observedValues.length > 0
+        ? observedValues.reduce((latest, value) =>
+            value > latest ? value : latest,
+          )
+        : cluster.windowEndAt,
+    updatedAt: toIsoString(cluster.updatedAt) ?? cluster.windowEndAt,
+    dispatchedAt: toIsoString(cluster.dispatchedAt),
+    directionText: representative?.directionText ?? null,
+    delayMinutes: representative?.delayMinutes ?? null,
+    stillHappening: representative?.stillHappening ?? null,
+    lines,
+    stations,
+  };
+}
+
+async function getReportSource(
+  db: AppDb,
+  sourceId: string,
+): Promise<CrowdReportSource | null> {
+  const [report] = await db
+    .select({
+      id: crowdReportsTable.id,
+      observedAt: crowdReportsTable.observed_at,
+      directionText: crowdReportsTable.direction_text,
+      effect: crowdReportsTable.effect,
+      delayMinutes: crowdReportsTable.delay_minutes,
+      stillHappening: crowdReportsTable.still_happening,
+      status: crowdReportsTable.status,
+      dispatchedAt: crowdReportsTable.dispatched_at,
+      updatedAt: crowdReportsTable.updated_at,
+    })
+    .from(crowdReportsTable)
+    .where(
+      and(
+        eq(crowdReportsTable.id, sourceId),
+        inArray(crowdReportsTable.status, ['accepted', 'dispatched']),
+        isNull(crowdReportsTable.cluster_id),
+        hasReportScopeSql(sourceId),
+      ),
+    )
+    .limit(1);
+
+  if (report == null) {
+    return null;
+  }
+
+  const [lines, stations] = await Promise.all([
+    db
+      .select({
+        id: linesTable.id,
+        name: linesTable.name,
+        color: linesTable.color,
+      })
+      .from(crowdReportLinesTable)
+      .innerJoin(linesTable, eq(crowdReportLinesTable.line_id, linesTable.id))
+      .where(eq(crowdReportLinesTable.report_id, report.id))
+      .orderBy(asc(linesTable.id)),
+    db
+      .select({
+        id: stationsTable.id,
+        name: stationsTable.name,
+      })
+      .from(crowdReportStationsTable)
+      .innerJoin(
+        stationsTable,
+        eq(crowdReportStationsTable.station_id, stationsTable.id),
+      )
+      .where(eq(crowdReportStationsTable.report_id, report.id))
+      .orderBy(asc(stationsTable.id)),
+  ]);
+
+  return {
+    kind: 'report',
+    id: report.id,
+    status: report.status as CrowdReportSourceStatus,
+    effect: report.effect,
+    reportCount: 1,
+    observedStartAt: report.observedAt,
+    observedEndAt: report.observedAt,
+    updatedAt: toIsoString(report.updatedAt) ?? report.observedAt,
+    dispatchedAt: toIsoString(report.dispatchedAt),
+    directionText: report.directionText,
+    delayMinutes: report.delayMinutes,
+    stillHappening: report.stillHappening,
+    lines,
+    stations,
+  };
+}
+
+export async function getCrowdReportSource(
+  db: AppDb,
+  input: z.infer<typeof RequestSchema>,
+) {
+  if (input.kind === 'cluster') {
+    return getClusterSource(db, input.sourceId);
+  }
+  return getReportSource(db, input.sourceId);
+}
+
+export const getCrowdReportSourceFn = createServerFn({
+  method: 'GET',
+})
+  .inputValidator((value) => RequestSchema.parse(value))
+  .handler(async ({ data }) => {
+    const source = await getCrowdReportSource(getDb(), data);
+    if (source == null) {
+      throw new Response('Not Found', {
+        status: 404,
+        statusText: 'Not Found',
+      });
+    }
+    return source;
+  });

--- a/app/util/publicHtmlCache.test.ts
+++ b/app/util/publicHtmlCache.test.ts
@@ -30,6 +30,8 @@ describe('public HTML cache headers', () => {
     '/zh-Hans/statistics',
     '/history',
     '/history/2025',
+    '/community-reports/cluster/cluster-1',
+    '/zh-Hans/community-reports/report/report-1',
     '/lines/EWL',
     '/operators/SMRT',
     '/stations/NS1',

--- a/app/util/publicHtmlCache.ts
+++ b/app/util/publicHtmlCache.ts
@@ -5,6 +5,7 @@ const PUBLIC_HTML_CACHE_NAME = 'mrtdown-public-html';
 const HTML_CONTENT_TYPES = ['text/html', 'application/xhtml+xml'];
 
 const CACHEABLE_ROUTE_PREFIXES = [
+  '/community-reports/',
   '/history/',
   '/lines/',
   '/operators/',

--- a/docs/DATA_PIPELINE.md
+++ b/docs/DATA_PIPELINE.md
@@ -36,8 +36,9 @@ Configure `CROWD_REPORT_DISPATCH_GITHUB_TOKEN` as a deployed secret. Optional
 overrides are `CROWD_REPORT_DISPATCH_GITHUB_OWNER`,
 `CROWD_REPORT_DISPATCH_GITHUB_REPO`, and
 `CROWD_REPORT_DISPATCH_GITHUB_EVENT_TYPE`. The canonical evidence source URL is
-built from `VITE_ROOT_URL`. Send `{ "dryRun": true }` to the endpoint to inspect
-pending payloads without calling GitHub or mutating report state.
+built from `VITE_ROOT_URL` as a stable `/community-reports/{kind}/{id}`
+permalink. Send `{ "dryRun": true }` to the endpoint to inspect pending payloads
+without calling GitHub or mutating report state.
 
 The existing six-hourly scheduled cron also invokes the same dispatch path when
 `CROWD_REPORT_DISPATCH_GITHUB_TOKEN` is configured. Use

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -526,6 +526,10 @@ Exit criteria:
   assembly by extracting the service-revision direction, station-code, and
   affected-stop path derivation into a pure helper while keeping the server
   function behavior unchanged.
+- 2026-06-18: Added stable `/community-reports/{kind}/{id}` evidence
+  permalinks for accepted or dispatched crowd report sources, and changed
+  canonical ingest dispatch payload URLs to point at those read-only public
+  source pages instead of the public report submission form.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Add stable `/community-reports/{kind}/{id}` public evidence permalinks for accepted or dispatched crowd report clusters and single reports.
- Add a server-side source lookup that exposes only structured public fields, excluding reporter metadata, abuse-control data, and moderation notes.
- Point crowd-report ingest dispatch payload URLs at the new permalink route and document the new URL shape.
- Include the new route in the public HTML cache allowlist and update regression coverage.

## Validation

- `npm run verify`

Note: final verification required unsandboxed execution because `tsx` could not create its IPC pipe inside the sandbox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Community report evidence pages now available at stable, shareable URLs (`/community-reports/{kind}/{id}`)
  * Pages display crowd-sourced report details including effect, location, timing, and dispatch information with full localization support

* **Documentation**
  * Updated documentation to reflect stable evidence permalink structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->