### PR TITLE
fix: show line disruption counts

### DIFF
--- a/app/routes/{-$lang}/lines/$lineId/components/CountTrendCards/CountTrendCards.test.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/components/CountTrendCards/CountTrendCards.test.tsx
@@ -1,0 +1,62 @@
+import { renderToString } from 'react-dom/server';
+import { IntlProvider } from 'react-intl';
+import { describe, expect, it } from 'vitest';
+import type { TimeScaleChart } from '~/types';
+import { CountTrendCards } from './index';
+
+const messages = {
+  'general.issues_past_period': 'Issue Count (past {period})',
+  'general.disruption_count':
+    '{count, plural, one {{count} disruption} other {{count} disruptions}}',
+  'general.change_since_previous': '{change} vs previous',
+};
+
+describe('Line CountTrendCards', () => {
+  it('renders cumulative disruption counts from the graph payload', () => {
+    const graph: TimeScaleChart = {
+      title: '7d',
+      dataTimeScale: {
+        granularity: 'day',
+        count: 7,
+      },
+      data: [
+        {
+          name: '2026-06-01',
+          payload: {
+            disruption: 5,
+            maintenance: 1,
+            infra: 0,
+          },
+        },
+      ],
+      dataCumulative: [
+        {
+          name: 'current',
+          payload: {
+            disruption: 5,
+            maintenance: 1,
+            infra: 0,
+          },
+        },
+        {
+          name: 'previous',
+          payload: {
+            disruption: 2,
+            maintenance: 0,
+            infra: 0,
+          },
+        },
+      ],
+    };
+
+    const html = renderToString(
+      <IntlProvider locale="en-SG" messages={messages}>
+        <CountTrendCards graphs={[graph]} />
+      </IntlProvider>,
+    );
+
+    expect(html).toContain('5 disruptions');
+    expect(html).toContain('+3');
+    expect(html).toContain('vs previous');
+  });
+});

--- a/app/routes/{-$lang}/lines/$lineId/components/CountTrendCards/index.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/components/CountTrendCards/index.tsx
@@ -65,9 +65,7 @@ export const CountTrendCards: React.FC<Props> = (props) => {
           defaultMessage="{count, plural, one {{count} disruption} other {{count} disruptions}}"
           values={{
             count:
-              (graph.dataCumulative[0]?.payload?.[
-                'count.disruption'
-              ] as number) ?? 0,
+              (graph.dataCumulative[0]?.payload?.disruption as number) ?? 0,
           }}
         />
       </span>
@@ -79,12 +77,10 @@ export const CountTrendCards: React.FC<Props> = (props) => {
             change: (
               <FormattedNumber
                 value={
-                  ((graph.dataCumulative[0]?.payload?.[
-                    'count.disruption'
-                  ] as number) ?? 0) -
-                  ((graph.dataCumulative[1]?.payload?.[
-                    'count.disruption'
-                  ] as number) ?? 0)
+                  ((graph.dataCumulative[0]?.payload?.disruption as number) ??
+                    0) -
+                  ((graph.dataCumulative[1]?.payload?.disruption as number) ??
+                    0)
                 }
                 signDisplay="always"
               />


### PR DESCRIPTION
## Summary

- Fix the line detail issue count card so it reads cumulative disruption counts from `payload.disruption`.
- Add a server-rendered regression test for the line `CountTrendCards` component.

## Root Cause

The line count card was reading `graph.dataCumulative[*].payload["count.disruption"]`, but the chart builder stores cumulative issue counts under the same unprefixed keys used by the chart series, such as `payload.disruption`. That made the card fall back to `0 disruptions` even when disruption data existed.

## Validation

- `npm run test:run -- 'app/routes/{-$lang}/lines/$lineId/components/CountTrendCards/CountTrendCards.test.tsx'`
- `npm run verify`

Note: the first `npm run verify` attempt passed typecheck, lint, and format checks, then the sandbox blocked `tsx` from creating an IPC pipe under `/var/folders/...`. Rerunning the same command with the required sandbox escalation passed fully.