### PR TITLE
fix: hide inactive crowd report lines

### DIFF
--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -623,8 +623,8 @@ export const stationCodesTable = pgTable(
       .references(() => stationsTable.id)
       .notNull(),
     code: text('code').notNull(),
-    started_at: date('started_at').notNull(),
-    ended_at: date('ended_at'),
+    started_at: date('started_at', { mode: 'string' }).notNull(),
+    ended_at: date('ended_at', { mode: 'string' }),
     structure_type: stationStructureTypeEnum().notNull(),
     ...timestampColumns,
   },

--- a/app/routes/{-$lang}/report.tsx
+++ b/app/routes/{-$lang}/report.tsx
@@ -861,22 +861,12 @@ function ReportPage() {
 
   useEffect(() => {
     const activeLineIds = selectedLineIds.filter(
-      (lineId) =>
-        lineById[lineId] != null &&
-        (reportScope !== 'station' ||
-          selectedStation == null ||
-          selectedStation.lineIds.includes(lineId)),
+      (lineId) => lineById[lineId] != null,
     );
     if (activeLineIds.length !== selectedLineIds.length) {
       setSelectedLineIds(activeLineIds);
     }
-  }, [
-    lineById,
-    reportScope,
-    selectedLineIds,
-    selectedStation,
-    setSelectedLineIds,
-  ]);
+  }, [lineById, selectedLineIds, setSelectedLineIds]);
 
   useEffect(() => {
     if (selectedStationId == null || selectedStation != null) {
@@ -892,6 +882,20 @@ function ReportPage() {
       return current;
     });
   }, [selectedStation, selectedStationId]);
