### PR TITLE
docs: complete crowdsourced reports plan

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -18,8 +18,6 @@ Use plans for:
 
 ## Active
 
-- [Crowdsourced reports](active/crowdsourced-reports.md): site-local public
-  report collection, moderation, clustering, and canonical ingest dispatch.
 - [Dynamic system map](active/dynamic-system-map.md): canonical schematic map
   data and data-driven site rendering.
 - [Production performance](active/production-performance.md): public route
@@ -27,6 +25,8 @@ Use plans for:
 
 ## Completed
 
+- [Crowdsourced reports](completed/crowdsourced-reports.md): site-local public
+  report collection, moderation, clustering, and canonical ingest dispatch.
 - [Markdown for agents](completed/markdown-for-agents.md): `llms.txt` and
   app-owned Markdown alternatives for agents and scrapers.
 - [Overhaul read model](completed/overhaul-read-model.md): local

--- a/docs/plans/completed/crowdsourced-reports.md
+++ b/docs/plans/completed/crowdsourced-reports.md
@@ -533,6 +533,11 @@ Exit criteria:
 - 2026-06-19: Added regression coverage for community-report evidence
   permalinks so single-report sources must remain unclustered and tied to a
   persisted line or station scope before they are publicly linkable.
+- 2026-06-21: Completed the site-side plan after `npm run verify` passed and
+  manual browser QA confirmed successful desktop line-issue and mobile
+  station-issue report submissions. Phase 6 threshold tuning remains a
+  post-launch operations concern driven by observed false-positive and
+  duplicate rates, not an implementation blocker.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Move the crowdsourced reports plan from active to completed.
- Update the plan index so active and completed plan lists reflect the current state.
- Record the final validation and browser QA pass, with Phase 6 threshold tuning noted as post-launch operations work.

## Validation

- `npm run verify`
- Manual browser QA: desktop line-issue report submission reached the success page.
- Manual browser QA: mobile station-issue report submission at 390x844 reached the success page.

## Notes

Local interactive QA required `VITE_ROOT_URL=http://127.0.0.1:3000` so the report route could hydrate correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project roadmap marking crowdsourced reports as complete.
  * Added progress entry documenting verification completion through automated testing and manual quality assurance across desktop and mobile platforms, confirming successful report submission functionality.
  * Noted ongoing post-launch performance monitoring as a follow-up operational concern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->