### PR TITLE
test: cover crowd report source permalinks

### DIFF
--- a/app/util/crowdReportSource.functions.test.ts
+++ b/app/util/crowdReportSource.functions.test.ts
@@ -78,6 +78,56 @@ function makeFakeClusterSourceDb() {
   };
 }
 
+function makeFakeReportSourceDb(
+  reportRows: Array<{
+    id: string;
+    observedAt: string;
+    directionText: string | null;
+    effect: string;
+    delayMinutes: number | null;
+    stillHappening: boolean;
+    status: string;
+    dispatchedAt: string | null;
+    updatedAt: string;
+  }>,
+) {
+  const whereCalls: unknown[] = [];
+  const selectResults = [
+    reportRows,
+    [{ id: 'BPLRT', name: name('Bukit Panjang LRT'), color: '#718472' }],
+    [{ id: 'BP6', name: name('Bukit Panjang') }],
+  ];
+  let selectCount = 0;
+
+  return {
+    whereCalls,
+    db: {
+      select() {
+        const selectIndex = selectCount;
+        selectCount += 1;
+        return {
+          from() {
+            return this;
+          },
+          innerJoin() {
+            return this;
+          },
+          where(condition: unknown) {
+            whereCalls.push(condition);
+            return this;
+          },
+          orderBy() {
+            return Promise.resolve(selectResults[selectIndex]);
+          },
+          limit() {
+            return Promise.resolve(selectResults[selectIndex]);
+          },
+        };
+      },
+    },
+  };
+}
+
 describe('getCrowdReportSource', () => {
   it('builds cluster evidence from ongoing reports only', async () => {
     const fake = makeFakeClusterSourceDb();
@@ -100,5 +150,63 @@ describe('getCrowdReportSource', () => {
     const reportWhereSql = dialect.sqlToQuery(fake.whereCalls[3] as SQL).sql;
 
     expect(reportWhereSql).toContain('"crowd_reports"."still_happening" =');
+  });
+
+  it('builds single-report evidence for accepted unclustered reports with scope', async () => {
+    const fake = makeFakeReportSourceDb([
+      {
+        id: 'report-1',
+        observedAt: '2026-05-24T04:30:00.000Z',
+        directionText: 'towards:BP6',
+        effect: 'delay',
+        delayMinutes: 10,
+        stillHappening: true,
+        status: 'accepted',
+        dispatchedAt: null,
+        updatedAt: '2026-05-24T04:35:00.000Z',
+      },
+    ]);
+
+    const source = await getCrowdReportSource(fake.db as never, {
+      kind: 'report',
+      sourceId: 'report-1',
+    });
+
+    expect(source).toMatchObject({
+      kind: 'report',
+      id: 'report-1',
+      status: 'accepted',
+      effect: 'delay',
+      reportCount: 1,
+      observedStartAt: '2026-05-24T04:30:00.000Z',
+      observedEndAt: '2026-05-24T04:30:00.000Z',
+      updatedAt: '2026-05-24T04:35:00.000Z',
+      dispatchedAt: null,
+      directionText: 'towards:BP6',
+      delayMinutes: 10,
+      stillHappening: true,
+      lines: [
+        { id: 'BPLRT', name: name('Bukit Panjang LRT'), color: '#718472' },
+      ],
+      stations: [{ id: 'BP6', name: name('Bukit Panjang') }],
+    });
+  });
+
+  it('requires single-report sources to be unclustered and scoped', async () => {
+    const fake = makeFakeReportSourceDb([]);
+
+    const source = await getCrowdReportSource(fake.db as never, {
+      kind: 'report',
+      sourceId: 'report-1',
+    });
+
+    expect(source).toBeNull();
+
+    const dialect = new PgDialect();
+    const reportWhereSql = dialect.sqlToQuery(fake.whereCalls[0] as SQL).sql;
+
+    expect(reportWhereSql).toContain('"crowd_reports"."cluster_id" is null');
+    expect(reportWhereSql).toContain('crowd_report_lines');
+    expect(reportWhereSql).toContain('crowd_report_stations');
   });
 });

--- a/docs/plans/active/crowdsourced-reports.md
+++ b/docs/plans/active/crowdsourced-reports.md
@@ -530,6 +530,9 @@ Exit criteria:
   permalinks for accepted or dispatched crowd report sources, and changed
   canonical ingest dispatch payload URLs to point at those read-only public
   source pages instead of the public report submission form.
+- 2026-06-19: Added regression coverage for community-report evidence
+  permalinks so single-report sources must remain unclustered and tied to a
+  persisted line or station scope before they are publicly linkable.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Add regression coverage for accepted single-report community evidence permalinks.
- Assert single-report source URLs stay limited to unclustered reports with persisted line or station scope.
- Record the coverage update in the active crowdsourced reports plan.

## Impact

This protects the canonical ingest source-link path from accidentally exposing stale clustered reports or unscoped local reports as public evidence pages.

## Validation

- `npm run test:run -- app/util/crowdReportSource.functions.test.ts`
- `npm run verify`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for single-report community sources, verifying correct metadata handling and SQL constraint enforcement for scoped, unclustered reports.

* **Documentation**
  * Updated progress documentation regarding regression coverage for community report evidence permalinks and scoping requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->