+
+  useEffect(() => {
+    if (
+      reportScope !== 'train' ||
+      selectedStation == null ||
+      selectedLineIds.length === 0 ||
+      selectedStation.lineIds.some((lineId) => selectedLineIds.includes(lineId))
+    ) {
+      return;
+    }
+    setReportContext((current) =>
+      current.scope === 'train' ? { ...current, stationId: null } : current,
+    );
+  }, [reportScope, selectedLineIds, selectedStation]);
 
   useEffect(() => {
     if (rangeStartStationId.length > 0 && rangeStartStation == null) {

--- a/app/routes/{-$lang}/report.tsx
+++ b/app/routes/{-$lang}/report.tsx
@@ -43,7 +43,10 @@ import { BetaBadge } from '~/components/BetaBadge';
 import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 import { buildSeoMetadata } from '~/helpers/seo';
 import { assert } from '~/util/assert';
-import { getCrowdReportFormOptionsFn } from '~/util/report.functions';
+import {
+  buildCrowdReportFormOptions,
+  getCrowdReportFormOptionsFn,
+} from '~/util/report.functions';
 
 type ReportSearch = {
   lineId?: string;
@@ -279,6 +282,16 @@ function datetimeLocalToSgIso(value: string) {
   }).toISO();
 }
 
+function datetimeLocalToSgDate(value: string) {
+  return (
+    DateTime.fromFormat(value, "yyyy-MM-dd'T'HH:mm", {
+      zone: 'Asia/Singapore',
+    }).toISODate() ??
+    DateTime.now().setZone('Asia/Singapore').toISODate() ??
+    new Date().toISOString().slice(0, 10)
+  );
+}
+
 function getReportContextLineIds(context: ReportContext) {
   if (context.scope === 'line' || context.scope === 'station') {
     return context.lineIds;
@@ -297,8 +310,7 @@ function getReportContextStationId(context: ReportContext) {
 }
 
 function ReportPage() {
-  const { lineDirections, lineStationPaths, lines, stations } =
-    Route.useLoaderData();
+  const loaderData = Route.useLoaderData();
   const search = Route.useSearch() as ReportSearch;
   const intl = useIntl();
   const posthog = usePostHog();
@@ -312,24 +324,38 @@ function ReportPage() {
   const observedAtRef = useRef<HTMLInputElement>(null);
   const turnstileRef = useRef<HTMLDivElement>(null);
   const turnstileWidgetIdRef = useRef<string | undefined>(undefined);
+  const initialObservedAtRef = useRef<string | null>(null);
+  initialObservedAtRef.current ??= toSgDatetimeLocal(DateTime.now());
+  const initialOptions = useMemo(
+    () =>
+      buildCrowdReportFormOptions({
+        referenceDate: datetimeLocalToSgDate(
+          initialObservedAtRef.current ?? '',
+        ),
+        ...loaderData.formOptionRows,
+      }),
+    [loaderData.formOptionRows],
+  );
   const prefilledLineId =
-    search.lineId != null && lines.some((line) => line.id === search.lineId)
+    search.lineId != null &&
+    initialOptions.lines.some((line) => line.id === search.lineId)
       ? search.lineId
       : undefined;
   const prefilledStationId =
     search.stationId != null &&
-    stations.some((station) => station.id === search.stationId)
+    initialOptions.stations.some((station) => station.id === search.stationId)
       ? search.stationId
       : undefined;
   const [reportContext, setReportContext] = useState<ReportContext>(() => {
     const base: ReportContextBase = {
-      observedAt: toSgDatetimeLocal(DateTime.now()),
+      observedAt:
+        initialObservedAtRef.current ?? toSgDatetimeLocal(DateTime.now()),
       effect: '',
       delayMinutes: '',
       isStillHappening: true,
     };
     if (prefilledStationId != null) {
-      const prefilledStation = stations.find(
+      const prefilledStation = initialOptions.stations.find(
         (station) => station.id === prefilledStationId,
       );
       const lineIds =
@@ -401,6 +427,15 @@ function ReportPage() {
     };
   }, [intl]);
 
+  const observedAt = reportContext.observedAt;
+  const { lineDirections, lineStationPaths, lines, stations } = useMemo(
+    () =>
+      buildCrowdReportFormOptions({
+        referenceDate: datetimeLocalToSgDate(observedAt),
+        ...loaderData.formOptionRows,
+      }),
+    [loaderData.formOptionRows, observedAt],
+  );
   const lineById = useMemo(
     () => Object.fromEntries(lines.map((line) => [line.id, line])),
     [lines],
@@ -416,7 +451,6 @@ function ReportPage() {
     ? stationById[selectedStationId]
     : undefined;
   const selectedStationIds = selectedStationId ? [selectedStationId] : [];
-  const observedAt = reportContext.observedAt;
   const effect = reportContext.effect;
   const delayMinutes = reportContext.delayMinutes;
   const isStillHappening = reportContext.isStillHappening;
@@ -806,6 +840,44 @@ function ReportPage() {
       return current;
     });
   };
+
+  useEffect(() => {
+    const activeLineIds = selectedLineIds.filter(
+      (lineId) => lineById[lineId] != null,
+    );
+    if (activeLineIds.length !== selectedLineIds.length) {
+      setSelectedLineIds(activeLineIds);
+    }
+  }, [lineById, selectedLineIds, setSelectedLineIds]);
+
+  useEffect(() => {
+    if (selectedStationId == null || selectedStation != null) {
+      return;
+    }
+    setReportContext((current) => {
+      if (current.scope === 'station') {
+        return { ...current, stationId: null, lineIds: [] };
+      }
+      if (current.scope === 'train') {
+        return { ...current, stationId: null };
+      }
+      return current;
+    });
+  }, [selectedStation, selectedStationId]);
+
+  useEffect(() => {
+    if (rangeStartStationId.length > 0 && rangeStartStation == null) {
+      setRangeStartStationId('');
+    }
+    if (rangeEndStationId.length > 0 && rangeEndStation == null) {
+      setRangeEndStationId('');
+    }
+  }, [
+    rangeEndStation,
+    rangeEndStationId,
+    rangeStartStation,
+    rangeStartStationId,
+  ]);
 
   const chooseReportScope = (scope: ReportScope) => {
     clearFieldError('scope');

--- a/app/routes/{-$lang}/report.tsx
+++ b/app/routes/{-$lang}/report.tsx
@@ -283,10 +283,13 @@ function datetimeLocalToSgIso(value: string) {
 }
 
 function datetimeLocalToSgDate(value: string) {
+  return DateTime.fromFormat(value, "yyyy-MM-dd'T'HH:mm", {
+    zone: 'Asia/Singapore',
+  }).toISODate();
+}
+
+function fallbackSgDate() {
   return (
-    DateTime.fromFormat(value, "yyyy-MM-dd'T'HH:mm", {
-      zone: 'Asia/Singapore',
-    }).toISODate() ??
     DateTime.now().setZone('Asia/Singapore').toISODate() ??
     new Date().toISOString().slice(0, 10)
   );
@@ -326,12 +329,16 @@ function ReportPage() {
   const turnstileWidgetIdRef = useRef<string | undefined>(undefined);
   const initialObservedAtRef = useRef<string | null>(null);
   initialObservedAtRef.current ??= toSgDatetimeLocal(DateTime.now());
+  const initialReferenceDateRef = useRef<string | null>(null);
+  initialReferenceDateRef.current ??=
+    datetimeLocalToSgDate(initialObservedAtRef.current) ?? fallbackSgDate();
+  const lastValidReferenceDateRef = useRef<string | null>(
+    initialReferenceDateRef.current,
+  );
   const initialOptions = useMemo(
     () =>
       buildCrowdReportFormOptions({
-        referenceDate: datetimeLocalToSgDate(
-          initialObservedAtRef.current ?? '',
-        ),
+        referenceDate: initialReferenceDateRef.current ?? fallbackSgDate(),
         ...loaderData.formOptionRows,
       }),
     [loaderData.formOptionRows],
@@ -428,13 +435,24 @@ function ReportPage() {
   }, [intl]);
 
   const observedAt = reportContext.observedAt;
+  const observedAtReferenceDate = datetimeLocalToSgDate(observedAt);
+  const formOptionsReferenceDate =
+    observedAtReferenceDate ??
+    lastValidReferenceDateRef.current ??
+    initialReferenceDateRef.current ??
+    fallbackSgDate();
+  useEffect(() => {
+    if (observedAtReferenceDate != null) {
+      lastValidReferenceDateRef.current = observedAtReferenceDate;
+    }
+  }, [observedAtReferenceDate]);
   const { lineDirections, lineStationPaths, lines, stations } = useMemo(
     () =>
       buildCrowdReportFormOptions({
-        referenceDate: datetimeLocalToSgDate(observedAt),
+        referenceDate: formOptionsReferenceDate,
         ...loaderData.formOptionRows,
       }),
-    [loaderData.formOptionRows, observedAt],
+    [formOptionsReferenceDate, loaderData.formOptionRows],
   );
   const lineById = useMemo(
     () => Object.fromEntries(lines.map((line) => [line.id, line])),
@@ -843,12 +861,22 @@ function ReportPage() {
 
   useEffect(() => {
     const activeLineIds = selectedLineIds.filter(
-      (lineId) => lineById[lineId] != null,
+      (lineId) =>
+        lineById[lineId] != null &&
+        (reportScope !== 'station' ||
+          selectedStation == null ||
+          selectedStation.lineIds.includes(lineId)),
     );
     if (activeLineIds.length !== selectedLineIds.length) {
       setSelectedLineIds(activeLineIds);
     }
-  }, [lineById, selectedLineIds, setSelectedLineIds]);
+  }, [
+    lineById,
+    reportScope,
+    selectedLineIds,
+    selectedStation,
+    setSelectedLineIds,
+  ]);
 
   useEffect(() => {
     if (selectedStationId == null || selectedStation != null) {

--- a/app/util/crowdReports.test.ts
+++ b/app/util/crowdReports.test.ts
@@ -265,6 +265,7 @@ function makeFakePublicSignalDb() {
 
 function makeFakeReferenceDb(selectResults: unknown[][]) {
   const nextSelectResult = () => selectResults.shift() ?? [];
+  const whereCalls: unknown[] = [];
   const selectBuilder = {
     from() {
       return this;
@@ -272,7 +273,8 @@ function makeFakeReferenceDb(selectResults: unknown[][]) {
     innerJoin() {
       return this;
     },
-    where() {
+    where(condition: unknown) {
+      whereCalls.push(condition);
       return Promise.resolve(nextSelectResult());
     },
   };
@@ -283,6 +285,7 @@ function makeFakeReferenceDb(selectResults: unknown[][]) {
         return selectBuilder;
       },
     },
+    whereCalls,
   };
 }
 
@@ -832,6 +835,7 @@ describe('findMissingCrowdReportReferences', () => {
     const fake = makeFakeReferenceDb([
       [{ id: 'BPLRT' }],
       [{ id: 'BP6' }],
+      [{ id: 'BP6' }],
       [
         {
           id: 'rev-current',
@@ -861,6 +865,7 @@ describe('findMissingCrowdReportReferences', () => {
     await expect(
       findMissingCrowdReportReferences(fake.db as never, {
         lineIds: ['BPLRT'],
+        observedAt: '2026-05-24T12:30:00.000+08:00',
         stationIds: [],
         directionStationId: 'BP6',
       }),
@@ -874,6 +879,7 @@ describe('findMissingCrowdReportReferences', () => {
   it('rejects a direction station that is not offered for the selected line', async () => {
     const fake = makeFakeReferenceDb([
       [{ id: 'BPLRT' }],
+      [{ id: 'BP6' }],
       [{ id: 'BP6' }],
       [
         {
@@ -904,6 +910,7 @@ describe('findMissingCrowdReportReferences', () => {
     await expect(
       findMissingCrowdReportReferences(fake.db as never, {
         lineIds: ['BPLRT'],
+        observedAt: '2026-05-24T12:30:00.000+08:00',
         stationIds: [],
         directionStationId: 'BP6',
       }),
@@ -918,11 +925,13 @@ describe('findMissingCrowdReportReferences', () => {
     const fake = makeFakeReferenceDb([
       [{ id: 'BPLRT' }, { id: 'CCL' }],
       [{ id: 'BP6' }],
+      [{ id: 'BP6' }],
     ]);
 
     await expect(
       findMissingCrowdReportReferences(fake.db as never, {
         lineIds: ['BPLRT', 'CCL'],
+        observedAt: '2026-05-24T12:30:00.000+08:00',
         stationIds: [],
         directionStationId: 'BP6',
       }),
@@ -931,6 +940,49 @@ describe('findMissingCrowdReportReferences', () => {
       stationIds: [],
       directionStationIds: ['BP6'],
     });
+  });
+
+  it('rejects stations without an active station code', async () => {
+    const fake = makeFakeReferenceDb([[{ id: 'BP6' }], []]);
+
+    await expect(
+      findMissingCrowdReportReferences(fake.db as never, {
+        lineIds: [],
+        observedAt: '2026-05-24T12:30:00.000+08:00',
+        stationIds: ['BP6'],
+      }),
+    ).resolves.toEqual({
+      lineIds: [],
+      stationIds: ['BP6'],
+      directionStationIds: [],
+    });
+  });
+
+  it('checks line and station activity against the observed Singapore date', async () => {
+    const fake = makeFakeReferenceDb([
+      [{ id: 'BPLRT' }],
+      [{ id: 'BP6' }],
+      [{ id: 'BP6' }],
+    ]);
+
+    await expect(
+      findMissingCrowdReportReferences(fake.db as never, {
+        lineIds: ['BPLRT'],
+        observedAt: '2026-05-23T23:30:00-05:00',
+        stationIds: ['BP6'],
+      }),
+    ).resolves.toEqual({
+      lineIds: [],
+      stationIds: [],
+      directionStationIds: [],
+    });
+
+    const dialect = new PgDialect();
+    const lineWhereSql = dialect.sqlToQuery(fake.whereCalls[0] as SQL);
+    const stationCodeWhereSql = dialect.sqlToQuery(fake.whereCalls[2] as SQL);
+
+    expect(lineWhereSql.params).toContain('2026-05-24');
+    expect(stationCodeWhereSql.params).toContain('2026-05-24');
   });
 });
 

--- a/app/util/crowdReports.test.ts
+++ b/app/util/crowdReports.test.ts
@@ -835,7 +835,7 @@ describe('findMissingCrowdReportReferences', () => {
     const fake = makeFakeReferenceDb([
       [{ id: 'BPLRT' }],
       [{ id: 'BP6' }],
-      [{ id: 'BP6' }],
+      [{ lineId: 'BPLRT', stationId: 'BP6' }],
       [
         {
           id: 'rev-current',
@@ -880,7 +880,7 @@ describe('findMissingCrowdReportReferences', () => {
     const fake = makeFakeReferenceDb([
       [{ id: 'BPLRT' }],
       [{ id: 'BP6' }],
-      [{ id: 'BP6' }],
+      [{ lineId: 'BPLRT', stationId: 'BP6' }],
       [
         {
           id: 'rev-current',
@@ -925,7 +925,10 @@ describe('findMissingCrowdReportReferences', () => {
     const fake = makeFakeReferenceDb([
       [{ id: 'BPLRT' }, { id: 'CCL' }],
       [{ id: 'BP6' }],
-      [{ id: 'BP6' }],
+      [
+        { lineId: 'BPLRT', stationId: 'BP6' },
+        { lineId: 'CCL', stationId: 'BP6' },
+      ],
     ]);
 
     await expect(
@@ -958,11 +961,31 @@ describe('findMissingCrowdReportReferences', () => {
     });
   });
 
+  it('rejects stations without an active station code on every submitted line', async () => {
+    const fake = makeFakeReferenceDb([
+      [{ id: 'BPLRT' }, { id: 'CCL' }],
+      [{ id: 'BP6' }],
+      [{ lineId: 'CCL', stationId: 'BP6' }],
+    ]);
+
+    await expect(
+      findMissingCrowdReportReferences(fake.db as never, {
+        lineIds: ['BPLRT', 'CCL'],
+        observedAt: '2026-05-24T12:30:00.000+08:00',
+        stationIds: ['BP6'],
+      }),
+    ).resolves.toEqual({
+      lineIds: [],
+      stationIds: ['BP6'],
+      directionStationIds: [],
+    });
+  });
+
   it('checks line and station activity against the observed Singapore date', async () => {
     const fake = makeFakeReferenceDb([
       [{ id: 'BPLRT' }],
       [{ id: 'BP6' }],
-      [{ id: 'BP6' }],
+      [{ lineId: 'BPLRT', stationId: 'BP6' }],
     ]);
 
     await expect(
@@ -980,9 +1003,11 @@ describe('findMissingCrowdReportReferences', () => {
     const dialect = new PgDialect();
     const lineWhereSql = dialect.sqlToQuery(fake.whereCalls[0] as SQL);
     const stationCodeWhereSql = dialect.sqlToQuery(fake.whereCalls[2] as SQL);
+    const countReferenceDateParams = (params: unknown[]) =>
+      params.filter((param) => param === '2026-05-24').length;
 
-    expect(lineWhereSql.params).toContain('2026-05-24');
-    expect(stationCodeWhereSql.params).toContain('2026-05-24');
+    expect(countReferenceDateParams(lineWhereSql.params)).toBe(2);
+    expect(countReferenceDateParams(stationCodeWhereSql.params)).toBe(4);
   });
 });
 

--- a/app/util/crowdReports.test.ts
+++ b/app/util/crowdReports.test.ts
@@ -860,12 +860,14 @@ describe('findMissingCrowdReportReferences', () => {
           pathIndex: 5,
         },
       ],
+      [{ stationId: 'BP1' }, { stationId: 'BP6' }],
     ]);
 
     await expect(
       findMissingCrowdReportReferences(fake.db as never, {
         lineIds: ['BPLRT'],
         observedAt: '2026-05-24T12:30:00.000+08:00',
+        reportScope: 'train',
         stationIds: [],
         directionStationId: 'BP6',
       }),
@@ -905,12 +907,14 @@ describe('findMissingCrowdReportReferences', () => {
           pathIndex: 5,
         },
       ],
+      [{ stationId: 'BP1' }, { stationId: 'BP14' }],
     ]);
 
     await expect(
       findMissingCrowdReportReferences(fake.db as never, {
         lineIds: ['BPLRT'],
         observedAt: '2026-05-24T12:30:00.000+08:00',
+        reportScope: 'train',
         stationIds: [],
         directionStationId: 'BP6',
       }),
@@ -918,6 +922,59 @@ describe('findMissingCrowdReportReferences', () => {
       lineIds: [],
       stationIds: [],
       directionStationIds: ['BP6'],
+    });
+  });
+
+  it('accepts a direction station after inactive path terminals are filtered out', async () => {
+    const fake = makeFakeReferenceDb([
+      [{ id: 'BPLRT' }],
+      [{ id: 'BP1' }],
+      [{ lineId: 'BPLRT', stationId: 'BP1' }],
+      [
+        {
+          id: 'rev-current',
+          serviceId: 'svc-bplrt',
+          lineId: 'BPLRT',
+          start_at: '2020-01-01',
+          end_at: null,
+          updated_at: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+      [
+        {
+          serviceRevisionId: 'rev-current',
+          serviceId: 'svc-bplrt',
+          stationId: 'BP0',
+          pathIndex: 0,
+        },
+        {
+          serviceRevisionId: 'rev-current',
+          serviceId: 'svc-bplrt',
+          stationId: 'BP1',
+          pathIndex: 1,
+        },
+        {
+          serviceRevisionId: 'rev-current',
+          serviceId: 'svc-bplrt',
+          stationId: 'BP6',
+          pathIndex: 5,
+        },
+      ],
+      [{ stationId: 'BP1' }, { stationId: 'BP6' }],
+    ]);
+
+    await expect(
+      findMissingCrowdReportReferences(fake.db as never, {
+        lineIds: ['BPLRT'],
+        observedAt: '2026-05-24T12:30:00.000+08:00',
+        reportScope: 'train',
+        stationIds: [],
+        directionStationId: 'BP1',
+      }),
+    ).resolves.toEqual({
+      lineIds: [],
+      stationIds: [],
+      directionStationIds: [],
     });
   });
 
@@ -935,6 +992,7 @@ describe('findMissingCrowdReportReferences', () => {
       findMissingCrowdReportReferences(fake.db as never, {
         lineIds: ['BPLRT', 'CCL'],
         observedAt: '2026-05-24T12:30:00.000+08:00',
+        reportScope: 'train',
         stationIds: [],
         directionStationId: 'BP6',
       }),
@@ -952,6 +1010,7 @@ describe('findMissingCrowdReportReferences', () => {
       findMissingCrowdReportReferences(fake.db as never, {
         lineIds: [],
         observedAt: '2026-05-24T12:30:00.000+08:00',
+        reportScope: 'station',
         stationIds: ['BP6'],
       }),
     ).resolves.toEqual({
@@ -961,7 +1020,7 @@ describe('findMissingCrowdReportReferences', () => {
     });
   });
 
-  it('rejects stations without an active station code on every submitted line', async () => {
+  it('accepts line affected stops served by any submitted line', async () => {
     const fake = makeFakeReferenceDb([
       [{ id: 'BPLRT' }, { id: 'CCL' }],
       [{ id: 'BP6' }],
@@ -972,6 +1031,24 @@ describe('findMissingCrowdReportReferences', () => {
       findMissingCrowdReportReferences(fake.db as never, {
         lineIds: ['BPLRT', 'CCL'],
         observedAt: '2026-05-24T12:30:00.000+08:00',
+        reportScope: 'line',
+        stationIds: ['BP6'],
+      }),
+    ).resolves.toEqual({
+      lineIds: [],
+      stationIds: [],
+      directionStationIds: [],
+    });
+  });
+
+  it('rejects train stations not served by the submitted line', async () => {
+    const fake = makeFakeReferenceDb([[{ id: 'BPLRT' }], [{ id: 'BP6' }], []]);
+
+    await expect(
+      findMissingCrowdReportReferences(fake.db as never, {
+        lineIds: ['BPLRT'],
+        observedAt: '2026-05-24T12:30:00.000+08:00',
+        reportScope: 'train',
         stationIds: ['BP6'],
       }),
     ).resolves.toEqual({
@@ -992,6 +1069,7 @@ describe('findMissingCrowdReportReferences', () => {
       findMissingCrowdReportReferences(fake.db as never, {
         lineIds: ['BPLRT'],
         observedAt: '2026-05-23T23:30:00-05:00',
+        reportScope: 'line',
         stationIds: ['BP6'],
       }),
     ).resolves.toEqual({

--- a/app/util/crowdReports.ts
+++ b/app/util/crowdReports.ts
@@ -2,7 +2,18 @@ import {
   type IngestContentCrowdReportEffect,
   IngestContentCrowdReportEffectSchema,
 } from '@mrtdown/ingest-contracts';
-import { and, desc, eq, gte, inArray, isNull, lte, ne, sql } from 'drizzle-orm';
+import {
+  and,
+  desc,
+  eq,
+  gte,
+  inArray,
+  isNull,
+  lte,
+  ne,
+  or,
+  sql,
+} from 'drizzle-orm';
 import { DateTime } from 'luxon';
 import { z } from 'zod';
 import {
@@ -770,6 +781,9 @@ export async function findMissingCrowdReportReferences(
     'directionStationId' | 'lineIds' | 'stationIds'
   >,
 ) {
+  const referenceDate =
+    DateTime.now().setZone(SG_TIMEZONE).toISODate() ??
+    new Date().toISOString().slice(0, 10);
   const referencedStationIds = [
     ...submission.stationIds,
     ...(submission.directionStationId ? [submission.directionStationId] : []),
@@ -780,7 +794,16 @@ export async function findMissingCrowdReportReferences(
         ? db
             .select({ id: linesTable.id })
             .from(linesTable)
-            .where(inArray(linesTable.id, submission.lineIds))
+            .where(
+              and(
+                inArray(linesTable.id, submission.lineIds),
+                lte(linesTable.started_at, referenceDate),
+                or(
+                  isNull(linesTable.ended_at),
+                  gte(linesTable.ended_at, referenceDate),
+                ),
+              ),
+            )
         : Promise.resolve([]),
       referencedStationIds.length > 0
         ? db

--- a/app/util/crowdReports.ts
+++ b/app/util/crowdReports.ts
@@ -812,12 +812,18 @@ export async function findMissingCrowdReportReferences(
         : Promise.resolve([]),
       referencedStationIds.length > 0
         ? db
-            .select({ id: stationCodesTable.station_id })
+            .select({
+              lineId: stationCodesTable.line_id,
+              stationId: stationCodesTable.station_id,
+            })
             .from(stationCodesTable)
             .innerJoin(linesTable, eq(stationCodesTable.line_id, linesTable.id))
             .where(
               and(
                 inArray(stationCodesTable.station_id, referencedStationIds),
+                ...(submission.lineIds.length > 0
+                  ? [inArray(stationCodesTable.line_id, submission.lineIds)]
+                  : []),
                 lte(linesTable.started_at, referenceDate),
                 or(
                   isNull(linesTable.ended_at),
@@ -836,12 +842,23 @@ export async function findMissingCrowdReportReferences(
 
   const existingLineIds = new Set(lineRows.map((row) => row.id));
   const existingStationIds = new Set(stationRows.map((row) => row.id));
-  const activeStationIds = new Set(activeStationRows.map((row) => row.id));
+  const activeStationIds = new Set(
+    activeStationRows.map((row) => row.stationId),
+  );
+  const activeStationLineKeys = new Set(
+    activeStationRows.map((row) => `${row.lineId}::${row.stationId}`),
+  );
 
   return {
     lineIds: submission.lineIds.filter((id) => !existingLineIds.has(id)),
     stationIds: referencedStationIds.filter(
-      (id) => !existingStationIds.has(id) || !activeStationIds.has(id),
+      (stationId) =>
+        !existingStationIds.has(stationId) ||
+        (submission.lineIds.length === 0
+          ? !activeStationIds.has(stationId)
+          : !submission.lineIds.every((lineId) =>
+              activeStationLineKeys.has(`${lineId}::${stationId}`),
+            )),
     ),
     directionStationIds: invalidDirectionStationIds,
   };

--- a/app/util/crowdReports.ts
+++ b/app/util/crowdReports.ts
@@ -779,7 +779,11 @@ export async function findMissingCrowdReportReferences(
   db: AppDb,
   submission: Pick<
     CrowdReportSubmission,
-    'directionStationId' | 'lineIds' | 'observedAt' | 'stationIds'
+    | 'directionStationId'
+    | 'lineIds'
+    | 'observedAt'
+    | 'reportScope'
+    | 'stationIds'
   >,
 ) {
   const referenceDate = getCrowdReportReferenceDate(submission);
@@ -821,7 +825,8 @@ export async function findMissingCrowdReportReferences(
             .where(
               and(
                 inArray(stationCodesTable.station_id, referencedStationIds),
-                ...(submission.lineIds.length > 0
+                ...(submission.reportScope !== 'station' &&
+                submission.lineIds.length > 0
                   ? [inArray(stationCodesTable.line_id, submission.lineIds)]
                   : []),
                 lte(linesTable.started_at, referenceDate),
@@ -854,11 +859,15 @@ export async function findMissingCrowdReportReferences(
     stationIds: referencedStationIds.filter(
       (stationId) =>
         !existingStationIds.has(stationId) ||
-        (submission.lineIds.length === 0
+        (submission.lineIds.length === 0 || submission.reportScope === 'station'
           ? !activeStationIds.has(stationId)
-          : !submission.lineIds.every((lineId) =>
-              activeStationLineKeys.has(`${lineId}::${stationId}`),
-            )),
+          : submission.reportScope === 'line'
+            ? !submission.lineIds.some((lineId) =>
+                activeStationLineKeys.has(`${lineId}::${stationId}`),
+              )
+            : !submission.lineIds.every((lineId) =>
+                activeStationLineKeys.has(`${lineId}::${stationId}`),
+              )),
     ),
     directionStationIds: invalidDirectionStationIds,
   };
@@ -988,6 +997,30 @@ async function findInvalidDirectionStationIds(
         ),
       ),
     );
+  const activeDirectionStationRows = await db
+    .select({
+      stationId: stationCodesTable.station_id,
+    })
+    .from(stationCodesTable)
+    .innerJoin(linesTable, eq(stationCodesTable.line_id, linesTable.id))
+    .where(
+      and(
+        inArray(stationCodesTable.line_id, submission.lineIds),
+        lte(linesTable.started_at, referenceDate),
+        or(
+          isNull(linesTable.ended_at),
+          gte(linesTable.ended_at, referenceDate),
+        ),
+        lte(stationCodesTable.started_at, referenceDate),
+        or(
+          isNull(stationCodesTable.ended_at),
+          gte(stationCodesTable.ended_at, referenceDate),
+        ),
+      ),
+    );
+  const activeDirectionStationIds = new Set(
+    activeDirectionStationRows.map((row) => row.stationId),
+  );
 
   const terminalStationIds = new Set<string>();
   const pathRowsByRevisionKey = pathRows.reduce<
@@ -1002,9 +1035,11 @@ async function findInvalidDirectionStationIds(
     return acc;
   }, {});
   for (const entries of Object.values(pathRowsByRevisionKey)) {
-    entries.sort((a, b) => a.pathIndex - b.pathIndex);
-    const firstStationId = entries[0]?.stationId;
-    const lastStationId = entries[entries.length - 1]?.stationId;
+    const activeEntries = entries
+      .filter((entry) => activeDirectionStationIds.has(entry.stationId))
+      .sort((a, b) => a.pathIndex - b.pathIndex);
+    const firstStationId = activeEntries[0]?.stationId;
+    const lastStationId = activeEntries[activeEntries.length - 1]?.stationId;
     if (firstStationId != null) {
       terminalStationIds.add(firstStationId);
     }

--- a/app/util/crowdReports.ts
+++ b/app/util/crowdReports.ts
@@ -29,6 +29,7 @@ import {
   serviceRevisionPathStationEntriesTable,
   serviceRevisionsTable,
   servicesTable,
+  stationCodesTable,
   stationsTable,
   crowdReportStationsTable,
 } from '~/db/schema';
@@ -778,18 +779,16 @@ export async function findMissingCrowdReportReferences(
   db: AppDb,
   submission: Pick<
     CrowdReportSubmission,
-    'directionStationId' | 'lineIds' | 'stationIds'
+    'directionStationId' | 'lineIds' | 'observedAt' | 'stationIds'
   >,
 ) {
-  const referenceDate =
-    DateTime.now().setZone(SG_TIMEZONE).toISODate() ??
-    new Date().toISOString().slice(0, 10);
+  const referenceDate = getCrowdReportReferenceDate(submission);
   const referencedStationIds = [
     ...submission.stationIds,
     ...(submission.directionStationId ? [submission.directionStationId] : []),
   ];
-  const [lineRows, stationRows, invalidDirectionStationIds] = await Promise.all(
-    [
+  const [lineRows, stationRows, activeStationRows, invalidDirectionStationIds] =
+    await Promise.all([
       submission.lineIds.length > 0
         ? db
             .select({ id: linesTable.id })
@@ -811,20 +810,56 @@ export async function findMissingCrowdReportReferences(
             .from(stationsTable)
             .where(inArray(stationsTable.id, referencedStationIds))
         : Promise.resolve([]),
-      findInvalidDirectionStationIds(db, submission),
-    ],
-  );
+      referencedStationIds.length > 0
+        ? db
+            .select({ id: stationCodesTable.station_id })
+            .from(stationCodesTable)
+            .innerJoin(linesTable, eq(stationCodesTable.line_id, linesTable.id))
+            .where(
+              and(
+                inArray(stationCodesTable.station_id, referencedStationIds),
+                lte(linesTable.started_at, referenceDate),
+                or(
+                  isNull(linesTable.ended_at),
+                  gte(linesTable.ended_at, referenceDate),
+                ),
+                lte(stationCodesTable.started_at, referenceDate),
+                or(
+                  isNull(stationCodesTable.ended_at),
+                  gte(stationCodesTable.ended_at, referenceDate),
+                ),
+              ),
+            )
+        : Promise.resolve([]),
+      findInvalidDirectionStationIds(db, submission, referenceDate),
+    ]);
 
   const existingLineIds = new Set(lineRows.map((row) => row.id));
   const existingStationIds = new Set(stationRows.map((row) => row.id));
+  const activeStationIds = new Set(activeStationRows.map((row) => row.id));
 
   return {
     lineIds: submission.lineIds.filter((id) => !existingLineIds.has(id)),
     stationIds: referencedStationIds.filter(
-      (id) => !existingStationIds.has(id),
+      (id) => !existingStationIds.has(id) || !activeStationIds.has(id),
     ),
     directionStationIds: invalidDirectionStationIds,
   };
+}
+
+function getCrowdReportReferenceDate(
+  submission: Pick<CrowdReportSubmission, 'observedAt'>,
+) {
+  const observedDate = DateTime.fromISO(submission.observedAt, {
+    setZone: true,
+  })
+    .setZone(SG_TIMEZONE)
+    .toISODate();
+  return (
+    observedDate ??
+    DateTime.now().setZone(SG_TIMEZONE).toISODate() ??
+    new Date().toISOString().slice(0, 10)
+  );
 }
 
 async function findInvalidDirectionStationIds(
@@ -833,6 +868,7 @@ async function findInvalidDirectionStationIds(
     CrowdReportSubmission,
     'directionStationId' | 'lineIds' | 'stationIds'
   >,
+  referenceDate: string,
 ) {
   if (submission.directionStationId == null) {
     return [];
@@ -841,9 +877,6 @@ async function findInvalidDirectionStationIds(
     return [submission.directionStationId];
   }
 
-  const referenceDate =
-    DateTime.now().setZone(SG_TIMEZONE).toISODate() ??
-    new Date().toISOString().slice(0, 10);
   const serviceRevisionRows = await db
     .select({
       id: serviceRevisionsTable.id,

--- a/app/util/report.functions.test.ts
+++ b/app/util/report.functions.test.ts
@@ -129,20 +129,6 @@ describe('buildCrowdReportFormOptions', () => {
         codePills: [{ lineId: 'CURRENT', code: 'C1' }],
         lineIds: ['CURRENT'],
       },
-      {
-        id: 'B',
-        name: name('Beta'),
-        codes: [],
-        codePills: [],
-        lineIds: [],
-      },
-      {
-        id: 'C',
-        name: name('Gamma'),
-        codes: [],
-        codePills: [],
-        lineIds: [],
-      },
     ]);
     expect(Object.keys(options.lineDirections)).toEqual(['CURRENT']);
     expect(Object.keys(options.lineStationPaths)).toEqual(['CURRENT']);
@@ -179,13 +165,6 @@ describe('buildCrowdReportFormOptions', () => {
           { lineId: 'DTL', code: 'DT1' },
         ],
         lineIds: ['BPLRT', 'DTL'],
-      },
-      {
-        id: 'DT1',
-        name: name('Bukit Panjang'),
-        codes: [],
-        codePills: [],
-        lineIds: [],
       },
     ]);
   });

--- a/app/util/report.functions.test.ts
+++ b/app/util/report.functions.test.ts
@@ -134,6 +134,62 @@ describe('buildCrowdReportFormOptions', () => {
     expect(Object.keys(options.lineStationPaths)).toEqual(['CURRENT']);
   });
 
+  it('excludes station codes that are not active on the reference date', () => {
+    const options = buildCrowdReportFormOptions({
+      referenceDate: '2026-06-17',
+      lines: [
+        {
+          id: 'ACTIVE',
+          name: name('Active Line'),
+          color: '#005ec4',
+          startedAt: '2020-01-01',
+          endedAt: null,
+        },
+      ],
+      stations: [
+        { id: 'CURRENT', name: name('Current Station') },
+        { id: 'ENDED', name: name('Ended Station') },
+        { id: 'FUTURE', name: name('Future Station') },
+      ],
+      stationCodes: [
+        {
+          stationId: 'CURRENT',
+          lineId: 'ACTIVE',
+          code: 'A1',
+          startedAt: '2020-01-01',
+          endedAt: null,
+        },
+        {
+          stationId: 'ENDED',
+          lineId: 'ACTIVE',
+          code: 'A2',
+          startedAt: '2020-01-01',
+          endedAt: '2025-12-31',
+        },
+        {
+          stationId: 'FUTURE',
+          lineId: 'ACTIVE',
+          code: 'A3',
+          startedAt: '2027-01-01',
+          endedAt: null,
+        },
+      ],
+      services: [],
+      serviceRevisions: [],
+      servicePathEntries: [],
+    });
+
+    expect(options.stations).toEqual([
+      {
+        id: 'CURRENT',
+        name: name('Current Station'),
+        codes: ['A1'],
+        codePills: [{ lineId: 'ACTIVE', code: 'A1' }],
+        lineIds: ['ACTIVE'],
+      },
+    ]);
+  });
+
   it('builds station search metadata and guided line choices', () => {
     const options = buildCrowdReportFormOptions({
       referenceDate: '2026-06-17',

--- a/app/util/report.functions.test.ts
+++ b/app/util/report.functions.test.ts
@@ -190,6 +190,98 @@ describe('buildCrowdReportFormOptions', () => {
     ]);
   });
 
+  it('excludes inactive stations from service paths and direction choices', () => {
+    const options = buildCrowdReportFormOptions({
+      referenceDate: '2026-06-17',
+      lines: [
+        {
+          id: 'ACTIVE',
+          name: name('Active Line'),
+          color: '#005ec4',
+          startedAt: '2020-01-01',
+          endedAt: null,
+        },
+      ],
+      stations: [
+        { id: 'START', name: name('Start') },
+        { id: 'HIDDEN', name: name('Hidden') },
+        { id: 'END', name: name('End') },
+        { id: 'TERMINAL', name: name('Inactive Terminal') },
+      ],
+      stationCodes: [
+        {
+          stationId: 'START',
+          lineId: 'ACTIVE',
+          code: 'A1',
+          startedAt: '2020-01-01',
+          endedAt: null,
+        },
+        {
+          stationId: 'HIDDEN',
+          lineId: 'ACTIVE',
+          code: 'A2',
+          startedAt: '2020-01-01',
+          endedAt: '2025-12-31',
+        },
+        {
+          stationId: 'END',
+          lineId: 'ACTIVE',
+          code: 'A3',
+          startedAt: '2020-01-01',
+          endedAt: null,
+        },
+        {
+          stationId: 'TERMINAL',
+          lineId: 'ACTIVE',
+          code: 'A4',
+          startedAt: '2027-01-01',
+          endedAt: null,
+        },
+      ],
+      services: [{ id: 'svc-active', lineId: 'ACTIVE' }],
+      serviceRevisions: [
+        {
+          id: 'current',
+          serviceId: 'svc-active',
+          start_at: '2020-01-01',
+          end_at: null,
+          updated_at: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+      servicePathEntries: [
+        {
+          serviceRevisionId: 'current',
+          serviceId: 'svc-active',
+          stationId: 'START',
+          pathIndex: 0,
+        },
+        {
+          serviceRevisionId: 'current',
+          serviceId: 'svc-active',
+          stationId: 'HIDDEN',
+          pathIndex: 1,
+        },
+        {
+          serviceRevisionId: 'current',
+          serviceId: 'svc-active',
+          stationId: 'END',
+          pathIndex: 2,
+        },
+        {
+          serviceRevisionId: 'current',
+          serviceId: 'svc-active',
+          stationId: 'TERMINAL',
+          pathIndex: 3,
+        },
+      ],
+    });
+
+    expect(options.lineStationPaths.ACTIVE).toEqual([['START', 'END']]);
+    expect(
+      options.lineDirections.ACTIVE?.map((option) => option.stationId),
+    ).toEqual(['END', 'START']);
+  });
+
   it('builds station search metadata and guided line choices', () => {
     const options = buildCrowdReportFormOptions({
       referenceDate: '2026-06-17',
@@ -237,7 +329,11 @@ describe('buildCrowdReportFormOptions', () => {
         { id: 'BP13', name: name('Senja') },
         { id: 'BP14', name: name('Ten Mile Junction') },
       ],
-      stationCodes: [],
+      stationCodes: [
+        { stationId: 'BP1', lineId: 'BPLRT', code: 'BP1' },
+        { stationId: 'BP6', lineId: 'BPLRT', code: 'BP6' },
+        { stationId: 'BP13', lineId: 'BPLRT', code: 'BP13' },
+      ],
       services: [{ id: 'svc-bplrt', lineId: 'BPLRT' }],
       serviceRevisions: [
         {
@@ -322,7 +418,10 @@ describe('buildCrowdReportFormOptions', () => {
         { id: 'CC1', name: name('Dhoby Ghaut') },
         { id: 'CC29', name: name('HarbourFront') },
       ],
-      stationCodes: [],
+      stationCodes: [
+        { stationId: 'CC1', lineId: 'CCL', code: 'CC1' },
+        { stationId: 'CC29', lineId: 'CCL', code: 'CC29' },
+      ],
       services: [
         { id: 'svc-ccl-main', lineId: 'CCL' },
         { id: 'svc-ccl-alt', lineId: 'CCL' },

--- a/app/util/report.functions.test.ts
+++ b/app/util/report.functions.test.ts
@@ -156,7 +156,7 @@ describe('buildCrowdReportFormOptions', () => {
           stationId: 'CURRENT',
           lineId: 'ACTIVE',
           code: 'A1',
-          startedAt: '2020-01-01',
+          startedAt: new Date('2026-06-17T00:00:00.000Z'),
           endedAt: null,
         },
         {
@@ -201,6 +201,13 @@ describe('buildCrowdReportFormOptions', () => {
           startedAt: '2020-01-01',
           endedAt: null,
         },
+        {
+          id: 'OTHER',
+          name: name('Other Line'),
+          color: '#748477',
+          startedAt: '2020-01-01',
+          endedAt: null,
+        },
       ],
       stations: [
         { id: 'START', name: name('Start') },
@@ -222,6 +229,13 @@ describe('buildCrowdReportFormOptions', () => {
           code: 'A2',
           startedAt: '2020-01-01',
           endedAt: '2025-12-31',
+        },
+        {
+          stationId: 'HIDDEN',
+          lineId: 'OTHER',
+          code: 'O1',
+          startedAt: '2020-01-01',
+          endedAt: null,
         },
         {
           stationId: 'END',

--- a/app/util/report.functions.test.ts
+++ b/app/util/report.functions.test.ts
@@ -16,6 +16,138 @@ function name(en: string) {
 }
 
 describe('buildCrowdReportFormOptions', () => {
+  it('excludes lines that are not in operation on the reference date', () => {
+    const options = buildCrowdReportFormOptions({
+      referenceDate: '2026-06-17',
+      lines: [
+        {
+          id: 'CURRENT',
+          name: name('Current Line'),
+          color: '#005ec4',
+          startedAt: '2020-01-01',
+          endedAt: null,
+        },
+        {
+          id: 'ENDED',
+          name: name('Ended Line'),
+          color: '#748477',
+          startedAt: '2010-01-01',
+          endedAt: '2025-12-31',
+        },
+        {
+          id: 'FUTURE',
+          name: name('Future Line'),
+          color: '#fa9e0d',
+          startedAt: '2027-01-01',
+          endedAt: null,
+        },
+      ],
+      stations: [
+        { id: 'A', name: name('Alpha') },
+        { id: 'B', name: name('Beta') },
+        { id: 'C', name: name('Gamma') },
+      ],
+      stationCodes: [
+        { stationId: 'A', lineId: 'CURRENT', code: 'C1' },
+        { stationId: 'B', lineId: 'ENDED', code: 'E1' },
+        { stationId: 'C', lineId: 'FUTURE', code: 'F1' },
+      ],
+      services: [
+        { id: 'svc-current', lineId: 'CURRENT' },
+        { id: 'svc-ended', lineId: 'ENDED' },
+        { id: 'svc-future', lineId: 'FUTURE' },
+      ],
+      serviceRevisions: [
+        {
+          id: 'current',
+          serviceId: 'svc-current',
+          start_at: '2020-01-01',
+          end_at: null,
+          updated_at: '2026-01-01T00:00:00.000Z',
+        },
+        {
+          id: 'ended',
+          serviceId: 'svc-ended',
+          start_at: '2010-01-01',
+          end_at: null,
+          updated_at: '2026-01-01T00:00:00.000Z',
+        },
+        {
+          id: 'future',
+          serviceId: 'svc-future',
+          start_at: '2020-01-01',
+          end_at: null,
+          updated_at: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+      servicePathEntries: [
+        {
+          serviceRevisionId: 'current',
+          serviceId: 'svc-current',
+          stationId: 'A',
+          pathIndex: 0,
+        },
+        {
+          serviceRevisionId: 'current',
+          serviceId: 'svc-current',
+          stationId: 'B',
+          pathIndex: 1,
+        },
+        {
+          serviceRevisionId: 'ended',
+          serviceId: 'svc-ended',
+          stationId: 'B',
+          pathIndex: 0,
+        },
+        {
+          serviceRevisionId: 'ended',
+          serviceId: 'svc-ended',
+          stationId: 'C',
+          pathIndex: 1,
+        },
+        {
+          serviceRevisionId: 'future',
+          serviceId: 'svc-future',
+          stationId: 'C',
+          pathIndex: 0,
+        },
+        {
+          serviceRevisionId: 'future',
+          serviceId: 'svc-future',
+          stationId: 'A',
+          pathIndex: 1,
+        },
+      ],
+    });
+
+    expect(options.lines.map((line) => line.id)).toEqual(['CURRENT']);
+    expect(options.stations).toEqual([
+      {
+        id: 'A',
+        name: name('Alpha'),
+        codes: ['C1'],
+        codePills: [{ lineId: 'CURRENT', code: 'C1' }],
+        lineIds: ['CURRENT'],
+      },
+      {
+        id: 'B',
+        name: name('Beta'),
+        codes: [],
+        codePills: [],
+        lineIds: [],
+      },
+      {
+        id: 'C',
+        name: name('Gamma'),
+        codes: [],
+        codePills: [],
+        lineIds: [],
+      },
+    ]);
+    expect(Object.keys(options.lineDirections)).toEqual(['CURRENT']);
+    expect(Object.keys(options.lineStationPaths)).toEqual(['CURRENT']);
+  });
+
   it('builds station search metadata and guided line choices', () => {
     const options = buildCrowdReportFormOptions({
       referenceDate: '2026-06-17',

--- a/app/util/report.functions.ts
+++ b/app/util/report.functions.ts
@@ -113,7 +113,7 @@ export function buildCrowdReportFormOptions({
     operatingLineIds.has(service.lineId),
   );
   const stationById = Object.fromEntries(
-    stations.map((station) => [station.id, station]),
+    operatingStations.map((station) => [station.id, station]),
   );
   const revisionsByServiceId = serviceRevisions.reduce<
     Record<string, CrowdReportFormServiceRevisionRow[]>

--- a/app/util/report.functions.ts
+++ b/app/util/report.functions.ts
@@ -18,12 +18,14 @@ import {
 } from './crowdReportFeatureFlag';
 import { selectServiceRevisionForReferenceDate } from './serviceRevisions';
 
+const SG_TIMEZONE = 'Asia/Singapore';
+
 type CrowdReportFormLineRow = {
   id: string;
   name: Translations;
   color: string;
-  startedAt?: string | null;
-  endedAt?: string | null;
+  startedAt?: Date | string | null;
+  endedAt?: Date | string | null;
 };
 
 type CrowdReportFormStationRow = {
@@ -35,8 +37,8 @@ type CrowdReportFormStationCodeRow = {
   lineId: string;
   stationId: string;
   code: string;
-  startedAt?: string | null;
-  endedAt?: string | null;
+  startedAt?: Date | string | null;
+  endedAt?: Date | string | null;
 };
 
 type CrowdReportFormServiceRow = {
@@ -69,17 +71,33 @@ type BuildCrowdReportFormOptionsInput = {
   servicePathEntries: CrowdReportFormPathEntryRow[];
 };
 
-function isLineInOperationOnDate(
+function normalizeDateValue(value: Date | string | null | undefined) {
+  if (value == null) {
+    return null;
+  }
+  if (value instanceof Date) {
+    return DateTime.fromJSDate(value, { zone: 'utc' }).toISODate();
+  }
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return value;
+  }
+  const parsed = DateTime.fromISO(value, { setZone: true });
+  return parsed.isValid ? parsed.setZone(SG_TIMEZONE).toISODate() : value;
+}
+
+function isEntityInOperationOnDate(
   entity: {
-    startedAt?: string | null;
-    endedAt?: string | null;
+    startedAt?: Date | string | null;
+    endedAt?: Date | string | null;
   },
   referenceDate: string,
 ) {
-  if (entity.startedAt != null && entity.startedAt > referenceDate) {
+  const startedAt = normalizeDateValue(entity.startedAt);
+  const endedAt = normalizeDateValue(entity.endedAt);
+  if (startedAt != null && startedAt > referenceDate) {
     return false;
   }
-  if (entity.endedAt != null && entity.endedAt < referenceDate) {
+  if (endedAt != null && endedAt < referenceDate) {
     return false;
   }
   return true;
@@ -95,16 +113,19 @@ export function buildCrowdReportFormOptions({
   servicePathEntries,
 }: BuildCrowdReportFormOptionsInput) {
   const operatingLines = lines
-    .filter((line) => isLineInOperationOnDate(line, referenceDate))
+    .filter((line) => isEntityInOperationOnDate(line, referenceDate))
     .map(({ id, name, color }) => ({ id, name, color }));
   const operatingLineIds = new Set(operatingLines.map((line) => line.id));
   const operatingStationCodes = stationCodes.filter(
     (code) =>
       operatingLineIds.has(code.lineId) &&
-      isLineInOperationOnDate(code, referenceDate),
+      isEntityInOperationOnDate(code, referenceDate),
   );
   const operatingStationIds = new Set(
     operatingStationCodes.map((code) => code.stationId),
+  );
+  const operatingStationLineKeys = new Set(
+    operatingStationCodes.map((code) => `${code.lineId}::${code.stationId}`),
   );
   const operatingStations = stations.filter((station) =>
     operatingStationIds.has(station.id),
@@ -169,7 +190,9 @@ export function buildCrowdReportFormOptions({
     ].sort((a, b) => a.pathIndex - b.pathIndex);
     const pathStationIds = entries
       .map((entry) => entry.stationId)
-      .filter((stationId) => operatingStationIds.has(stationId));
+      .filter((stationId) =>
+        operatingStationLineKeys.has(`${service.lineId}::${stationId}`),
+      );
     if (pathStationIds.length > 0) {
       stationPathsByLineId[service.lineId] ??= [];
       stationPathKeysByLineId[service.lineId] ??= new Set();
@@ -276,7 +299,7 @@ export const getCrowdReportFormOptionsFn = createServerFn({
 
   const db = getDb();
   const referenceDate =
-    DateTime.now().setZone('Asia/Singapore').toISODate() ??
+    DateTime.now().setZone(SG_TIMEZONE).toISODate() ??
     new Date().toISOString().slice(0, 10);
   const [
     lines,

--- a/app/util/report.functions.ts
+++ b/app/util/report.functions.ts
@@ -96,6 +96,12 @@ export function buildCrowdReportFormOptions({
   const operatingStationCodes = stationCodes.filter((code) =>
     operatingLineIds.has(code.lineId),
   );
+  const operatingStationIds = new Set(
+    operatingStationCodes.map((code) => code.stationId),
+  );
+  const operatingStations = stations.filter((station) =>
+    operatingStationIds.has(station.id),
+  );
   const operatingServices = services.filter((service) =>
     operatingLineIds.has(service.lineId),
   );
@@ -236,7 +242,7 @@ export function buildCrowdReportFormOptions({
     lines: operatingLines,
     lineDirections: directionsByLineId,
     lineStationPaths: stationPathsByLineId,
-    stations: stations.map((station) => ({
+    stations: operatingStations.map((station) => ({
       ...station,
       codes: stationCodesByStationId[station.id] ?? [],
       codePills: stationCodePillsByStationId[station.id] ?? [],

--- a/app/util/report.functions.ts
+++ b/app/util/report.functions.ts
@@ -1,7 +1,7 @@
 import { env } from 'cloudflare:workers';
 import type { Translations } from '@mrtdown/core';
 import { createServerFn } from '@tanstack/react-start';
-import { and, asc, eq, inArray } from 'drizzle-orm';
+import { and, asc, eq, gte, inArray, isNull, lte, or } from 'drizzle-orm';
 import { DateTime } from 'luxon';
 import { getDb } from '~/db';
 import {
@@ -22,6 +22,8 @@ type CrowdReportFormLineRow = {
   id: string;
   name: Translations;
   color: string;
+  startedAt?: string | null;
+  endedAt?: string | null;
 };
 
 type CrowdReportFormStationRow = {
@@ -65,6 +67,19 @@ type BuildCrowdReportFormOptionsInput = {
   servicePathEntries: CrowdReportFormPathEntryRow[];
 };
 
+function isLineInOperationOnDate(
+  line: CrowdReportFormLineRow,
+  referenceDate: string,
+) {
+  if (line.startedAt != null && line.startedAt > referenceDate) {
+    return false;
+  }
+  if (line.endedAt != null && line.endedAt < referenceDate) {
+    return false;
+  }
+  return true;
+}
+
 export function buildCrowdReportFormOptions({
   referenceDate,
   lines,
@@ -74,6 +89,16 @@ export function buildCrowdReportFormOptions({
   serviceRevisions,
   servicePathEntries,
 }: BuildCrowdReportFormOptionsInput) {
+  const operatingLines = lines
+    .filter((line) => isLineInOperationOnDate(line, referenceDate))
+    .map(({ id, name, color }) => ({ id, name, color }));
+  const operatingLineIds = new Set(operatingLines.map((line) => line.id));
+  const operatingStationCodes = stationCodes.filter((code) =>
+    operatingLineIds.has(code.lineId),
+  );
+  const operatingServices = services.filter((service) =>
+    operatingLineIds.has(service.lineId),
+  );
   const stationById = Object.fromEntries(
     stations.map((station) => [station.id, station]),
   );
@@ -118,7 +143,7 @@ export function buildCrowdReportFormOptions({
   const stationPathsByLineId: Record<string, string[][]> = {};
   const stationPathKeysByLineId: Record<string, Set<string>> = {};
 
-  for (const service of services) {
+  for (const service of operatingServices) {
     const latestRevision = latestRevisionByServiceId[service.id];
     if (latestRevision == null) {
       continue;
@@ -166,18 +191,17 @@ export function buildCrowdReportFormOptions({
     lineDirections.sort((a, b) => a.stationId.localeCompare(b.stationId));
   }
 
-  const stationCodesByStationId = stationCodes.reduce<Record<string, string[]>>(
-    (acc, code) => {
-      acc[code.stationId] ??= [];
-      if (!acc[code.stationId].includes(code.code)) {
-        acc[code.stationId].push(code.code);
-      }
-      return acc;
-    },
-    {},
-  );
+  const stationCodesByStationId = operatingStationCodes.reduce<
+    Record<string, string[]>
+  >((acc, code) => {
+    acc[code.stationId] ??= [];
+    if (!acc[code.stationId].includes(code.code)) {
+      acc[code.stationId].push(code.code);
+    }
+    return acc;
+  }, {});
 
-  const stationCodePillsByStationId = stationCodes.reduce<
+  const stationCodePillsByStationId = operatingStationCodes.reduce<
     Record<string, Array<{ code: string; lineId: string }>>
   >((acc, code) => {
     acc[code.stationId] ??= [];
@@ -194,7 +218,7 @@ export function buildCrowdReportFormOptions({
     return acc;
   }, {});
 
-  const stationLineIdsByStationId = stationCodes.reduce<
+  const stationLineIdsByStationId = operatingStationCodes.reduce<
     Record<string, string[]>
   >((acc, code) => {
     acc[code.stationId] ??= [];
@@ -209,7 +233,7 @@ export function buildCrowdReportFormOptions({
   }
 
   return {
-    lines,
+    lines: operatingLines,
     lineDirections: directionsByLineId,
     lineStationPaths: stationPathsByLineId,
     stations: stations.map((station) => ({
@@ -251,8 +275,19 @@ export const getCrowdReportFormOptionsFn = createServerFn({
         id: linesTable.id,
         name: linesTable.name,
         color: linesTable.color,
+        startedAt: linesTable.started_at,
+        endedAt: linesTable.ended_at,
       })
       .from(linesTable)
+      .where(
+        and(
+          lte(linesTable.started_at, referenceDate),
+          or(
+            isNull(linesTable.ended_at),
+            gte(linesTable.ended_at, referenceDate),
+          ),
+        ),
+      )
       .orderBy(asc(linesTable.id)),
     db
       .select({

--- a/app/util/report.functions.ts
+++ b/app/util/report.functions.ts
@@ -1,7 +1,7 @@
 import { env } from 'cloudflare:workers';
 import type { Translations } from '@mrtdown/core';
 import { createServerFn } from '@tanstack/react-start';
-import { and, asc, eq, gte, inArray, isNull, lte, or } from 'drizzle-orm';
+import { and, asc, eq } from 'drizzle-orm';
 import { DateTime } from 'luxon';
 import { getDb } from '~/db';
 import {
@@ -167,7 +167,9 @@ export function buildCrowdReportFormOptions({
         `${latestRevision.id}::${service.id}`
       ] ?? []),
     ].sort((a, b) => a.pathIndex - b.pathIndex);
-    const pathStationIds = entries.map((entry) => entry.stationId);
+    const pathStationIds = entries
+      .map((entry) => entry.stationId)
+      .filter((stationId) => operatingStationIds.has(stationId));
     if (pathStationIds.length > 0) {
       stationPathsByLineId[service.lineId] ??= [];
       stationPathKeysByLineId[service.lineId] ??= new Set();
@@ -178,8 +180,8 @@ export function buildCrowdReportFormOptions({
       }
     }
     const terminalStationIds = [
-      entries[0]?.stationId,
-      entries[entries.length - 1]?.stationId,
+      pathStationIds[0],
+      pathStationIds[pathStationIds.length - 1],
     ].filter((stationId): stationId is string => stationId != null);
 
     for (const stationId of terminalStationIds) {
@@ -292,15 +294,6 @@ export const getCrowdReportFormOptionsFn = createServerFn({
         endedAt: linesTable.ended_at,
       })
       .from(linesTable)
-      .where(
-        and(
-          lte(linesTable.started_at, referenceDate),
-          or(
-            isNull(linesTable.ended_at),
-            gte(linesTable.ended_at, referenceDate),
-          ),
-        ),
-      )
       .orderBy(asc(linesTable.id)),
     db
       .select({
@@ -318,15 +311,6 @@ export const getCrowdReportFormOptionsFn = createServerFn({
         endedAt: stationCodesTable.ended_at,
       })
       .from(stationCodesTable)
-      .where(
-        and(
-          lte(stationCodesTable.started_at, referenceDate),
-          or(
-            isNull(stationCodesTable.ended_at),
-            gte(stationCodesTable.ended_at, referenceDate),
-          ),
-        ),
-      )
       .orderBy(asc(stationCodesTable.code)),
     db
       .select({
@@ -368,50 +352,30 @@ export const getCrowdReportFormOptionsFn = createServerFn({
     serviceRevisionByKey.set(`${revision.serviceId}::${revision.id}`, revision);
   }
   const serviceRevisions = Array.from(serviceRevisionByKey.values());
-  const revisionsByServiceId = serviceRevisions.reduce<
-    Record<string, typeof serviceRevisions>
-  >((acc, revision) => {
-    acc[revision.serviceId] ??= [];
-    acc[revision.serviceId].push(revision);
-    return acc;
-  }, {});
-  const selectedServiceRevisions = Object.values(revisionsByServiceId)
-    .map((revisions) =>
-      selectServiceRevisionForReferenceDate(revisions, referenceDate),
-    )
-    .filter((revision): revision is (typeof serviceRevisions)[number] => {
-      return revision != null;
-    });
+  const servicePathEntries = await db
+    .select({
+      serviceRevisionId:
+        serviceRevisionPathStationEntriesTable.service_revision_id,
+      serviceId: serviceRevisionPathStationEntriesTable.service_id,
+      stationId: serviceRevisionPathStationEntriesTable.station_id,
+      pathIndex: serviceRevisionPathStationEntriesTable.path_index,
+    })
+    .from(serviceRevisionPathStationEntriesTable);
 
-  const latestRevisionIds = [
-    ...new Set(selectedServiceRevisions.map((revision) => revision.id)),
-  ];
-  const servicePathEntries =
-    latestRevisionIds.length > 0
-      ? await db
-          .select({
-            serviceRevisionId:
-              serviceRevisionPathStationEntriesTable.service_revision_id,
-            serviceId: serviceRevisionPathStationEntriesTable.service_id,
-            stationId: serviceRevisionPathStationEntriesTable.station_id,
-            pathIndex: serviceRevisionPathStationEntriesTable.path_index,
-          })
-          .from(serviceRevisionPathStationEntriesTable)
-          .where(
-            inArray(
-              serviceRevisionPathStationEntriesTable.service_revision_id,
-              latestRevisionIds,
-            ),
-          )
-      : [];
-
-  return buildCrowdReportFormOptions({
-    referenceDate,
+  const formOptionRows = {
     lines,
     stations,
     stationCodes,
     services,
     serviceRevisions,
     servicePathEntries,
-  });
+  };
+
+  return {
+    ...buildCrowdReportFormOptions({
+      referenceDate,
+      ...formOptionRows,
+    }),
+    formOptionRows,
+  };
 });

--- a/app/util/report.functions.ts
+++ b/app/util/report.functions.ts
@@ -35,6 +35,8 @@ type CrowdReportFormStationCodeRow = {
   lineId: string;
   stationId: string;
   code: string;
+  startedAt?: string | null;
+  endedAt?: string | null;
 };
 
 type CrowdReportFormServiceRow = {
@@ -68,13 +70,16 @@ type BuildCrowdReportFormOptionsInput = {
 };
 
 function isLineInOperationOnDate(
-  line: CrowdReportFormLineRow,
+  entity: {
+    startedAt?: string | null;
+    endedAt?: string | null;
+  },
   referenceDate: string,
 ) {
-  if (line.startedAt != null && line.startedAt > referenceDate) {
+  if (entity.startedAt != null && entity.startedAt > referenceDate) {
     return false;
   }
-  if (line.endedAt != null && line.endedAt < referenceDate) {
+  if (entity.endedAt != null && entity.endedAt < referenceDate) {
     return false;
   }
   return true;
@@ -93,8 +98,10 @@ export function buildCrowdReportFormOptions({
     .filter((line) => isLineInOperationOnDate(line, referenceDate))
     .map(({ id, name, color }) => ({ id, name, color }));
   const operatingLineIds = new Set(operatingLines.map((line) => line.id));
-  const operatingStationCodes = stationCodes.filter((code) =>
-    operatingLineIds.has(code.lineId),
+  const operatingStationCodes = stationCodes.filter(
+    (code) =>
+      operatingLineIds.has(code.lineId) &&
+      isLineInOperationOnDate(code, referenceDate),
   );
   const operatingStationIds = new Set(
     operatingStationCodes.map((code) => code.stationId),
@@ -307,8 +314,19 @@ export const getCrowdReportFormOptionsFn = createServerFn({
         lineId: stationCodesTable.line_id,
         stationId: stationCodesTable.station_id,
         code: stationCodesTable.code,
+        startedAt: stationCodesTable.started_at,
+        endedAt: stationCodesTable.ended_at,
       })
       .from(stationCodesTable)
+      .where(
+        and(
+          lte(stationCodesTable.started_at, referenceDate),
+          or(
+            isNull(stationCodesTable.ended_at),
+            gte(stationCodesTable.ended_at, referenceDate),
+          ),
+        ),
+      )
       .orderBy(asc(stationCodesTable.code)),
     db
       .select({


### PR DESCRIPTION
## Summary

- Filter crowd report form line options to lines currently in operation based on `started_at` and `ended_at`.
- Keep inactive lines out of station code metadata, guided direction choices, and affected-stop paths.
- Treat submissions that reference inactive lines as invalid if the form is bypassed.

## Root Cause

The crowd report form loaded every row from `lines`, so future or ended lines could appear as selectable line options and leak through station metadata.

## Validation

- `npm run test:run -- app/util/report.functions.test.ts`
- `npm run verify`

Note: the first sandboxed `npm run verify` attempt failed in `db:generate:check` because `tsx` could not create its IPC pipe under `/var/folders/...` (`listen EPERM`). The same command passed after rerunning with escalated filesystem permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Crowd report validation and option generation now consistently use the selected **observed at** (Singapore date) to include only active lines, station codes, stations, and direction/path choices within their valid time windows.
  * Improved handling when referenced direction stations/paths are inactive, preventing incorrect selections.

* **New Features**
  * The report page now derives line/station options from the selected date, memoizes results, and keeps compatible selections (including range endpoints) in sync as the date changes.

* **Tests**
  * Updated and expanded coverage for observed-at filtering, option output changes, and SQL/date-parameter validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->