### PR TITLE
fix: render deferred widgets during SSR

### DIFF
--- a/app/components/DeferredViewportWidget.test.tsx
+++ b/app/components/DeferredViewportWidget.test.tsx
@@ -1,0 +1,19 @@
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { DeferredViewportWidget } from './DeferredViewportWidget';
+
+describe('DeferredViewportWidget', () => {
+  it('renders its content during server rendering', () => {
+    const html = renderToString(
+      <DeferredViewportWidget
+        className="col-span-6"
+        fallback={<span>Loading graph</span>}
+      >
+        <section>Issue Count by Line</section>
+      </DeferredViewportWidget>,
+    );
+
+    expect(html).toContain('Issue Count by Line');
+    expect(html).not.toContain('Loading graph');
+  });
+});

--- a/app/components/DeferredViewportWidget.tsx
+++ b/app/components/DeferredViewportWidget.tsx
@@ -1,5 +1,6 @@
 import { Suspense, useEffect, useRef, useState } from 'react';
 import type React from 'react';
+import { useHydrated } from '~/hooks/useHydrated';
 
 interface DeferredViewportWidgetProps {
   children: React.ReactNode;
@@ -10,7 +11,9 @@ interface DeferredViewportWidgetProps {
 
 export function DeferredViewportWidget(props: DeferredViewportWidgetProps) {
   const { children, className, fallback, rootMargin = '600px 0px' } = props;
-  const [shouldRender, setShouldRender] = useState(false);
+  const isHydrated = useHydrated();
+  // SSR and the matching hydration pass should emit real content for crawlers.
+  const [shouldRender, setShouldRender] = useState(() => !isHydrated);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Render `DeferredViewportWidget` children during SSR and the matching hydration pass so chart and profile content is present in crawlable HTML.
- Preserve viewport-gated rendering for widgets mounted after hydration, such as client-side navigations.
- Add a regression test covering server-rendered deferred widget content.

## Root Cause

The deferred wrapper initialized `shouldRender` to `false`, so SSR emitted only skeleton fallbacks. Below-the-fold chart widgets could therefore be absent from the initial HTML despite having meaningful page content.

## Validation

- `npm run verify`