### PR TITLE
fix: centralize SEO metadata

### DIFF
--- a/app/helpers/seo.test.ts
+++ b/app/helpers/seo.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildLocaleAlternates,
+  buildLocalizedAbsoluteUrl,
+  buildSeoMetadata,
+  normalizeSeoPath,
+} from './seo';
+
+const ROOT_URL = 'https://www.mrtdown.org';
+
+describe('SEO helpers', () => {
+  it('normalizes route paths for canonical URLs', () => {
+    expect(normalizeSeoPath('')).toBe('/');
+    expect(normalizeSeoPath('/')).toBe('/');
+    expect(normalizeSeoPath('statistics')).toBe('/statistics');
+    expect(normalizeSeoPath('/statistics/')).toBe('/statistics');
+  });
+
+  it('builds localized absolute URLs from canonical route paths', () => {
+    expect(buildLocalizedAbsoluteUrl('/', 'en-SG', ROOT_URL)).toBe(
+      'https://www.mrtdown.org/',
+    );
+    expect(buildLocalizedAbsoluteUrl('/', 'zh-Hans', ROOT_URL)).toBe(
+      'https://www.mrtdown.org/zh-Hans/',
+    );
+    expect(buildLocalizedAbsoluteUrl('/statistics/', 'ms', ROOT_URL)).toBe(
+      'https://www.mrtdown.org/ms/statistics',
+    );
+  });
+
+  it('builds full locale alternates with x-default', () => {
+    expect(buildLocaleAlternates('/about', ROOT_URL)).toEqual([
+      { hreflang: 'en-SG', href: 'https://www.mrtdown.org/about' },
+      { hreflang: 'zh-Hans', href: 'https://www.mrtdown.org/zh-Hans/about' },
+      { hreflang: 'ms', href: 'https://www.mrtdown.org/ms/about' },
+      { hreflang: 'ta', href: 'https://www.mrtdown.org/ta/about' },
+      { hreflang: 'x-default', href: 'https://www.mrtdown.org/about' },
+    ]);
+  });
+
+  it('uses the same localized URL for canonical and og:url', () => {
+    const metadata = buildSeoMetadata({
+      lang: 'ta',
+      path: '/history/2026/',
+      rootUrl: ROOT_URL,
+    });
+
+    expect(metadata.canonicalUrl).toBe(
+      'https://www.mrtdown.org/ta/history/2026',
+    );
+    expect(metadata.ogUrl).toBe(metadata.canonicalUrl);
+    expect(metadata.ogImage).toBe('https://www.mrtdown.org/og_image.png');
+    expect(metadata.links).toContainEqual({
+      rel: 'canonical',
+      href: metadata.canonicalUrl,
+    });
+    expect(metadata.links).toContainEqual({
+      rel: 'alternate',
+      hrefLang: 'x-default',
+      href: 'https://www.mrtdown.org/history/2026',
+    });
+  });
+});

