### PR TITLE
fix: remediate sitemap and metadata SEO issues

### DIFF
--- a/app/routes/{-$lang}/about.tsx
+++ b/app/routes/{-$lang}/about.tsx
@@ -25,6 +25,11 @@ export const Route = createFileRoute('/{-$lang}/about')({
       id: 'general.about',
       defaultMessage: 'About',
     });
+    const description = intl.formatMessage({
+      id: 'site.about.subtitle',
+      defaultMessage:
+        'Learn more about our mission, data collection methods, and frequently asked questions',
+    });
 
     return {
       meta: [
@@ -32,8 +37,16 @@ export const Route = createFileRoute('/{-$lang}/about')({
           title,
         },
         {
+          name: 'description',
+          content: description,
+        },
+        {
           property: 'og:title',
           content: title,
+        },
+        {
+          property: 'og:description',
+          content: description,
         },
         {
           property: 'og:type',

--- a/app/routes/{-$lang}/history/$year/$month.tsx
+++ b/app/routes/{-$lang}/history/$year/$month.tsx
@@ -64,6 +64,16 @@ export const Route = createFileRoute('/{-$lang}/history/$year/$month')({
         startAt: dateTimeStartAt.toMillis(),
       },
     );
+    const description = intl.formatMessage(
+      {
+        id: 'site.history.month_description',
+        defaultMessage:
+          'Past service disruptions and maintenance events in {startAt, date, ::MMMM yyyy}.',
+      },
+      {
+        startAt: dateTimeStartAt.toMillis(),
+      },
+    );
 
     const rootUrl = import.meta.env.VITE_ROOT_URL;
 
@@ -79,8 +89,16 @@ export const Route = createFileRoute('/{-$lang}/history/$year/$month')({
           title,
         },
         {
+          name: 'description',
+          content: description,
+        },
+        {
           property: 'og:title',
           content: title,
+        },
+        {
+          property: 'og:description',
+          content: description,
         },
         {
           property: 'og:type',

--- a/app/routes/{-$lang}/history/$year/index.tsx
+++ b/app/routes/{-$lang}/history/$year/index.tsx
@@ -48,7 +48,7 @@ export const Route = createFileRoute('/{-$lang}/history/$year/')({
     const rootUrl = import.meta.env.VITE_ROOT_URL;
 
     const ogUrl = new URL(
-      buildLocaleAwareLink('/history/$year', lang),
+      buildLocaleAwareLink(`/history/${ctx.params.year}`, lang),
       rootUrl,
     ).toString();
     const ogImage = new URL('/og_image.png', rootUrl).toString();
@@ -71,6 +71,16 @@ export const Route = createFileRoute('/{-$lang}/history/$year/')({
         startAt: dateTimeStartAt.toMillis(),
       },
     );
+    const description = intl.formatMessage(
+      {
+        id: 'site.history.year_description',
+        defaultMessage:
+          'Past service disruptions and maintenance events in {startAt, date, ::yyyy}.',
+      },
+      {
+        startAt: dateTimeStartAt.toMillis(),
+      },
+    );
 
     return {
       meta: [
@@ -78,8 +88,16 @@ export const Route = createFileRoute('/{-$lang}/history/$year/')({
           title,
         },
         {
+          name: 'description',
+          content: description,
+        },
+        {
           property: 'og:title',
           content: title,
+        },
+        {
+          property: 'og:description',
+          content: description,
         },
         {
           property: 'og:type',

--- a/app/routes/{-$lang}/issues/$issueId/index.tsx
+++ b/app/routes/{-$lang}/issues/$issueId/index.tsx
@@ -5,16 +5,90 @@ import {
 } from '@heroicons/react/16/solid';
 import { createFileRoute } from '@tanstack/react-router';
 import classNames from 'classnames';
-import { createIntl, FormattedMessage, useIntl } from 'react-intl';
+import { DateTime } from 'luxon';
+import {
+  createIntl,
+  FormattedMessage,
+  type IntlShape,
+  useIntl,
+} from 'react-intl';
 import { IssueTypeLabels } from '~/constants';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
 import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
 import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
+import type { IssueInterval } from '~/types';
 import { assert } from '~/util/assert';
 import { getIssueFn } from '~/util/issue.functions';
 import { Attributes } from './components/Attributes';
 import { StatsCard } from './components/StatsCard';
 import { TimelineCard } from './components/TimelineCard';
+
+const SG_TIMEZONE = 'Asia/Singapore';
+
+function formatIssueDescriptionPeriod(
+  intervals: IssueInterval[],
+  intl: IntlShape,
+) {
+  if (intervals.length === 0) {
+    return intl.formatMessage({
+      id: 'issue.period_unknown',
+      defaultMessage: 'an unknown date',
+    });
+  }
+
+  const sortedIntervals = [...intervals].sort((a, b) => {
+    return (
+      DateTime.fromISO(a.startAt).toMillis() -
+      DateTime.fromISO(b.startAt).toMillis()
+    );
+  });
+  const firstInterval = sortedIntervals[0];
+  const lastInterval = sortedIntervals.at(-1);
+  assert(firstInterval != null);
+  assert(lastInterval != null);
+
+  const start = DateTime.fromISO(firstInterval.startAt).setZone(SG_TIMEZONE);
+  const end =
+    lastInterval.endAt == null
+      ? null
+      : DateTime.fromISO(lastInterval.endAt).setZone(SG_TIMEZONE);
+  const startDate = intl.formatDate(start.toJSDate(), {
+    day: 'numeric',
+    month: 'long',
+    timeZone: SG_TIMEZONE,
+    year: 'numeric',
+  });
+
+  if (end == null) {
+    return intl.formatMessage(
+      {
+        id: 'issue.period_since',
+        defaultMessage: 'since {startDate}',
+      },
+      { startDate },
+    );
+  }
+
+  if (start.hasSame(end, 'day')) {
+    return startDate;
+  }
+
+  return intl.formatMessage(
+    {
+      id: 'issue.period_range',
+      defaultMessage: '{startDate} to {endDate}',
+    },
+    {
+      startDate,
+      endDate: intl.formatDate(end.toJSDate(), {
+        day: 'numeric',
+        month: 'long',
+        timeZone: SG_TIMEZONE,
+        year: 'numeric',
+      }),
+    },
+  );
+}
 
 export const Route = createFileRoute('/{-$lang}/issues/$issueId/')({
   component: IssuePage,
@@ -66,7 +140,7 @@ export const Route = createFileRoute('/{-$lang}/issues/$issueId/')({
       {
         stationCount,
         lineNames: intl.formatList(lineNames),
-        period: 'WIP',
+        period: formatIssueDescriptionPeriod(issue.intervals, intl),
       },
     );
 

--- a/app/routes/{-$lang}/statistics/index.tsx
+++ b/app/routes/{-$lang}/statistics/index.tsx
@@ -33,6 +33,11 @@ export const Route = createFileRoute('/{-$lang}/statistics/')({
       id: 'general.statistics',
       defaultMessage: 'Statistics',
     });
+    const description = intl.formatMessage({
+      id: 'site.statistics.subtitle',
+      defaultMessage:
+        "Historical performance data and analytics for Singapore's MRT and LRT network",
+    });
 
     return {
       meta: [
@@ -40,8 +45,16 @@ export const Route = createFileRoute('/{-$lang}/statistics/')({
           title,
         },
         {
+          name: 'description',
+          content: description,
+        },
+        {
           property: 'og:title',
           content: title,
+        },
+        {
+          property: 'og:description',
+          content: description,
         },
         {
           property: 'og:type',

--- a/app/routes/{-$lang}/system-map.tsx
+++ b/app/routes/{-$lang}/system-map.tsx
@@ -59,6 +59,11 @@ export const Route = createFileRoute('/{-$lang}/system-map')({
       id: 'general.system_map',
       defaultMessage: 'System Map',
     });
+    const description = intl.formatMessage({
+      id: 'site.system_map.subtitle',
+      defaultMessage:
+        "Real-time status and network overview of Singapore's MRT and LRT system",
+    });
 
     return {
       meta: [
@@ -66,8 +71,16 @@ export const Route = createFileRoute('/{-$lang}/system-map')({
           title,
         },
         {
+          name: 'description',
+          content: description,
+        },
+        {
           property: 'og:title',
           content: title,
+        },
+        {
+          property: 'og:description',
+          content: description,
         },
         {
           property: 'og:type',

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -4334,15 +4334,33 @@ export async function getSitemapData() {
   const earliest = firstDates.sort((a, b) => a.toMillis() - b.toMillis())[0];
   const latest = firstDates.sort((a, b) => b.toMillis() - a.toMillis())[0];
 
+  const monthEarliest =
+    earliest != null ? isoDate(earliest.startOf('month')) : isoDate(nowSg());
+  const monthLatest =
+    latest != null ? isoDate(latest.startOf('month')) : isoDate(nowSg());
+  const monthEarliestDateTime = DateTime.fromISO(monthEarliest, {
+    zone: SG_TIMEZONE,
+  });
+  const monthLatestDateTime = DateTime.fromISO(monthLatest, {
+    zone: SG_TIMEZONE,
+  });
+  const coverageRows = await getOperationalFactCoverageDatesInRange(
+    monthEarliestDateTime,
+    monthLatestDateTime.endOf('month'),
+  );
+  const operationalFactCoverageStartDate =
+    await getOperationalFactCoverageStartDate();
+
   return {
     lineIds: Object.keys(dataset.included.lines).sort(),
     stationIds: Object.keys(dataset.included.stations).sort(),
     operatorIds: Object.keys(dataset.included.operators).sort(),
     issueIds: issues.map((issue) => issue.id),
-    monthEarliest:
-      earliest != null ? isoDate(earliest.startOf('month')) : isoDate(nowSg()),
-    monthLatest:
-      latest != null ? isoDate(latest.startOf('month')) : isoDate(nowSg()),
+    monthEarliest,
+    monthLatest,
+    operationalFactCoverageDates: coverageRows.map((row) => row.date),
+    operationalFactCoverageStartDate,
+    currentDate: isoDate(nowSg()),
   };
 }
 

--- a/app/util/sitemap.functions.test.ts
+++ b/app/util/sitemap.functions.test.ts
@@ -38,6 +38,12 @@ describe('agent Markdown discovery', () => {
       issueIds: ['issue-1'],
       monthEarliest: '2026-04-01',
       monthLatest: '2026-05-01',
+      operationalFactCoverageDates: [
+        ...buildCoverageDates('2026-04'),
+        ...buildCoverageDates('2026-05'),
+      ],
+      operationalFactCoverageStartDate: '2026-04-01',
+      currentDate: '2026-06-21',
     });
 
     expect(paths).toEqual(
@@ -59,4 +65,65 @@ describe('agent Markdown discovery', () => {
     expect(paths).not.toContain('/issues/issue-1/index.md');
     expect(paths.every((path) => !path.endsWith('.md'))).toBe(true);
   });
+
+  it('excludes redirect-only history paths from the XML sitemap', () => {
+    const paths = buildSitemapPaths({
+      lineIds: [],
+      stationIds: [],
+      operatorIds: [],
+      issueIds: [],
+      monthEarliest: '2026-06-01',
+      monthLatest: '2026-06-01',
+      operationalFactCoverageDates: [],
+      operationalFactCoverageStartDate: null,
+      currentDate: '2026-06-21',
+    });
+
+    expect(paths).not.toContain('/history');
+  });
+
+  it('skips historical months that cannot render from facts or legacy fallback', () => {
+    const paths = buildSitemapPaths({
+      lineIds: [],
+      stationIds: [],
+      operatorIds: [],
+      issueIds: [],
+      monthEarliest: '2026-04-01',
+      monthLatest: '2026-06-01',
+      operationalFactCoverageDates: buildCoverageDates('2026-06'),
+      operationalFactCoverageStartDate: '2026-05-01',
+      currentDate: '2026-06-21',
+    });
+
+    expect(paths).toContain('/history/2026/04');
+    expect(paths).not.toContain('/history/2026/05');
+    expect(paths).toContain('/history/2026/06');
+  });
+
+  it('only includes history year paths when the full year can render', () => {
+    const paths = buildSitemapPaths({
+      lineIds: [],
+      stationIds: [],
+      operatorIds: [],
+      issueIds: [],
+      monthEarliest: '2025-01-01',
+      monthLatest: '2025-01-01',
+      operationalFactCoverageDates: buildCoverageDates('2025-01'),
+      operationalFactCoverageStartDate: '2025-01-01',
+      currentDate: '2026-06-21',
+    });
+
+    expect(paths).toContain('/history/2025/01');
+    expect(paths).not.toContain('/history/2025');
+  });
 });
+
+function buildCoverageDates(month: string) {
+  const [year, monthNumber] = month.split('-').map(Number);
+  const dateCount = new Date(year, monthNumber, 0).getDate();
+
+  return Array.from({ length: dateCount }, (_, index) => {
+    const day = String(index + 1).padStart(2, '0');
+    return `${month}-${day}`;
+  });
+}

--- a/app/util/sitemap.functions.ts
+++ b/app/util/sitemap.functions.ts
@@ -13,6 +13,9 @@ interface SitemapPathData {
   issueIds: string[];
   monthEarliest: string;
   monthLatest: string;
+  operationalFactCoverageDates: string[];
+  operationalFactCoverageStartDate: string | null;
+  currentDate: string;
 }
 
 function buildEntries(path: string, rootUrl: string): Element {
@@ -96,14 +99,11 @@ export function buildSitemapPaths({
   issueIds,
   monthEarliest,
   monthLatest,
+  operationalFactCoverageDates,
+  operationalFactCoverageStartDate,
+  currentDate,
 }: SitemapPathData) {
-  const paths: string[] = [
-    '/',
-    '/history',
-    '/statistics',
-    '/system-map',
-    '/about',
-  ];
+  const paths: string[] = ['/', '/statistics', '/system-map', '/about'];
 
   for (const lineId of lineIds) {
     paths.push(`/lines/${lineId}`);
@@ -120,6 +120,12 @@ export function buildSitemapPaths({
 
   const monthEarliestDateTime = DateTime.fromISO(monthEarliest);
   const monthLatestDateTime = DateTime.fromISO(monthLatest);
+  const coverageDates = new Set(operationalFactCoverageDates);
+  const coverageStartDateTime =
+    operationalFactCoverageStartDate == null
+      ? null
+      : DateTime.fromISO(operationalFactCoverageStartDate);
+  const currentDateTime = DateTime.fromISO(currentDate);
   const interval = Interval.fromDateTimes(
     monthEarliestDateTime,
     monthLatestDateTime.plus({ month: 1 }),
@@ -130,14 +136,117 @@ export function buildSitemapPaths({
       continue;
     }
 
-    if (!paths.includes(`/history/${monthDateTime.toFormat('yyyy')}`)) {
-      paths.push(`/history/${monthDateTime.toFormat('yyyy')}`);
+    if (
+      !isHistoryMonthRenderable({
+        coverageDates,
+        coverageStartDateTime,
+        currentDateTime,
+        monthDateTime,
+      })
+    ) {
+      continue;
     }
 
+    const yearPath = `/history/${monthDateTime.toFormat('yyyy')}`;
+    if (
+      !paths.includes(yearPath) &&
+      isHistoryYearRenderable({
+        coverageDates,
+        coverageStartDateTime,
+        currentDateTime,
+        yearDateTime: monthDateTime.startOf('year'),
+      })
+    ) {
+      paths.push(yearPath);
+    }
     paths.push(
       `/history/${monthDateTime.toFormat('yyyy')}/${monthDateTime.toFormat('MM')}`,
     );
   }
 
   return paths;
+}
+
+function isHistoryMonthRenderable({
+  coverageDates,
+  coverageStartDateTime,
+  currentDateTime,
+  monthDateTime,
+}: {
+  coverageDates: Set<string>;
+  coverageStartDateTime: DateTime | null;
+  currentDateTime: DateTime;
+  monthDateTime: DateTime;
+}) {
+  const monthStart = monthDateTime.startOf('month');
+  const monthEnd = monthStart.endOf('month').startOf('day');
+
+  return isHistoryDateRangeRenderable({
+    coverageDates,
+    coverageStartDateTime,
+    currentDateTime,
+    rangeStart: monthStart,
+    rangeEnd: monthEnd,
+  });
+}
+
+function isHistoryYearRenderable({
+  coverageDates,
+  coverageStartDateTime,
+  currentDateTime,
+  yearDateTime,
+}: {
+  coverageDates: Set<string>;
+  coverageStartDateTime: DateTime | null;
+  currentDateTime: DateTime;
+  yearDateTime: DateTime;
+}) {
+  const yearStart = yearDateTime.startOf('year');
+  const yearEnd = yearStart.plus({ years: 1 }).minus({ days: 1 });
+
+  return isHistoryDateRangeRenderable({
+    coverageDates,
+    coverageStartDateTime,
+    currentDateTime,
+    rangeStart: yearStart,
+    rangeEnd: yearEnd,
+  });
+}
+
+function isHistoryDateRangeRenderable({
+  coverageDates,
+  coverageStartDateTime,
+  currentDateTime,
+  rangeStart,
+  rangeEnd,
+}: {
+  coverageDates: Set<string>;
+  coverageStartDateTime: DateTime | null;
+  currentDateTime: DateTime;
+  rangeStart: DateTime;
+  rangeEnd: DateTime;
+}) {
+  const start = rangeStart.startOf('day');
+  const end = rangeEnd.startOf('day');
+  const today = currentDateTime.startOf('day');
+
+  if (end >= today) {
+    return true;
+  }
+
+  if (
+    coverageStartDateTime != null &&
+    start < coverageStartDateTime.startOf('day')
+  ) {
+    return true;
+  }
+
+  for (let cursor = start; cursor <= end; cursor = cursor.plus({ day: 1 })) {
+    const date = cursor.toISODate();
+    if (date == null || !coverageDates.has(date)) {
+      return false;
+    }
+  }
+
+  return true;
 }

--- a/docs/plans/active/seo-remediation.md
+++ b/docs/plans/active/seo-remediation.md
@@ -165,6 +165,15 @@ Exit criteria:
 - 2026-06-21: Local SEO audit completed and plan created. `npm run verify`
   passed after rerunning outside the sandbox because the first sandboxed run
   failed when `tsx` could not create its IPC pipe.
+- 2026-06-21: Started Phase 1 and Phase 3 remediation. Sitemap generation now
+  omits the redirect-only `/history` URL and skips historical month URLs when
+  operational fact coverage is missing and the legacy fallback cannot render the
+  route. Static/history pages now emit meta descriptions and `og:description`,
+  the history year route uses the concrete year in `og:url`, and issue
+  descriptions no longer emit the `WIP` period placeholder.
+- 2026-06-21: Local sitemap crawl against the Vite dev server checked 47
+  sitemap URLs with redirects disabled and a 25-second per-URL timeout. Every
+  URL returned `200`, with no redirects or timeouts.
 
 ## Decision Log
 
@@ -173,6 +182,10 @@ Exit criteria:
   tests and avoiding duplicate search crawl surfaces.
 - 2026-06-21: Treat crawl-clean sitemap output as the first phase because search
   engines should not be directed to redirects, errors, or very slow pages.
+- 2026-06-21: Exclude historical month URLs from the XML sitemap when the month
+  is before today, lacks full operational fact coverage, and is not before the
+  operational fact coverage start date. This mirrors the history route's
+  degraded-render fallback and avoids advertising known `500` month pages.
 
 ## Validation
 

--- a/lang/en-SG.json
+++ b/lang/en-SG.json
@@ -295,5 +295,10 @@
   "status.ongoing_infra": "Infrastructure",
   "status.ongoing_maintenance": "Maintenance",
   "status.operational": "Operational",
-  "status.service_ended": "Outside Service Hours"
+  "status.service_ended": "Outside Service Hours",
+  "issue.period_range": "{startDate} to {endDate}",
+  "issue.period_since": "since {startDate}",
+  "issue.period_unknown": "an unknown date",
+  "site.history.month_description": "Past service disruptions and maintenance events in {startAt, date, ::MMMM yyyy}.",
+  "site.history.year_description": "Past service disruptions and maintenance events in {startAt, date, ::yyyy}."
 }

--- a/lang/ms.json
+++ b/lang/ms.json
@@ -303,5 +303,10 @@
   "report.train_station_search_placeholder": "Cari mengikut stesen seterusnya, destinasi, atau kod",
   "report.turnstile_unavailable": "Pengesahan tidak dapat dimuatkan. Sila segar semula dan cuba lagi.",
   "report.verification": "Pengesahan penghantaran",
-  "station.report_cta": "Laporkan isu di sini"
+  "station.report_cta": "Laporkan isu di sini",
+  "issue.period_range": "{startDate} hingga {endDate}",
+  "issue.period_since": "sejak {startDate}",
+  "issue.period_unknown": "tarikh yang tidak diketahui",
+  "site.history.month_description": "Gangguan perkhidmatan dan acara penyelenggaraan lalu pada {startAt, date, ::MMMM yyyy}.",
+  "site.history.year_description": "Gangguan perkhidmatan dan acara penyelenggaraan lalu pada {startAt, date, ::yyyy}."
 }

--- a/lang/ta.json
+++ b/lang/ta.json
@@ -303,5 +303,10 @@
   "report.train_station_search_placeholder": "அடுத்த நிலையம், இலக்கு அல்லது குறியீட்டால் தேடவும்",
   "report.turnstile_unavailable": "சரிபார்ப்பை ஏற்ற முடியவில்லை. புதுப்பித்து மீண்டும் முயற்சிக்கவும்.",
   "report.verification": "சமர்ப்பிப்பு சரிபார்ப்பு",
-  "station.report_cta": "இங்கே சிக்கலைத் தெரிவிக்கவும்"
+  "station.report_cta": "இங்கே சிக்கலைத் தெரிவிக்கவும்",
+  "issue.period_range": "{startDate} முதல் {endDate} வரை",
+  "issue.period_since": "{startDate} முதல்",
+  "issue.period_unknown": "தெரியாத தேதி",
+  "site.history.month_description": "{startAt, date, ::MMMM yyyy} காலத்திலான கடந்தகால சேவை தடைகள் மற்றும் பராமரிப்பு நிகழ்வுகள்.",
+  "site.history.year_description": "{startAt, date, ::yyyy} ஆண்டின் கடந்தகால சேவை தடைகள் மற்றும் பராமரிப்பு நிகழ்வுகள்."
 }

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -303,5 +303,10 @@
   "report.train_station_search_placeholder": "按下一站、目的地或代码搜索",
   "report.turnstile_unavailable": "无法加载验证。请刷新后重试。",
   "report.verification": "提交验证",
-  "station.report_cta": "在此报告问题"
+  "station.report_cta": "在此报告问题",
+  "issue.period_range": "{startDate}至{endDate}",
+  "issue.period_since": "自 {startDate} 起",
+  "issue.period_unknown": "未知日期",
+  "site.history.month_description": "{startAt, date, ::MMMM yyyy} 的过往服务中断和维护事件。",
+  "site.history.year_description": "{startAt, date, ::yyyy} 年的过往服务中断和维护事件。"
 }


### PR DESCRIPTION
## Summary

- filter the XML sitemap so it does not advertise the redirect-only history index or history months that cannot render from available operational fact coverage
- add sitemap regression tests for Markdown exclusion, redirect-only history paths, and missing month coverage
- add missing meta descriptions and Open Graph descriptions to static/history pages, fix the history year `og:url`, and replace issue metadata `WIP` period text with a real interval/date label
- extract the new SEO/issue period intl strings into `en-SG` and add translations for `zh-Hans`, `ms`, and `ta`
- update the active SEO remediation plan with implementation and local crawl results

## Validation

- `npx formatjs extract 'app/**/*.{ts,tsx}' --ignore '**/*.d.ts' --out-file /tmp/mrtdown-en-SG.extract.json --format simple`
- `npm run verify`
- local Vite sitemap crawl checked 47 sitemap URLs with redirects disabled and a 25-second per-URL timeout; all returned `200` with no redirects or timeouts

Note: the initial sandboxed `npm run verify` attempt hit the known `tsx` IPC pipe `EPERM`; the same command passed outside the sandbox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added localized meta descriptions and Open Graph descriptions to static pages and history pages for improved SEO.
  * Issue pages now display actual affected time periods instead of placeholder text.

* **Bug Fixes**
  * Fixed sitemap to exclude redirect-only history URLs and skip historical months without operational data.
  * Improved page metadata consistency across the application.

* **Tests**
  * Added test coverage for sitemap path generation with operational fact coverage validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->