### PR TITLE
feat: add crowd report beta badge

### DIFF
--- a/app/components/BetaBadge.tsx
+++ b/app/components/BetaBadge.tsx
@@ -1,0 +1,11 @@
+import { BeakerIcon } from '@heroicons/react/24/outline';
+import { FormattedMessage } from 'react-intl';
+
+export function BetaBadge() {
+  return (
+    <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-sky-100 px-2 py-0.5 font-semibold text-sky-800 text-xs ring-1 ring-sky-600/20 ring-inset dark:bg-sky-900/40 dark:text-sky-200 dark:ring-sky-400/30">
+      <BeakerIcon className="size-3" />
+      <FormattedMessage id="general.beta" defaultMessage="Beta" />
+    </span>
+  );
+}

--- a/app/components/CommunitySignalsSection.tsx
+++ b/app/components/CommunitySignalsSection.tsx
@@ -10,6 +10,7 @@ import {
 import { useIncludedEntities } from '~/contexts/IncludedEntities';
 import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 import type { PublicCrowdReportSignal } from '~/util/crowdReports';
+import { BetaBadge } from './BetaBadge';
 import { LineBar } from './LineBar';
 
 const EFFECT_LABEL_MESSAGES = defineMessages({
@@ -66,12 +67,15 @@ export const CommunitySignalsSection: React.FC<Props> = (props) => {
           <ChatBubbleLeftRightIcon className="size-5" />
         </span>
         <div className="min-w-0 flex-1">
-          <h2 className="font-semibold text-base text-gray-900 dark:text-gray-100">
-            <FormattedMessage
-              id="community_signals.title"
-              defaultMessage="Community reports"
-            />
-          </h2>
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="font-semibold text-base text-gray-900 dark:text-gray-100">
+              <FormattedMessage
+                id="community_signals.title"
+                defaultMessage="Community reports"
+              />
+            </h2>
+            <BetaBadge />
+          </div>
           <p className="mt-1 text-gray-700 text-sm leading-5 dark:text-gray-300">
             <FormattedMessage
               id="community_signals.description"

--- a/app/routes/{-$lang}/index.tsx
+++ b/app/routes/{-$lang}/index.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, Link, notFound } from '@tanstack/react-router';
 import { DateTime } from 'luxon';
 import { lazy, useMemo } from 'react';
 import { createIntl, FormattedMessage } from 'react-intl';
+import { BetaBadge } from '~/components/BetaBadge';
 import { DeferredViewportWidget } from '~/components/DeferredViewportWidget';
 import { LineSummaryBlock } from '~/components/LineSummaryBlock';
 import { CommunitySignalsSectionSkeleton } from '~/components/ProfileWidgetSkeletons';
@@ -208,12 +209,15 @@ function HomePage() {
         {crowdReportsEnabled && (
           <section className="flex flex-col gap-4 rounded-2xl border border-sky-200 bg-sky-50 p-4 sm:flex-row sm:items-center sm:justify-between dark:border-sky-900 dark:bg-sky-950/30">
             <div>
-              <h2 className="font-semibold text-base text-gray-900 dark:text-gray-100">
-                <FormattedMessage
-                  id="home.report_cta_title"
-                  defaultMessage="Seeing a train delay?"
-                />
-              </h2>
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="font-semibold text-base text-gray-900 dark:text-gray-100">
+                  <FormattedMessage
+                    id="home.report_cta_title"
+                    defaultMessage="Seeing a train delay?"
+                  />
+                </h2>
+                <BetaBadge />
+              </div>
               <p className="mt-1 text-gray-600 text-sm leading-5 dark:text-gray-300">
                 <FormattedMessage
                   id="home.report_cta_body"

--- a/app/routes/{-$lang}/lines/$lineId/index.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/index.tsx
@@ -8,6 +8,7 @@ import {
   FormattedMessage,
   useIntl,
 } from 'react-intl';
+import { BetaBadge } from '~/components/BetaBadge';
 import { DeferredViewportWidget } from '~/components/DeferredViewportWidget';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
 import {
@@ -330,6 +331,7 @@ function ComponentPage() {
                       />
                     </Link>
                     <span className="max-w-md text-gray-300 text-xs leading-5">
+                      <BetaBadge />{' '}
                       <FormattedMessage
                         id="line.report_cta_note"
                         defaultMessage="Community reports are reviewed separately from official operator advisories."

--- a/app/routes/{-$lang}/report.tsx
+++ b/app/routes/{-$lang}/report.tsx
@@ -39,6 +39,7 @@ import {
   useIntl,
 } from 'react-intl';
 import { z } from 'zod';
+import { BetaBadge } from '~/components/BetaBadge';
 import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
 import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 import { assert } from '~/util/assert';
@@ -1350,12 +1351,15 @@ function ReportPage() {
   return (
     <div className="mx-auto flex w-full max-w-3xl flex-col gap-6">
       <header>
-        <h1 className="font-bold text-3xl text-gray-900 tracking-normal dark:text-gray-100">
-          <FormattedMessage
-            id="report.heading"
-            defaultMessage="Submit a community train report"
-          />
-        </h1>
+        <div className="flex flex-wrap items-center gap-2">
+          <h1 className="font-bold text-3xl text-gray-900 tracking-normal dark:text-gray-100">
+            <FormattedMessage
+              id="report.heading"
+              defaultMessage="Submit a community train report"
+            />
+          </h1>
+          <BetaBadge />
+        </div>
         <p className="mt-2 max-w-2xl text-gray-600 text-sm leading-6 dark:text-gray-300">
           <FormattedMessage
             id="report.intro"

--- a/app/routes/{-$lang}/stations/$stationId.tsx
+++ b/app/routes/{-$lang}/stations/$stationId.tsx
@@ -10,6 +10,7 @@ import {
   type IntlShape,
   useIntl,
 } from 'react-intl';
+import { BetaBadge } from '~/components/BetaBadge';
 import { DeferredViewportWidget } from '~/components/DeferredViewportWidget';
 import {
   CommunitySignalsSectionSkeleton,
@@ -320,12 +321,13 @@ function StationPage() {
                   <Link
                     to="/{-$lang}/report"
                     search={{ stationId: station.id }}
-                    className="inline-flex min-h-10 items-center justify-center rounded-lg bg-accent-light px-4 py-2 font-semibold text-sm text-white transition-colors hover:bg-accent-dark"
+                    className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg bg-accent-light px-4 py-2 font-semibold text-sm text-white transition-colors hover:bg-accent-dark"
                   >
                     <FormattedMessage
                       id="station.report_cta"
                       defaultMessage="Report issue here"
                     />
+                    <BetaBadge />
                   </Link>
                 )}
               </div>

--- a/lang/en-SG.json
+++ b/lang/en-SG.json
@@ -34,6 +34,7 @@
   "general.about": "About",
   "general.active_disruptions": "<bold>{count}</bold> Active {count, plural, one {Disruption} other {Disruptions}}",
   "general.active_intervals": "Active Intervals",
+  "general.beta": "Beta",
   "general.affected_stations": "Affected stations",
   "general.change_since_previous": "{change} vs previous",
   "general.close": "Close",

--- a/lang/ms.json
+++ b/lang/ms.json
@@ -32,6 +32,7 @@
   "general.about": "Tentang",
   "general.active_disruptions": "<bold>{count}</bold> {count, plural, one {Gangguan Aktif} other {Gangguan Aktif}}",
   "general.active_intervals": "Selang Masa Aktif",
+  "general.beta": "Beta",
   "general.affected_stations": "Stesen Terjejas",
   "general.change_since_previous": "{change} berbanding sebelumnya",
   "general.close": "Tutup",

--- a/lang/ta.json
+++ b/lang/ta.json
@@ -32,6 +32,7 @@
   "general.about": "எங்களைப் பற்றி",
   "general.active_disruptions": "<bold>{count}</bold> {count, plural, one {நடைபெற்று வரும் தடை} other {நடைபெற்று வரும் தடைகள்}}",
   "general.active_intervals": "செயலில் உள்ள இடைவெளிகள்",
+  "general.beta": "Beta",
   "general.affected_stations": "பாதிக்கப்பட்ட நிலையங்கள்",
   "general.change_since_previous": "முந்தையதுடன் ஒப்பிடும் போது {change}",
   "general.close": "மூடு",

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -32,6 +32,7 @@
   "general.about": "关于",
   "general.active_disruptions": "<bold>{count}</bold> {count, plural, one {进行中的服务中断} other {进行中的服务中断}}",
   "general.active_intervals": "活跃间隔",
+  "general.beta": "Beta",
   "general.affected_stations": "受影响车站",
   "general.change_since_previous": "与之前相比 {change}",
   "general.close": "关闭",


### PR DESCRIPTION
## Summary

- add a reusable `BetaBadge` component for the crowd reports beta UI
- show the badge on the community signals panel, home/report entry points, and line/station report CTAs
- add the `general.beta` locale key across supported languages

## Impact

This makes the crowdsourced/community reporting surfaces visibly marked as beta while keeping the existing feature flag behavior unchanged.

## Validation

- `npm run verify`
- `curl -I http://localhost:3000/report` returned `200 OK` during local preview