--- a/app/helpers/seo.ts
+++ b/app/helpers/seo.ts
@@ -1,0 +1,102 @@
+import { LANGUAGES } from '~/constants';
+import { buildLocaleAwareLink } from './buildLocaleAwareLink';
+
+type SeoLanguage = (typeof LANGUAGES)[number];
+
+export interface LocaleAlternate {
+  href: string;
+  hreflang: SeoLanguage | 'x-default';
+}
+
+export interface SeoHeadMetadata {
+  canonicalUrl: string;
+  links: Array<
+    | {
+        href: string;
+        rel: 'canonical';
+      }
+    | {
+        href: string;
+        hrefLang: LocaleAlternate['hreflang'];
+        rel: 'alternate';
+      }
+  >;
+  ogImage: string;
+  ogUrl: string;
+}
+
+export function buildSeoMetadata({
+  lang = 'en-SG',
+  path,
+  rootUrl,
+}: {
+  lang?: string;
+  path: string;
+  rootUrl: string;
+}): SeoHeadMetadata {
+  const normalizedPath = normalizeSeoPath(path);
+  const canonicalUrl = buildLocalizedAbsoluteUrl(normalizedPath, lang, rootUrl);
+
+  return {
+    canonicalUrl,
+    links: [
+      {
+        rel: 'canonical',
+        href: canonicalUrl,
+      },
+      ...buildLocaleAlternates(normalizedPath, rootUrl).map((alternate) => {
+        return {
+          rel: 'alternate' as const,
+          hrefLang: alternate.hreflang,
+          href: alternate.href,
+        };
+      }),
+    ],
+    ogImage: new URL('/og_image.png', rootUrl).toString(),
+    ogUrl: canonicalUrl,
+  };
+}
+
+export function buildLocaleAlternates(
+  path: string,
+  rootUrl: string,
+): LocaleAlternate[] {
+  const normalizedPath = normalizeSeoPath(path);
+
+  return [
+    ...LANGUAGES.map((lang) => {
+      return {
+        hreflang: lang,
+        href: buildLocalizedAbsoluteUrl(normalizedPath, lang, rootUrl),
+      };
+    }),
+    {
+      hreflang: 'x-default' as const,
+      href: buildLocalizedAbsoluteUrl(normalizedPath, 'en-SG', rootUrl),
+    },
+  ];
+}
+
+export function buildLocalizedAbsoluteUrl(
+  path: string,
+  lang: string,
+  rootUrl: string,
+) {
+  return new URL(
+    buildLocaleAwareLink(normalizeSeoPath(path), lang),
+    rootUrl,
+  ).toString();
+}
+
+export function normalizeSeoPath(path: string) {
+  const trimmedPath = path.trim();
+  if (trimmedPath === '' || trimmedPath === '/') {
+    return '/';
+  }
+
+  const prefixedPath = trimmedPath.startsWith('/')
+    ? trimmedPath
+    : `/${trimmedPath}`;
+
+  return prefixedPath.endsWith('/') ? prefixedPath.slice(0, -1) : prefixedPath;
+}

