### PR TITLE
chore: add SEO smoke check

### DIFF
--- a/app/scripts/checkSeo.ts
+++ b/app/scripts/checkSeo.ts
@@ -1,0 +1,365 @@
+export {};
+
+type HtmlHead = {
+  canonicalUrls: string[];
+  descriptions: string[];
+  hrefLangs: string[];
+  ogUrls: string[];
+  title: string | null;
+};
+
+type SeoFailure = {
+  label: string;
+  message: string;
+  url: string;
+};
+
+const DEFAULT_BASE_URL = 'http://localhost:3000';
+const DEFAULT_TIMEOUT_MS = 25_000;
+const REQUIRED_HREFLANGS = ['en-SG', 'zh-Hans', 'ms', 'ta', 'x-default'];
+const PLACEHOLDER_DESCRIPTION_PATTERNS = [/\bWIP\b/i];
+
+function getBaseUrl() {
+  const baseUrl =
+    process.argv[2] ?? process.env.VITE_ROOT_URL ?? DEFAULT_BASE_URL;
+  return baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+}
+
+function getTimeoutMs() {
+  const timeoutMs = Number.parseInt(
+    process.env.SEO_CHECK_TIMEOUT_MS ?? `${DEFAULT_TIMEOUT_MS}`,
+    10,
+  );
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new Error('SEO_CHECK_TIMEOUT_MS must be a positive integer.');
+  }
+  return timeoutMs;
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, {
+      ...init,
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function decodeEntities(value: string) {
+  return value
+    .replaceAll('&amp;', '&')
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&apos;', "'");
+}
+
+function extractSitemapLocs(xml: string) {
+  return [...xml.matchAll(/<loc>([\s\S]*?)<\/loc>/gi)].map((match) =>
+    decodeEntities(match[1]?.trim() ?? ''),
+  );
+}
+
+function extractAttribute(tag: string, attributeName: string) {
+  const pattern = new RegExp(
+    `${attributeName}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`,
+    'i',
+  );
+  const match = tag.match(pattern);
+  return decodeEntities(match?.[1] ?? match?.[2] ?? '');
+}
+
+function getHeadTag(html: string) {
+  return html.match(/<head[^>]*>([\s\S]*?)<\/head>/i)?.[1] ?? '';
+}
+
+function parseHtmlHead(html: string): HtmlHead {
+  const head = getHeadTag(html);
+  const title = head.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1]?.trim();
+  const canonicalUrls: string[] = [];
+  const descriptions: string[] = [];
+  const hrefLangs: string[] = [];
+  const ogUrls: string[] = [];
+
+  for (const match of head.matchAll(/<(meta|link)\b[^>]*>/gi)) {
+    const tag = match[0];
+    if (tag.startsWith('<link')) {
+      const rel = extractAttribute(tag, 'rel').toLowerCase();
+      if (rel === 'canonical') {
+        canonicalUrls.push(extractAttribute(tag, 'href'));
+      }
+      if (rel === 'alternate') {
+        const hrefLang = extractAttribute(tag, 'hreflang');
+        if (hrefLang !== '') {
+          hrefLangs.push(hrefLang);
+        }
+      }
+      continue;
+    }
+
+    const name = extractAttribute(tag, 'name').toLowerCase();
+    const property = extractAttribute(tag, 'property').toLowerCase();
+    if (name === 'description') {
+      descriptions.push(extractAttribute(tag, 'content'));
+    }
+    if (property === 'og:url') {
+      ogUrls.push(extractAttribute(tag, 'content'));
+    }
+  }
+
+  return {
+    canonicalUrls,
+    descriptions,
+    hrefLangs,
+    ogUrls,
+    title: title == null || title === '' ? null : decodeEntities(title),
+  };
+}
+
+function getPathname(url: string) {
+  return new URL(url).pathname;
+}
+
+function getRepresentativeUrls(baseUrl: string, sitemapLocs: string[]) {
+  const requiredPaths = [
+    '/',
+    '/zh-Hans',
+    '/about',
+    '/statistics',
+    '/system-map',
+    '/history/2026',
+    '/history/2026/06',
+  ];
+  const sitemapPaths = sitemapLocs.map((loc) => ({
+    loc,
+    pathname: getPathname(loc),
+  }));
+  const dynamicPrefixes = ['/lines/', '/stations/', '/operators/', '/issues/'];
+  const representativeUrls = requiredPaths.map((path) =>
+    new URL(path, baseUrl).toString(),
+  );
+  const missingDynamicPrefixes: string[] = [];
+
+  for (const prefix of dynamicPrefixes) {
+    const match = sitemapPaths.find(({ pathname }) =>
+      pathname.startsWith(prefix),
+    );
+    if (match == null) {
+      missingDynamicPrefixes.push(prefix);
+      continue;
+    }
+    representativeUrls.push(match.loc);
+  }
+
+  return { missingDynamicPrefixes, representativeUrls };
+}
+
+function validateHead(url: string, head: HtmlHead): SeoFailure[] {
+  const failures: SeoFailure[] = [];
+
+  if (head.title == null) {
+    failures.push({ label: 'head', url, message: 'missing <title>' });
+  }
+
+  if (head.descriptions.length !== 1) {
+    failures.push({
+      label: 'head',
+      url,
+      message: `expected one meta description, found ${head.descriptions.length}`,
+    });
+  }
+
+  for (const description of head.descriptions) {
+    if (description.trim() === '') {
+      failures.push({
+        label: 'head',
+        url,
+        message: 'meta description is empty',
+      });
+    }
+    for (const pattern of PLACEHOLDER_DESCRIPTION_PATTERNS) {
+      if (pattern.test(description)) {
+        failures.push({
+          label: 'head',
+          url,
+          message: `meta description contains placeholder text: ${description}`,
+        });
+      }
+    }
+  }
+
+  if (head.canonicalUrls.length !== 1) {
+    failures.push({
+      label: 'head',
+      url,
+      message: `expected one canonical link, found ${head.canonicalUrls.length}`,
+    });
+  }
+
+  if (head.ogUrls.length !== 1) {
+    failures.push({
+      label: 'head',
+      url,
+      message: `expected one og:url, found ${head.ogUrls.length}`,
+    });
+  }
+
+  if (
+    head.canonicalUrls.length === 1 &&
+    head.ogUrls.length === 1 &&
+    head.canonicalUrls[0] !== head.ogUrls[0]
+  ) {
+    failures.push({
+      label: 'head',
+      url,
+      message: `canonical URL does not match og:url: ${head.canonicalUrls[0]} != ${head.ogUrls[0]}`,
+    });
+  }
+
+  for (const hrefLang of REQUIRED_HREFLANGS) {
+    if (!head.hrefLangs.includes(hrefLang)) {
+      failures.push({
+        label: 'head',
+        url,
+        message: `missing hreflang alternate: ${hrefLang}`,
+      });
+    }
+  }
+
+  return failures;
+}
+
+async function checkSitemap(baseUrl: string, timeoutMs: number) {
+  const sitemapUrl = new URL('/sitemap.xml', baseUrl).toString();
+  const response = await fetchWithTimeout(
+    sitemapUrl,
+    {
+      headers: { accept: 'application/xml,text/xml;q=0.9,*/*;q=0.1' },
+      redirect: 'manual',
+    },
+    timeoutMs,
+  );
+
+  if (response.status !== 200) {
+    throw new Error(`Sitemap returned ${response.status}: ${sitemapUrl}`);
+  }
+
+  const locs = extractSitemapLocs(await response.text());
+  if (locs.length === 0) {
+    throw new Error(`Sitemap contains no <loc> entries: ${sitemapUrl}`);
+  }
+
+  return locs;
+}
+
+async function checkSitemapUrls(locs: string[], timeoutMs: number) {
+  const failures: SeoFailure[] = [];
+
+  for (const loc of locs) {
+    try {
+      const response = await fetchWithTimeout(
+        loc,
+        {
+          headers: { accept: 'text/html,*/*;q=0.1' },
+          redirect: 'manual',
+        },
+        timeoutMs,
+      );
+      if (response.status !== 200) {
+        failures.push({
+          label: 'sitemap',
+          url: loc,
+          message: `expected 200 without redirect, got ${response.status}`,
+        });
+      }
+    } catch (error) {
+      failures.push({
+        label: 'sitemap',
+        url: loc,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return failures;
+}
+
+async function checkRepresentativePages(
+  urls: string[],
+  timeoutMs: number,
+): Promise<SeoFailure[]> {
+  const failures: SeoFailure[] = [];
+
+  for (const url of urls) {
+    try {
+      const response = await fetchWithTimeout(
+        url,
+        {
+          headers: { accept: 'text/html' },
+          redirect: 'manual',
+        },
+        timeoutMs,
+      );
+      if (response.status !== 200) {
+        failures.push({
+          label: 'head',
+          url,
+          message: `expected 200 without redirect, got ${response.status}`,
+        });
+        continue;
+      }
+
+      failures.push(...validateHead(url, parseHtmlHead(await response.text())));
+    } catch (error) {
+      failures.push({
+        label: 'head',
+        url,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return failures;
+}
+
+async function main() {
+  const baseUrl = getBaseUrl();
+  const timeoutMs = getTimeoutMs();
+  const sitemapLocs = await checkSitemap(baseUrl, timeoutMs);
+  const { missingDynamicPrefixes, representativeUrls } = getRepresentativeUrls(
+    baseUrl,
+    sitemapLocs,
+  );
+  const failures: SeoFailure[] = [
+    ...(await checkSitemapUrls(sitemapLocs, timeoutMs)),
+    ...(await checkRepresentativePages(representativeUrls, timeoutMs)),
+    ...missingDynamicPrefixes.map((prefix) => ({
+      label: 'representative',
+      url: new URL(prefix, baseUrl).toString(),
+      message: `sitemap has no URL matching ${prefix}`,
+    })),
+  ];
+
+  if (failures.length > 0) {
+    console.table(failures);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `SEO check passed: ${sitemapLocs.length} sitemap URLs and ${representativeUrls.length} representative pages checked.`,
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/docs/plans/active/seo-remediation.md
+++ b/docs/plans/active/seo-remediation.md
@@ -139,8 +139,8 @@ Exit criteria:
 
 ### Phase 4: Add SEO Smoke Checks
 
-- Add a local script, for example `npm run seo:check`, that fetches the local
-  sitemap and validates each `<loc>`.
+- Add a local script, `npm run seo:check`, that fetches the local sitemap and
+  validates each `<loc>`.
 - Validate that representative HTML pages include:
   - `<title>`
   - meta description
@@ -179,6 +179,11 @@ Exit criteria:
   history, entity, report, and community report pages now emit canonical links
   and full `hreflang` alternates from the same route path policy. XML sitemap
   alternates now use the same helper and include `en-SG` plus `x-default`.
+- 2026-06-21: Started Phase 4 by adding `npm run seo:check`. The check expects
+  a running app, fetches `/sitemap.xml`, verifies each sitemap `<loc>` returns
+  `200` without redirects, and validates representative HTML pages for title,
+  meta description, canonical link, `hreflang` alternates, `og:url`, and the
+  known `WIP` description placeholder.
 
 ## Decision Log
 
@@ -197,7 +202,10 @@ Exit criteria:
 Before handing back implementation work for this plan:
 
 - Run `npm run verify`.
-- Run the SEO smoke-check command once it exists.
+- Run `npm run seo:check` against a running local or deployed app. Pass the base
+  URL as the first argument or set `VITE_ROOT_URL`; otherwise the script checks
+  `http://localhost:3000`. Set `SEO_CHECK_TIMEOUT_MS` to override the default
+  25-second per-request timeout.
 - Manually or programmatically crawl `http://localhost:3000/sitemap.xml` and
   confirm every `<loc>` returns `200` without redirects.
 - Sample at least these rendered pages for title, description, canonical,

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "biome lint .",
     "format:check": "biome format .",
+    "seo:check": "tsx app/scripts/checkSeo.ts",
     "perf:routes": "tsx app/scripts/checkRouteTimings.ts",
     "verify": "npm run typecheck && npm run lint && npm run format:check && npm run db:generate:check && npm run test:run",
     "verify:strict": "npm run typecheck && npm run lint && npm run format:check && npm run db:generate:check && npm run test:run",


### PR DESCRIPTION
## Summary

Adds a dependency-free SEO smoke-check script and exposes it as `npm run seo:check`.

The script checks a running app by fetching `/sitemap.xml`, verifying every sitemap `<loc>` returns `200` without redirects, and sampling representative HTML pages for title, meta description, canonical link, locale alternates, `og:url`, and the known `WIP` description placeholder regression.

The SEO remediation plan now documents the Phase 4 progress and how to run the smoke check against a local or deployed base URL.

## Validation

- `npm run seo:check -- http://127.0.0.1:3000`
- `npm run verify`

Note: both commands were run successfully. `seo:check` checked 48 sitemap URLs and 11 representative pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SEO verification script accessible via `npm run seo:check`
  * Validates sitemap URL accessibility with proper HTTP responses and no redirects
  * Checks for required HTML metadata elements including title, canonical links, og:url, and language alternates
  * Reports all validation failures in structured format

* **Documentation**
  * Updated SEO remediation plan with operational instructions for the new verification script

<!-- end of auto-generated comment: release notes by coderabbit.ai -->