--- a/app/routes/{-$lang}/about.tsx
+++ b/app/routes/{-$lang}/about.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { createIntl, FormattedMessage } from 'react-intl';
-import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
+import { buildSeoMetadata } from '~/helpers/seo';
 
 export const Route = createFileRoute('/{-$lang}/about')({
   component: AboutPage,
@@ -10,11 +10,7 @@ export const Route = createFileRoute('/{-$lang}/about')({
 
     const rootUrl = import.meta.env.VITE_ROOT_URL;
 
-    const ogUrl = new URL(
-      buildLocaleAwareLink('/about', lang),
-      rootUrl,
-    ).toString();
-    const ogImage = new URL('/og_image.png', rootUrl).toString();
+    const seo = buildSeoMetadata({ path: '/about', lang, rootUrl });
 
     const intl = createIntl({
       locale: lang,
@@ -32,6 +28,7 @@ export const Route = createFileRoute('/{-$lang}/about')({
     });
 
     return {
+      links: seo.links,
       meta: [
         {
           title,
@@ -54,11 +51,11 @@ export const Route = createFileRoute('/{-$lang}/about')({
         },
         {
           property: 'og:url',
-          content: ogUrl,
+          content: seo.ogUrl,
         },
         {
           property: 'og:image',
-          content: ogImage,
+          content: seo.ogImage,
         },
       ],
     };

--- a/app/routes/{-$lang}/community-reports/$kind/$sourceId.tsx
+++ b/app/routes/{-$lang}/community-reports/$kind/$sourceId.tsx
@@ -18,8 +18,8 @@ import {
   type MessageDescriptor,
   useIntl,
 } from 'react-intl';
-import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
 import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
+import { buildSeoMetadata } from '~/helpers/seo';
 import { assert } from '~/util/assert';
 import {
   getCrowdReportSourceFn,
@@ -92,24 +92,23 @@ export const Route = createFileRoute(
       },
       { count: source.reportCount },
     );
-    const ogUrl = new URL(
-      buildLocaleAwareLink(
-        `/community-reports/${encodeURIComponent(kind)}/${encodeURIComponent(
-          sourceId,
-        )}`,
-        lang,
-      ),
+    const seo = buildSeoMetadata({
+      path: `/community-reports/${encodeURIComponent(kind)}/${encodeURIComponent(
+        sourceId,
+      )}`,
+      lang,
       rootUrl,
-    ).toString();
+    });
 
     return {
+      links: seo.links,
       meta: [
         { title },
         { name: 'description', content: description },
         { property: 'og:title', content: title },
         { property: 'og:description', content: description },
         { property: 'og:type', content: 'website' },
-        { property: 'og:url', content: ogUrl },
+        { property: 'og:url', content: seo.ogUrl },
       ],
     };
   },

--- a/app/routes/{-$lang}/history/$year/$month.tsx
+++ b/app/routes/{-$lang}/history/$year/$month.tsx
@@ -16,7 +16,7 @@ import {
 } from 'react-intl';
 import { IssueCard } from '~/components/IssueCard';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
-import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
+import { buildSeoMetadata } from '~/helpers/seo';
 import { useHydrated } from '~/hooks/useHydrated';
 import {
   getIssuesHistoryYearMonthFn,
@@ -77,13 +77,14 @@ export const Route = createFileRoute('/{-$lang}/history/$year/$month')({
 
     const rootUrl = import.meta.env.VITE_ROOT_URL;
 
-    const ogUrl = new URL(
-      buildLocaleAwareLink(`/history/${year}/${month}`, lang),
+    const seo = buildSeoMetadata({
+      path: `/history/${year}/${month}`,
+      lang,
       rootUrl,
-    ).toString();
-    const ogImage = new URL('/og_image.png', rootUrl).toString();
+    });
 
     return {
+      links: seo.links,
       meta: [
         {
           title,
@@ -106,11 +107,11 @@ export const Route = createFileRoute('/{-$lang}/history/$year/$month')({
         },
         {
           property: 'og:url',
-          content: ogUrl,
+          content: seo.ogUrl,
         },
         {
           property: 'og:image',
-          content: ogImage,
+          content: seo.ogImage,
         },
       ],
     };

--- a/app/routes/{-$lang}/history/$year/index.tsx
+++ b/app/routes/{-$lang}/history/$year/index.tsx
@@ -16,7 +16,7 @@ import {
   FormattedNumber,
 } from 'react-intl';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
-import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
+import { buildSeoMetadata } from '~/helpers/seo';
 import { useHydrated } from '~/hooks/useHydrated';
 import {
   getIssuesHistoryYearFn,
@@ -47,11 +47,11 @@ export const Route = createFileRoute('/{-$lang}/history/$year/')({
 
     const rootUrl = import.meta.env.VITE_ROOT_URL;
 
-    const ogUrl = new URL(
-      buildLocaleAwareLink(`/history/${ctx.params.year}`, lang),
+    const seo = buildSeoMetadata({
+      path: `/history/${ctx.params.year}`,
+      lang,
       rootUrl,
-    ).toString();
-    const ogImage = new URL('/og_image.png', rootUrl).toString();
+    });
 
     const intl = createIntl({
       locale: lang,
@@ -83,6 +83,7 @@ export const Route = createFileRoute('/{-$lang}/history/$year/')({
     );
 
     return {
+      links: seo.links,
       meta: [
         {
           title,
@@ -105,11 +106,11 @@ export const Route = createFileRoute('/{-$lang}/history/$year/')({
         },
         {
           property: 'og:url',
-          content: ogUrl,
+          content: seo.ogUrl,
         },
         {
           property: 'og:image',
-          content: ogImage,
+          content: seo.ogImage,
         },
       ],
     };

--- a/app/routes/{-$lang}/index.tsx
+++ b/app/routes/{-$lang}/index.tsx
@@ -11,6 +11,7 @@ import { HOME_OVERVIEW_INITIAL_DATE_COUNT, LANGUAGES } from '~/constants';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
 import { useCrowdReportsFeatureEnabled } from '~/contexts/CrowdReportsFeature';
 import { getDateCountForViewport } from '~/helpers/getDateCountForViewport';
+import { buildSeoMetadata } from '~/helpers/seo';
 import { useViewport } from '~/hooks/useViewport';
 import { getOverviewFn } from '~/util/overview.functions';
 import { CurrentAdvisoriesSection } from '../../components/CurrentAdvisoriesSection';
@@ -72,14 +73,10 @@ export const Route = createFileRoute('/{-$lang}/')({
     const rootUrl = import.meta.env.VITE_ROOT_URL;
     assert(rootUrl != null, 'VITE_ROOT_URL is not set');
 
-    let ogUrl = new URL(rootUrl).toString();
-    if (lang !== 'en-SG') {
-      ogUrl = new URL(`/${lang}/`, rootUrl).toString();
-    }
-
-    const ogImage = new URL('/og_image.png', rootUrl).toString();
+    const seo = buildSeoMetadata({ path: '/', lang, rootUrl });
 
     return {
+      links: seo.links,
       meta: [
         {
           title,
@@ -98,11 +95,11 @@ export const Route = createFileRoute('/{-$lang}/')({
         },
         {
           property: 'og:url',
-          content: ogUrl,
+          content: seo.ogUrl,
         },
         {
           property: 'og:image',
-          content: ogImage,
+          content: seo.ogImage,
         },
         {
           property: 'og:site_name',

--- a/app/routes/{-$lang}/issues/$issueId/index.tsx
+++ b/app/routes/{-$lang}/issues/$issueId/index.tsx
@@ -14,8 +14,8 @@ import {
 } from 'react-intl';
 import { IssueTypeLabels } from '~/constants';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
-import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
 import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
+import { buildSeoMetadata } from '~/helpers/seo';
 import type { IssueInterval } from '~/types';
 import { assert } from '~/util/assert';
 import { getIssueFn } from '~/util/issue.functions';
@@ -104,11 +104,11 @@ export const Route = createFileRoute('/{-$lang}/issues/$issueId/')({
     const title = getLocalizedTranslation(issue.title, lang);
 
     const rootUrl = import.meta.env.VITE_ROOT_URL;
-    const ogUrl = new URL(
-      buildLocaleAwareLink(`/issues/${issueId}`, lang),
+    const seo = buildSeoMetadata({
+      path: `/issues/${issueId}`,
+      lang,
       rootUrl,
-    ).toString();
-    const ogImage = new URL('/og_image.png', rootUrl).toString();
+    });
 
     const { default: messages } = await import(
       `../../../../../lang/${lang}.json`
@@ -145,6 +145,7 @@ export const Route = createFileRoute('/{-$lang}/issues/$issueId/')({
     );
 
     return {
+      links: seo.links,
       meta: [
         {
           title,
@@ -167,11 +168,11 @@ export const Route = createFileRoute('/{-$lang}/issues/$issueId/')({
         },
         {
           property: 'og:url',
-          content: ogUrl,
+          content: seo.ogUrl,
         },
         {
           property: 'og:image',
-          content: ogImage,
+          content: seo.ogImage,
         },
         {
           'script:ld+json': {
@@ -189,8 +190,8 @@ export const Route = createFileRoute('/{-$lang}/issues/$issueId/')({
                 location: 'Singapore Public Transport',
               };
             }),
-            url: ogUrl,
-            image: ogImage,
+            url: seo.ogUrl,
+            image: seo.ogImage,
           },
         },
       ],

--- a/app/routes/{-$lang}/lines/$lineId/index.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/index.tsx
@@ -19,8 +19,8 @@ import {
 } from '~/components/ProfileWidgetSkeletons';
 import { useCrowdReportsFeatureEnabled } from '~/contexts/CrowdReportsFeature';
 import { buildIssueTypeCountString } from '~/helpers/buildIssueTypeCountString';
-import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
 import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
+import { buildSeoMetadata } from '~/helpers/seo';
 import type { Station } from '~/types';
 import { assert } from '~/util/assert';
 import type { LineBranch } from '~/util/db.queries';
@@ -117,11 +117,11 @@ export const Route = createFileRoute('/{-$lang}/lines/$lineId/')({
 
     const rootUrl = import.meta.env.VITE_ROOT_URL;
 
-    const ogUrl = new URL(
-      buildLocaleAwareLink(`/lines/${lineId}`, lang),
+    const seo = buildSeoMetadata({
+      path: `/lines/${lineId}`,
+      lang,
       rootUrl,
-    ).toString();
-    const ogImage = new URL('/og_image.png', rootUrl).toString();
+    });
 
     const { default: messages } = await import(
       `../../../../../lang/${lang}.json`
@@ -171,6 +171,7 @@ export const Route = createFileRoute('/{-$lang}/lines/$lineId/')({
         );
 
     return {
+      links: seo.links,
       meta: [
         {
           title,
@@ -193,11 +194,11 @@ export const Route = createFileRoute('/{-$lang}/lines/$lineId/')({
         },
         {
           property: 'og:url',
-          content: ogUrl,
+          content: seo.ogUrl,
         },
         {
           property: 'og:image',
-          content: ogImage,
+          content: seo.ogImage,
         },
         {
           'script:ld+json': {
@@ -228,7 +229,7 @@ export const Route = createFileRoute('/{-$lang}/lines/$lineId/')({
                 });
               }),
             },
-            url: ogUrl,
+            url: seo.ogUrl,
           },
         },
       ],

--- a/app/routes/{-$lang}/operators/$operatorId/index.tsx
+++ b/app/routes/{-$lang}/operators/$operatorId/index.tsx
@@ -15,9 +15,9 @@ import {
   ProfileTrendCardSkeleton,
 } from '~/components/ProfileWidgetSkeletons';
 import { buildIssueTypeCountString } from '~/helpers/buildIssueTypeCountString';
-import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
 import { getDateCountForViewport } from '~/helpers/getDateCountForViewport';
 import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
+import { buildSeoMetadata } from '~/helpers/seo';
 import { useHydrated } from '~/hooks/useHydrated';
 import { useViewport } from '~/hooks/useViewport';
 import { getOperatorProfileFn } from '~/util/operator.functions';
@@ -105,11 +105,11 @@ export const Route = createFileRoute('/{-$lang}/operators/$operatorId/')({
 
     const rootUrl = import.meta.env.VITE_ROOT_URL;
 
-    const ogUrl = new URL(
-      buildLocaleAwareLink(`/operators/${ctx.params.operatorId}`, lang),
+    const seo = buildSeoMetadata({
+      path: `/operators/${ctx.params.operatorId}`,
+      lang,
       rootUrl,
-    ).toString();
-    const ogImage = new URL('/og_image.png', rootUrl).toString();
+    });
 
     // Build enhanced Organization structured data
     const organizationData: Record<string, unknown> = {
@@ -127,6 +127,7 @@ export const Route = createFileRoute('/{-$lang}/operators/$operatorId/')({
     }
 
     return {
+      links: seo.links,
       meta: [
         {
           title,
@@ -149,11 +150,11 @@ export const Route = createFileRoute('/{-$lang}/operators/$operatorId/')({
         },
         {
           property: 'og:url',
-          content: ogUrl,
+          content: seo.ogUrl,
         },
         {
           property: 'og:image',
-          content: ogImage,
+          content: seo.ogImage,
         },
         {
           property: 'og:image:alt',
@@ -181,7 +182,7 @@ export const Route = createFileRoute('/{-$lang}/operators/$operatorId/')({
         },
         {
           name: 'twitter:image',
-          content: ogImage,
+          content: seo.ogImage,
         },
         {
           'script:ld+json': {
@@ -190,8 +191,8 @@ export const Route = createFileRoute('/{-$lang}/operators/$operatorId/')({
             name: title,
             description,
             mainEntity: organizationData,
-            url: ogUrl,
-            image: ogImage,
+            url: seo.ogUrl,
+            image: seo.ogImage,
             inLanguage: lang,
           },
         },

--- a/app/routes/{-$lang}/report.tsx
+++ b/app/routes/{-$lang}/report.tsx
@@ -40,8 +40,8 @@ import {
 } from 'react-intl';
 import { z } from 'zod';
 import { BetaBadge } from '~/components/BetaBadge';
-import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
 import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
+import { buildSeoMetadata } from '~/helpers/seo';
 import { assert } from '~/util/assert';
 import { getCrowdReportFormOptionsFn } from '~/util/report.functions';
 
@@ -254,20 +254,16 @@ export const Route = createFileRoute('/{-$lang}/report')({
       defaultMessage:
         'Share a concise community report about MRT or LRT delays, crowding, skipped stops, or service issues.',
     });
+    const seo = buildSeoMetadata({ path: '/report', lang, rootUrl });
 
     return {
+      links: seo.links,
       meta: [
         { title },
         { name: 'description', content: description },
         { property: 'og:title', content: title },
         { property: 'og:description', content: description },
-        {
-          property: 'og:url',
-          content: new URL(
-            buildLocaleAwareLink('/report', lang),
-            rootUrl,
-          ).toString(),
-        },
+        { property: 'og:url', content: seo.ogUrl },
       ],
     };
   },

--- a/app/routes/{-$lang}/stations/$stationId.tsx
+++ b/app/routes/{-$lang}/stations/$stationId.tsx
@@ -21,8 +21,8 @@ import { LineTypeLabels, StationStructureTypeLabels } from '~/constants';
 import { useCrowdReportsFeatureEnabled } from '~/contexts/CrowdReportsFeature';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
 import { buildIssueTypeCountString } from '~/helpers/buildIssueTypeCountString';
-import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
 import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
+import { buildSeoMetadata } from '~/helpers/seo';
 import { useHydrated } from '~/hooks/useHydrated';
 import type { IncludedEntities, Station } from '~/types';
 import { getStationProfileFn } from '~/util/station.functions';
@@ -154,13 +154,14 @@ export const Route = createFileRoute('/{-$lang}/stations/$stationId')({
         );
 
     const rootUrl = import.meta.env.VITE_ROOT_URL;
-    const ogUrl = new URL(
-      buildLocaleAwareLink(`/stations/${stationId}`, lang),
+    const seo = buildSeoMetadata({
+      path: `/stations/${stationId}`,
+      lang,
       rootUrl,
-    ).toString();
-    const ogImage = new URL('/og_image.png', rootUrl).toString();
+    });
 
     return {
+      links: seo.links,
       meta: [
         {
           title,
@@ -183,11 +184,11 @@ export const Route = createFileRoute('/{-$lang}/stations/$stationId')({
         },
         {
           property: 'og:url',
-          content: ogUrl,
+          content: seo.ogUrl,
         },
         {
           property: 'og:image',
-          content: ogImage,
+          content: seo.ogImage,
         },
         {
           'script:ld+json': {
@@ -200,8 +201,8 @@ export const Route = createFileRoute('/{-$lang}/stations/$stationId')({
               alternateName: Array.from(stationCodes).join(' / '),
               description,
             },
-            url: ogUrl,
-            image: ogImage,
+            url: seo.ogUrl,
+            image: seo.ogImage,
           },
         },
       ],

--- a/app/routes/{-$lang}/statistics/index.tsx
+++ b/app/routes/{-$lang}/statistics/index.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { createIntl, FormattedMessage } from 'react-intl';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
-import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
+import { buildSeoMetadata } from '~/helpers/seo';
 import { getStatisticsFn } from '~/util/statistics.functions';
 import { StatisticsGrid } from './components/StatisticsGrid';
 import { StatisticsGridSkeleton } from './components/StatisticsGrid/components/StatisticsGridSkeleton';
@@ -18,11 +18,7 @@ export const Route = createFileRoute('/{-$lang}/statistics/')({
 
     const rootUrl = import.meta.env.VITE_ROOT_URL;
 
-    const ogUrl = new URL(
-      buildLocaleAwareLink('/statistics', lang),
-      rootUrl,
-    ).toString();
-    const ogImage = new URL('/og_image.png', rootUrl).toString();
+    const seo = buildSeoMetadata({ path: '/statistics', lang, rootUrl });
 
     const intl = createIntl({
       locale: lang,
@@ -40,6 +36,7 @@ export const Route = createFileRoute('/{-$lang}/statistics/')({
     });
 
     return {
+      links: seo.links,
       meta: [
         {
           title,
@@ -62,11 +59,11 @@ export const Route = createFileRoute('/{-$lang}/statistics/')({
         },
         {
           property: 'og:url',
-          content: ogUrl,
+          content: seo.ogUrl,
         },
         {
           property: 'og:image',
-          content: ogImage,
+          content: seo.ogImage,
         },
       ],
     };

--- a/app/routes/{-$lang}/system-map.tsx
+++ b/app/routes/{-$lang}/system-map.tsx
@@ -19,8 +19,8 @@ import { MapJan2012 } from '~/components/StationMap/components/MapJan2012';
 import { MapNov2017 } from '~/components/StationMap/components/MapNov2017';
 import { MapNov2024 } from '~/components/StationMap/components/MapNov2024';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
-import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
 import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
+import { buildSeoMetadata } from '~/helpers/seo';
 import { getSystemMapFn } from '~/util/system-map.functions';
 
 const SYSTEM_MAP_SNAPSHOTS = {
@@ -44,11 +44,7 @@ export const Route = createFileRoute('/{-$lang}/system-map')({
 
     const rootUrl = import.meta.env.VITE_ROOT_URL;
 
-    const ogUrl = new URL(
-      buildLocaleAwareLink('/system-map', lang),
-      rootUrl,
-    ).toString();
-    const ogImage = new URL('/og_image.png', rootUrl).toString();
+    const seo = buildSeoMetadata({ path: '/system-map', lang, rootUrl });
 
     const intl = createIntl({
       locale: lang,
@@ -66,6 +62,7 @@ export const Route = createFileRoute('/{-$lang}/system-map')({
     });
 
     return {
+      links: seo.links,
       meta: [
         {
           title,
@@ -88,11 +85,11 @@ export const Route = createFileRoute('/{-$lang}/system-map')({
         },
         {
           property: 'og:url',
-          content: ogUrl,
+          content: seo.ogUrl,
         },
         {
           property: 'og:image',
-          content: ogImage,
+          content: seo.ogImage,
         },
       ],
     };

--- a/app/util/sitemap.functions.ts
+++ b/app/util/sitemap.functions.ts
@@ -2,8 +2,7 @@ import { createServerFn } from '@tanstack/react-start';
 import { DateTime, Interval } from 'luxon';
 import type { Element, Root } from 'xast';
 import { toXml } from 'xast-util-to-xml';
-import { LANGUAGES_NON_DEFAULT } from '~/constants';
-import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
+import { buildLocaleAlternates } from '~/helpers/seo';
 import { getSitemapData } from './db.queries';
 
 interface SitemapPathData {
@@ -48,14 +47,14 @@ function buildEntries(path: string, rootUrl: string): Element {
         attributes: {},
         children: [{ type: 'text', value: '0.7' }],
       },
-      ...LANGUAGES_NON_DEFAULT.map((lang) => {
+      ...buildLocaleAlternates(path, rootUrl).map((alternate) => {
         return {
           type: 'element' as const,
           name: 'xhtml:link',
           attributes: {
             rel: 'alternate',
-            hreflang: lang,
-            href: new URL(buildLocaleAwareLink(path, lang), rootUrl).toString(),
+            hreflang: alternate.hreflang,
+            href: alternate.href,
           },
           children: [],
         } satisfies Element;

--- a/docs/plans/active/seo-remediation.md
+++ b/docs/plans/active/seo-remediation.md
@@ -174,6 +174,11 @@ Exit criteria:
 - 2026-06-21: Local sitemap crawl against the Vite dev server checked 47
   sitemap URLs with redirects disabled and a 25-second per-URL timeout. Every
   URL returned `200`, with no redirects or timeouts.
+- 2026-06-21: Continued Phase 2 by adding a shared SEO helper for canonical
+  URLs, Open Graph URLs, locale alternates, and head links. Home, static,
+  history, entity, report, and community report pages now emit canonical links
+  and full `hreflang` alternates from the same route path policy. XML sitemap
+  alternates now use the same helper and include `en-SG` plus `x-default`.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Add a shared SEO helper for canonical URLs, Open Graph URLs, locale alternates, and page head links.
- Wire the helper into public HTML routes so canonical links, locale alternates, and `og:url` are generated from the same path policy.
- Update XML sitemap alternates to use the shared helper and include `en-SG` plus `x-default`.
- Record Phase 2 progress in the active SEO remediation plan.

## Validation

- `npm run test:run -- app/helpers/seo.test.ts app/util/sitemap.functions.test.ts`
- `npm run verify` passed outside the sandbox after sandboxed `tsx` IPC failed with `listen EPERM` during `db:generate:check`.
- Local sitemap crawl checked 48 sitemap `<loc>` URLs with `badCount: 0`.
- Representative metadata sample checked 11 pages for title, description, canonical link, locale alternates, and `og:url` with `badCount: 0`.