### PR TITLE
perf: self-host Radio Canada Big font

### DIFF
--- a/app/components/StationMap/components/MapApr2025.tsx
+++ b/app/components/StationMap/components/MapApr2025.tsx
@@ -52,7 +52,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
             <text
               id="U/C"
               fill="white"
-              font-family="Radio Canada Big"
+              font-family="Radio Canada Big Variable"
               font-size="16"
               font-weight="500"
               letter-spacing="0em"
@@ -1633,7 +1633,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jur"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1645,7 +1645,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1660,7 +1660,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bbt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1672,7 +1672,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1684,7 +1684,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cck"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1696,7 +1696,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ywt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1708,7 +1708,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bkp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1720,7 +1720,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kth"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1732,7 +1732,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1744,7 +1744,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnx"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1756,7 +1756,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_snj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1768,7 +1768,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jlp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1780,7 +1780,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sgr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1792,7 +1792,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fjr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1804,7 +1804,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_stk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1816,7 +1816,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cgl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1828,7 +1828,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fmw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1840,7 +1840,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kpg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1852,7 +1852,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1864,7 +1864,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fnv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1876,7 +1876,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lyr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1888,7 +1888,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1900,7 +1900,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rnj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1912,7 +1912,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1924,7 +1924,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1936,7 +1936,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bak"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1948,7 +1948,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rmb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1960,7 +1960,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cpv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1972,7 +1972,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_smg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1984,7 +1984,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nbg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1996,7 +1996,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_smd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2008,7 +2008,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pgp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2020,7 +2020,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2032,7 +2032,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_smk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2044,7 +2044,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dam"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2056,7 +2056,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_oas"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2068,7 +2068,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2080,7 +2080,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_riv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2092,7 +2092,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cre"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2104,7 +2104,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2116,7 +2116,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cov"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2128,7 +2128,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bkt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2140,7 +2140,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2152,7 +2152,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ptr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2164,7 +2164,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_shv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2176,7 +2176,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_krj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2188,7 +2188,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_csw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2200,7 +2200,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hvw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2212,7 +2212,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hme"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2224,7 +2224,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_btw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2236,7 +2236,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kap"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2248,7 +2248,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sav"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2260,7 +2260,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2272,7 +2272,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_msl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2284,7 +2284,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2296,7 +2296,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wdn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2308,7 +2308,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wds"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2320,7 +2320,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_spl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2332,7 +2332,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ltr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2344,7 +2344,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mfl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2356,7 +2356,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_brh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2368,7 +2368,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_uts"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2380,7 +2380,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_npr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2392,7 +2392,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_obv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2404,7 +2404,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_adm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2416,7 +2416,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sbw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2428,7 +2428,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cbr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2440,7 +2440,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_yis"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2452,7 +2452,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ktb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2464,7 +2464,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_yck"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2476,7 +2476,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_amk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2488,7 +2488,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bsh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2500,7 +2500,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lrc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2512,7 +2512,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ser"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2524,7 +2524,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bly"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2536,7 +2536,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tsg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2548,7 +2548,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mps"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2560,7 +2560,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ubi"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2572,7 +2572,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kkb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2584,7 +2584,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2596,7 +2596,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2611,7 +2611,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2626,7 +2626,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tam"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2638,7 +2638,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpe"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2650,7 +2650,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_upc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2662,7 +2662,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_xpo"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2674,7 +2674,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cga"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2689,7 +2689,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_xln"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2701,7 +2701,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sgb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2713,7 +2713,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pyl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2725,7 +2725,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dkt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2737,7 +2737,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mbt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2749,7 +2749,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sdm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2761,7 +2761,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nch"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2773,7 +2773,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pmn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2785,7 +2785,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_epn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2797,7 +2797,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bbs"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2812,7 +2812,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bft"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2824,7 +2824,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2836,7 +2836,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tap"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2848,7 +2848,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_psr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2860,7 +2860,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pgc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2872,7 +2872,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pgl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2884,7 +2884,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_skg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2896,7 +2896,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2908,7 +2908,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hgn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2920,7 +2920,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kvn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2932,7 +2932,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wlh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2944,7 +2944,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ptp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2956,7 +2956,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2968,7 +2968,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_frp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2980,7 +2980,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sim"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2992,7 +2992,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3004,7 +3004,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_eun"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3016,7 +3016,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_alj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3028,7 +3028,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kal"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3040,7 +3040,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lvr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3052,7 +3052,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kem"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3064,7 +3064,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tnm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3076,7 +3076,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nov"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3088,7 +3088,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_new"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3100,7 +3100,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_orc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3112,7 +3112,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_grw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3124,7 +3124,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hvl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3136,7 +3136,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_max"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3148,7 +3148,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_shw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3160,7 +3160,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_som"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3172,7 +3172,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cth"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3187,7 +3187,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3202,7 +3202,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rfp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3217,7 +3217,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3229,7 +3229,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_grb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3241,7 +3241,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_trh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3253,7 +3253,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ktp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3265,7 +3265,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3277,7 +3277,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mpr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3289,7 +3289,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mtc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3301,7 +3301,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sgl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3313,7 +3313,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bsr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3325,7 +3325,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bds"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3337,7 +3337,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_msp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3349,7 +3349,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hbf"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3361,7 +3361,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tlb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3373,7 +3373,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lbd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3385,7 +3385,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ppj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3397,7 +3397,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hpv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3409,7 +3409,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_krg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3421,7 +3421,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_onh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3433,7 +3433,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3445,7 +3445,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dvr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3457,7 +3457,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cle"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3469,7 +3469,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lks"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3481,7 +3481,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3493,7 +3493,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3505,7 +3505,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jkn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3517,7 +3517,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_gcl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3529,7 +3529,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tcr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3541,7 +3541,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_twr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3553,7 +3553,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tlk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3565,7 +3565,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hlv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3577,7 +3577,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_frr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3589,7 +3589,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cdt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3601,7 +3601,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3613,7 +3613,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_btn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3628,7 +3628,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_stv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3640,7 +3640,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lti"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3655,7 +3655,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rcr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3667,7 +3667,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3679,7 +3679,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_glb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3691,7 +3691,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mtr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3703,7 +3703,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jlb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3715,7 +3715,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgs"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3727,7 +3727,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dtn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3739,7 +3739,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tla"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3754,7 +3754,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ctn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3766,7 +3766,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_otp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3778,7 +3778,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tib"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3790,7 +3790,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rdh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3802,7 +3802,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_que"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3814,7 +3814,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_com"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3826,7 +3826,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fcn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3838,7 +3838,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bcl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3850,7 +3850,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dbg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3865,7 +3865,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_crq"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3891,7 +3891,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3911,7 +3911,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 15"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3935,7 +3935,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3955,7 +3955,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PTC"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3979,7 +3979,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3999,7 +3999,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="STC"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4023,7 +4023,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4043,7 +4043,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 13"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4067,7 +4067,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4087,7 +4087,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 10"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4111,7 +4111,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4131,7 +4131,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 9"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4155,7 +4155,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4175,7 +4175,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4199,7 +4199,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4219,7 +4219,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 4"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4243,7 +4243,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4263,7 +4263,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CE 1"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4287,7 +4287,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4307,7 +4307,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4331,7 +4331,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4351,7 +4351,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4375,7 +4375,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4395,7 +4395,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4419,7 +4419,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 29"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4439,7 +4439,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4463,7 +4463,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4483,7 +4483,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4503,7 +4503,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 1"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4527,7 +4527,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4547,7 +4547,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4567,7 +4567,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4591,7 +4591,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4611,7 +4611,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4631,7 +4631,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CE 2"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4657,7 +4657,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4695,7 +4695,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4719,7 +4719,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4739,7 +4739,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4763,7 +4763,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 22"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4783,7 +4783,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4807,7 +4807,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 19"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4827,7 +4827,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4851,7 +4851,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4871,7 +4871,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4895,7 +4895,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4915,7 +4915,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4939,7 +4939,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4959,7 +4959,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 35"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4983,7 +4983,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 31"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5003,7 +5003,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 37"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5027,7 +5027,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5047,7 +5047,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5071,7 +5071,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5091,7 +5091,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5115,7 +5115,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 17"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5135,7 +5135,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5159,7 +5159,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5179,7 +5179,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5205,7 +5205,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5243,7 +5243,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5268,7 +5268,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
               <text
                 id="EW 2"
                 fill="white"
-                font-family="Radio Canada Big"
+                font-family="Radio Canada Big Variable"
                 font-size="16"
                 font-weight="600"
                 letter-spacing="0em"
@@ -5310,7 +5310,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
               <text
                 id="DT 32"
                 fill="white"
-                font-family="Radio Canada Big"
+                font-family="Radio Canada Big Variable"
                 font-size="16"
                 font-weight="600"
                 letter-spacing="0em"
@@ -5333,7 +5333,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5353,7 +5353,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5377,7 +5377,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 32"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5401,7 +5401,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 31"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5425,7 +5425,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 30"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5449,7 +5449,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 29"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5473,7 +5473,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5497,7 +5497,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5521,7 +5521,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 33"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5545,7 +5545,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5569,7 +5569,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5593,7 +5593,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5617,7 +5617,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5641,7 +5641,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5665,7 +5665,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5689,7 +5689,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5713,7 +5713,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5737,7 +5737,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5761,7 +5761,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5785,7 +5785,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5809,7 +5809,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5833,7 +5833,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5857,7 +5857,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5881,7 +5881,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5905,7 +5905,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5929,7 +5929,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5953,7 +5953,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5977,7 +5977,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6001,7 +6001,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6025,7 +6025,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6049,7 +6049,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6073,7 +6073,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6097,7 +6097,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6121,7 +6121,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6145,7 +6145,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6169,7 +6169,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6193,7 +6193,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6217,7 +6217,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6241,7 +6241,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6265,7 +6265,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6289,7 +6289,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6313,7 +6313,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6337,7 +6337,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6361,7 +6361,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6385,7 +6385,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6409,7 +6409,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6433,7 +6433,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6457,7 +6457,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6481,7 +6481,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6505,7 +6505,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6529,7 +6529,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6553,7 +6553,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6577,7 +6577,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6601,7 +6601,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6625,7 +6625,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6649,7 +6649,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6673,7 +6673,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6697,7 +6697,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6721,7 +6721,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6745,7 +6745,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6769,7 +6769,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6793,7 +6793,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6817,7 +6817,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6841,7 +6841,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6865,7 +6865,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6889,7 +6889,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6913,7 +6913,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6937,7 +6937,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6961,7 +6961,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6985,7 +6985,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7009,7 +7009,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7033,7 +7033,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7057,7 +7057,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7081,7 +7081,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7105,7 +7105,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7129,7 +7129,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7153,7 +7153,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7177,7 +7177,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7201,7 +7201,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7225,7 +7225,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7249,7 +7249,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7273,7 +7273,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7297,7 +7297,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7321,7 +7321,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7345,7 +7345,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 29"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7369,7 +7369,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 30"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7393,7 +7393,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7417,7 +7417,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7441,7 +7441,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7465,7 +7465,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7489,7 +7489,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7513,7 +7513,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7537,7 +7537,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7561,7 +7561,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7585,7 +7585,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7609,7 +7609,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7633,7 +7633,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7657,7 +7657,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7681,7 +7681,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7705,7 +7705,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7729,7 +7729,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7753,7 +7753,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7777,7 +7777,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7801,7 +7801,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7825,7 +7825,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7849,7 +7849,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7873,7 +7873,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7897,7 +7897,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7921,7 +7921,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7945,7 +7945,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7969,7 +7969,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7993,7 +7993,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8017,7 +8017,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8041,7 +8041,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8065,7 +8065,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8089,7 +8089,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8113,7 +8113,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 29"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8137,7 +8137,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 30"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8161,7 +8161,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 31"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8185,7 +8185,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 33"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8209,7 +8209,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 34"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8233,7 +8233,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 34_2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8257,7 +8257,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8281,7 +8281,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8305,7 +8305,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8329,7 +8329,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8353,7 +8353,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8377,7 +8377,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 28"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8401,7 +8401,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 27"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8425,7 +8425,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 26"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8449,7 +8449,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 25"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8473,7 +8473,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 24"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8497,7 +8497,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 23"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8521,7 +8521,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 21"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8545,7 +8545,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 20"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8569,7 +8569,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 16"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8593,7 +8593,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 14"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8617,7 +8617,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 12"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8641,7 +8641,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 11"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8665,7 +8665,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 8"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8689,7 +8689,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 7"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8713,7 +8713,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 6"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8737,7 +8737,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 5"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8761,7 +8761,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 3"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8785,7 +8785,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 2"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8809,7 +8809,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8833,7 +8833,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8857,7 +8857,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8881,7 +8881,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8905,7 +8905,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8929,7 +8929,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8953,7 +8953,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8977,7 +8977,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9001,7 +9001,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9025,7 +9025,7 @@ const _MapApr2025: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"

--- a/app/components/StationMap/components/MapDec2019.tsx
+++ b/app/components/StationMap/components/MapDec2019.tsx
@@ -1334,7 +1334,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jur"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1346,7 +1346,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1361,7 +1361,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bbt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1373,7 +1373,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1385,7 +1385,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cck"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1397,7 +1397,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ywt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1409,7 +1409,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bkp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1421,7 +1421,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kth"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1433,7 +1433,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1445,7 +1445,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnx"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1457,7 +1457,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_snj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1469,7 +1469,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jlp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1481,7 +1481,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sgr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1493,7 +1493,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fjr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1505,7 +1505,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_stk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1517,7 +1517,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cgl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1529,7 +1529,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fmw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1541,7 +1541,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kpg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1553,7 +1553,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1565,7 +1565,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fnv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1577,7 +1577,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lyr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1589,7 +1589,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1601,7 +1601,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rnj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1613,7 +1613,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1625,7 +1625,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1637,7 +1637,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bak"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1649,7 +1649,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rmb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1661,7 +1661,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cpv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1673,7 +1673,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_smg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1685,7 +1685,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nbg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1697,7 +1697,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_smd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1709,7 +1709,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pgp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1721,7 +1721,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1733,7 +1733,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_smk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1745,7 +1745,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dam"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1757,7 +1757,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_oas"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1769,7 +1769,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1781,7 +1781,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_riv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1793,7 +1793,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cre"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1805,7 +1805,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1817,7 +1817,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cov"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1829,7 +1829,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bkt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1841,7 +1841,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1853,7 +1853,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ptr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1865,7 +1865,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_shv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1877,7 +1877,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_krj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1889,7 +1889,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_csw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1901,7 +1901,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hvw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1913,7 +1913,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_btw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1925,7 +1925,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kap"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1937,7 +1937,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sav"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1949,7 +1949,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1961,7 +1961,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_msl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1973,7 +1973,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1985,7 +1985,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wdn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1997,7 +1997,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wds"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2009,7 +2009,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_adm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2021,7 +2021,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sbw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2033,7 +2033,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cbr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2045,7 +2045,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_yis"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2057,7 +2057,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ktb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2069,7 +2069,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_yck"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2081,7 +2081,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_amk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2093,7 +2093,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bsh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2105,7 +2105,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lrc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2117,7 +2117,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ser"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2129,7 +2129,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bly"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2141,7 +2141,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tsg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2153,7 +2153,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mps"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2165,7 +2165,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ubi"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2177,7 +2177,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kkb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2189,7 +2189,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2201,7 +2201,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2216,7 +2216,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2231,7 +2231,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tam"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2243,7 +2243,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpe"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2255,7 +2255,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_upc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2267,7 +2267,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_xpo"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2279,7 +2279,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cga"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2294,7 +2294,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pyl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2306,7 +2306,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dkt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2318,7 +2318,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mbt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2330,7 +2330,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sdm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2342,7 +2342,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nch"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2354,7 +2354,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pmn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2366,7 +2366,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_epn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2378,7 +2378,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bbs"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2393,7 +2393,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bft"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2405,7 +2405,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2417,7 +2417,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tap"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2429,7 +2429,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_psr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2441,7 +2441,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pgl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2453,7 +2453,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_skg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2465,7 +2465,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2477,7 +2477,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hgn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2489,7 +2489,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kvn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2501,7 +2501,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wlh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2513,7 +2513,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ptp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2525,7 +2525,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2537,7 +2537,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_frp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2549,7 +2549,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sim"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2561,7 +2561,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2573,7 +2573,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_eun"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2585,7 +2585,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_alj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2597,7 +2597,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kal"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2609,7 +2609,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lvr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2621,7 +2621,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kem"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2633,7 +2633,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tnm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2645,7 +2645,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nov"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2657,7 +2657,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_new"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2669,7 +2669,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_orc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2681,7 +2681,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_som"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2693,7 +2693,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cth"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2708,7 +2708,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2723,7 +2723,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rfp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2738,7 +2738,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2750,7 +2750,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_msp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2762,7 +2762,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hbf"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2774,7 +2774,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tlb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2786,7 +2786,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lbd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2798,7 +2798,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ppj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2810,7 +2810,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hpv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2822,7 +2822,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_krg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2834,7 +2834,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_onh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2846,7 +2846,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2858,7 +2858,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dvr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2870,7 +2870,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cle"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2882,7 +2882,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lks"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2894,7 +2894,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2906,7 +2906,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2918,7 +2918,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jkn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2930,7 +2930,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_gcl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2942,7 +2942,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tcr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2954,7 +2954,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_twr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2966,7 +2966,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tlk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2978,7 +2978,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hlv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2990,7 +2990,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_frr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3002,7 +3002,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3014,7 +3014,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_btn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3029,7 +3029,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lti"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3044,7 +3044,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rcr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3056,7 +3056,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3068,7 +3068,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_glb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3080,7 +3080,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mtr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3092,7 +3092,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jlb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3104,7 +3104,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgs"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3116,7 +3116,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dtn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3128,7 +3128,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tla"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3143,7 +3143,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ctn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3155,7 +3155,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_otp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3167,7 +3167,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tib"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3179,7 +3179,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rdh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3191,7 +3191,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_que"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3203,7 +3203,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_com"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3215,7 +3215,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fcn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3227,7 +3227,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bcl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3239,7 +3239,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dbg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3254,7 +3254,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_crq"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3269,7 +3269,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cdt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3281,7 +3281,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_stv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3304,7 +3304,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3324,7 +3324,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 15"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3348,7 +3348,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3368,7 +3368,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PTC"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3392,7 +3392,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3412,7 +3412,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="STC"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3436,7 +3436,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3456,7 +3456,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 13"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3480,7 +3480,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3500,7 +3500,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 10"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3524,7 +3524,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3544,7 +3544,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 9"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3568,7 +3568,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3588,7 +3588,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3612,7 +3612,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3632,7 +3632,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 4"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3656,7 +3656,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3676,7 +3676,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CE 1"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3700,7 +3700,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3724,7 +3724,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3744,7 +3744,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3768,7 +3768,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3788,7 +3788,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3812,7 +3812,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 29"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3832,7 +3832,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3856,7 +3856,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3876,7 +3876,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3896,7 +3896,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 1"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3920,7 +3920,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3940,7 +3940,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3964,7 +3964,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3984,7 +3984,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CE 2"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4010,7 +4010,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4048,7 +4048,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4072,7 +4072,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4092,7 +4092,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4116,7 +4116,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 22"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4136,7 +4136,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4160,7 +4160,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 19"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4180,7 +4180,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4204,7 +4204,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4224,7 +4224,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4248,7 +4248,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4268,7 +4268,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4292,7 +4292,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4312,7 +4312,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 35"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4336,7 +4336,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4356,7 +4356,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4380,7 +4380,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4404,7 +4404,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 17"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4428,7 +4428,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4448,7 +4448,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4474,7 +4474,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4512,7 +4512,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4537,7 +4537,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
               <text
                 id="EW 2"
                 fill="white"
-                font-family="Radio Canada Big"
+                font-family="Radio Canada Big Variable"
                 font-size="16"
                 font-weight="600"
                 letter-spacing="0em"
@@ -4579,7 +4579,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
               <text
                 id="DT 32"
                 fill="white"
-                font-family="Radio Canada Big"
+                font-family="Radio Canada Big Variable"
                 font-size="16"
                 font-weight="600"
                 letter-spacing="0em"
@@ -4602,7 +4602,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4622,7 +4622,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4646,7 +4646,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 32"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4670,7 +4670,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 31"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4694,7 +4694,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 30"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4718,7 +4718,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 29"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4742,7 +4742,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4766,7 +4766,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4790,7 +4790,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 33"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4814,7 +4814,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4838,7 +4838,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4862,7 +4862,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4886,7 +4886,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4910,7 +4910,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4934,7 +4934,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4958,7 +4958,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4982,7 +4982,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5006,7 +5006,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5030,7 +5030,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5054,7 +5054,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5078,7 +5078,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5102,7 +5102,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5126,7 +5126,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5150,7 +5150,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5174,7 +5174,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5198,7 +5198,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5222,7 +5222,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5246,7 +5246,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5270,7 +5270,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5294,7 +5294,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5318,7 +5318,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5342,7 +5342,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5366,7 +5366,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5390,7 +5390,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5414,7 +5414,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5438,7 +5438,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5462,7 +5462,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5486,7 +5486,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5510,7 +5510,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5534,7 +5534,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5558,7 +5558,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5582,7 +5582,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5606,7 +5606,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5630,7 +5630,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5654,7 +5654,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5678,7 +5678,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5702,7 +5702,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5726,7 +5726,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5750,7 +5750,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5774,7 +5774,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5798,7 +5798,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5822,7 +5822,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5846,7 +5846,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5870,7 +5870,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5894,7 +5894,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5918,7 +5918,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5942,7 +5942,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5966,7 +5966,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5990,7 +5990,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6014,7 +6014,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6038,7 +6038,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6062,7 +6062,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6086,7 +6086,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6110,7 +6110,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6134,7 +6134,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6158,7 +6158,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6182,7 +6182,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6206,7 +6206,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6230,7 +6230,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6254,7 +6254,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6278,7 +6278,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6302,7 +6302,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6326,7 +6326,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6350,7 +6350,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6374,7 +6374,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6398,7 +6398,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6422,7 +6422,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6446,7 +6446,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6470,7 +6470,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6494,7 +6494,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6518,7 +6518,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6542,7 +6542,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6566,7 +6566,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6590,7 +6590,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6614,7 +6614,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6638,7 +6638,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6662,7 +6662,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6686,7 +6686,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6710,7 +6710,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6734,7 +6734,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6758,7 +6758,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6782,7 +6782,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6806,7 +6806,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6830,7 +6830,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6854,7 +6854,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 29"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6878,7 +6878,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 30"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6902,7 +6902,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 31"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6926,7 +6926,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 33"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6950,7 +6950,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 34"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6974,7 +6974,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6998,7 +6998,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7022,7 +7022,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7046,7 +7046,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7070,7 +7070,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7094,7 +7094,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 28"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7118,7 +7118,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 27"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7142,7 +7142,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 26"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7166,7 +7166,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 25"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7190,7 +7190,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 24"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7214,7 +7214,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 23"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7238,7 +7238,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 21"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7262,7 +7262,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 20"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7286,7 +7286,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 16"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7310,7 +7310,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 14"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7334,7 +7334,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 12"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7358,7 +7358,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 11"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7382,7 +7382,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 8"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7406,7 +7406,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 7"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7430,7 +7430,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 6"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7454,7 +7454,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 5"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7478,7 +7478,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 3"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7502,7 +7502,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 2"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7526,7 +7526,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7550,7 +7550,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7574,7 +7574,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7598,7 +7598,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7622,7 +7622,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7646,7 +7646,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7670,7 +7670,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7694,7 +7694,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7718,7 +7718,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7742,7 +7742,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7785,7 +7785,7 @@ const _MapDec2019: React.ForwardRefRenderFunction<SVGSVGElement> = (
             <text
               id="CLOSED"
               fill="white"
-              font-family="Radio Canada Big"
+              font-family="Radio Canada Big Variable"
               font-size="16"
               font-weight="500"
               letter-spacing="0em"

--- a/app/components/StationMap/components/MapDec2027.tsx
+++ b/app/components/StationMap/components/MapDec2027.tsx
@@ -1683,7 +1683,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jur"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1695,7 +1695,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1710,7 +1710,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bbt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1722,7 +1722,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1734,7 +1734,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cck"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1746,7 +1746,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ckw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1758,7 +1758,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tgh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1770,7 +1770,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1785,7 +1785,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cpn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1797,7 +1797,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jrw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1812,7 +1812,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bhj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1827,7 +1827,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_gkp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1842,7 +1842,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tws"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1854,7 +1854,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ywt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1866,7 +1866,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bkp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1878,7 +1878,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kth"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1890,7 +1890,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1902,7 +1902,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnx"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1914,7 +1914,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_snj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1926,7 +1926,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jlp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1938,7 +1938,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sgr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1950,7 +1950,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fjr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1962,7 +1962,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_stk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1974,7 +1974,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cgl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1986,7 +1986,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fmw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1998,7 +1998,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kpg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2010,7 +2010,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2022,7 +2022,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fnv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2034,7 +2034,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lyr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2046,7 +2046,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2058,7 +2058,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rnj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2070,7 +2070,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2082,7 +2082,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2094,7 +2094,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bak"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2106,7 +2106,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rmb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2118,7 +2118,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cpv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2130,7 +2130,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_smg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2142,7 +2142,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nbg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2154,7 +2154,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_smd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2166,7 +2166,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pgp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2178,7 +2178,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2190,7 +2190,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_smk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2202,7 +2202,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dam"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2214,7 +2214,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_oas"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2226,7 +2226,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2238,7 +2238,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_riv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2250,7 +2250,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cre"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2262,7 +2262,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2274,7 +2274,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cov"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2286,7 +2286,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bkt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2298,7 +2298,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2310,7 +2310,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ptr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2322,7 +2322,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_shv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2334,7 +2334,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_krj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2346,7 +2346,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_csw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2358,7 +2358,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hvw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2370,7 +2370,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hme"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2382,7 +2382,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_btw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2394,7 +2394,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kap"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2406,7 +2406,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sav"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2418,7 +2418,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2430,7 +2430,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_msl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2442,7 +2442,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2454,7 +2454,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wdn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2466,7 +2466,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wds"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2478,7 +2478,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_spl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2490,7 +2490,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ltr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2502,7 +2502,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mfl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2514,7 +2514,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_brh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2526,7 +2526,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_uts"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2538,7 +2538,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_npr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2550,7 +2550,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_obv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2562,7 +2562,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_adm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2574,7 +2574,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sbw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2586,7 +2586,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cbr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2598,7 +2598,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_yis"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2610,7 +2610,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ktb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2622,7 +2622,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_yck"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2634,7 +2634,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_amk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2646,7 +2646,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bsh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2658,7 +2658,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lrc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2670,7 +2670,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ser"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2682,7 +2682,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bly"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2694,7 +2694,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tsg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2706,7 +2706,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mps"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2718,7 +2718,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ubi"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2730,7 +2730,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kkb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2742,7 +2742,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2754,7 +2754,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2769,7 +2769,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2784,7 +2784,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tam"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2796,7 +2796,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpe"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2808,7 +2808,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_upc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2820,7 +2820,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_xpo"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2832,7 +2832,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cga"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2847,7 +2847,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_xln"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2859,7 +2859,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sgb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2871,7 +2871,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pyl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2883,7 +2883,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dkt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2895,7 +2895,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mbt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2907,7 +2907,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sdm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2919,7 +2919,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nch"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2931,7 +2931,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pmn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2943,7 +2943,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_epn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2955,7 +2955,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bbs"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2970,7 +2970,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bft"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2982,7 +2982,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2994,7 +2994,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tap"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3006,7 +3006,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_psr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3018,7 +3018,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pgc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3030,7 +3030,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pgl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3042,7 +3042,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_skg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3054,7 +3054,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3066,7 +3066,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hgn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3078,7 +3078,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kvn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3090,7 +3090,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wlh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3102,7 +3102,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ptp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3114,7 +3114,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3126,7 +3126,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_frp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3138,7 +3138,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sim"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3150,7 +3150,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3162,7 +3162,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_eun"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3174,7 +3174,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_alj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3186,7 +3186,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kal"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3198,7 +3198,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lvr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3210,7 +3210,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kem"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3222,7 +3222,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tnm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3234,7 +3234,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nov"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3246,7 +3246,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_new"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3258,7 +3258,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_orc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3270,7 +3270,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_grw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3282,7 +3282,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hvl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3294,7 +3294,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_max"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3306,7 +3306,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_shw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3318,7 +3318,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_som"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3330,7 +3330,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cth"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3345,7 +3345,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3360,7 +3360,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rfp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3375,7 +3375,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3387,7 +3387,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_grb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3399,7 +3399,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_trh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3411,7 +3411,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ktp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3423,7 +3423,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3435,7 +3435,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mpr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3447,7 +3447,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mtc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3459,7 +3459,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sgl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3471,7 +3471,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bsr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3483,7 +3483,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bds"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3495,7 +3495,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_msp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3507,7 +3507,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hbf"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3519,7 +3519,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kpl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3531,7 +3531,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ctm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3543,7 +3543,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_per"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3558,7 +3558,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tlb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3570,7 +3570,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lbd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3582,7 +3582,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ppj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3594,7 +3594,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hpv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3606,7 +3606,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_krg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3618,7 +3618,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_onh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3630,7 +3630,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3642,7 +3642,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dvr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3654,7 +3654,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cle"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3666,7 +3666,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lks"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3678,7 +3678,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3690,7 +3690,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3702,7 +3702,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jkn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3714,7 +3714,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_gcl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3726,7 +3726,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tcr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3741,7 +3741,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_twr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3759,7 +3759,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tlk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3771,7 +3771,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hlv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3783,7 +3783,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_frr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3795,7 +3795,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cdt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3807,7 +3807,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3819,7 +3819,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_btn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3834,7 +3834,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_stv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3846,7 +3846,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lti"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3861,7 +3861,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rcr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3873,7 +3873,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3885,7 +3885,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_glb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3897,7 +3897,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mtr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3909,7 +3909,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jlb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3921,7 +3921,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgs"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3933,7 +3933,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dtn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3945,7 +3945,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tla"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3960,7 +3960,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ctn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3972,7 +3972,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_otp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3984,7 +3984,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tib"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3996,7 +3996,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rdh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4008,7 +4008,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_que"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4020,7 +4020,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_com"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4032,7 +4032,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fcn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4044,7 +4044,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bcl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4056,7 +4056,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dbg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4071,7 +4071,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_crq"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4097,7 +4097,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4117,7 +4117,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 15"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4141,7 +4141,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4161,7 +4161,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PTC"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4185,7 +4185,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4205,7 +4205,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="STC"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4229,7 +4229,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4249,7 +4249,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 13"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4273,7 +4273,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4293,7 +4293,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 10"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4317,7 +4317,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4337,7 +4337,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 9"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4361,7 +4361,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4381,7 +4381,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4405,7 +4405,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4425,7 +4425,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 4"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4449,7 +4449,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4469,7 +4469,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CE 1"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4493,7 +4493,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4513,7 +4513,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4537,7 +4537,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4557,7 +4557,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4581,7 +4581,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4601,7 +4601,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4625,7 +4625,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 29"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4645,7 +4645,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4669,7 +4669,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4689,7 +4689,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4709,7 +4709,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 1"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4733,7 +4733,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4753,7 +4753,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4773,7 +4773,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4797,7 +4797,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4817,7 +4817,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4837,7 +4837,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CE 2"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4863,7 +4863,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4901,7 +4901,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4925,7 +4925,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4945,7 +4945,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4969,7 +4969,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 22"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4989,7 +4989,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5013,7 +5013,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 19"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5033,7 +5033,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5057,7 +5057,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5077,7 +5077,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5101,7 +5101,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5121,7 +5121,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5145,7 +5145,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5165,7 +5165,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 35"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5189,7 +5189,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 31"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5209,7 +5209,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 37"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5233,7 +5233,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5253,7 +5253,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5277,7 +5277,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5297,7 +5297,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5321,7 +5321,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 17"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5341,7 +5341,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5365,7 +5365,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5385,7 +5385,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5405,7 +5405,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5431,7 +5431,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5469,7 +5469,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5494,7 +5494,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
               <text
                 id="EW 2"
                 fill="white"
-                font-family="Radio Canada Big"
+                font-family="Radio Canada Big Variable"
                 font-size="16"
                 font-weight="600"
                 letter-spacing="0em"
@@ -5536,7 +5536,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
               <text
                 id="DT 32"
                 fill="white"
-                font-family="Radio Canada Big"
+                font-family="Radio Canada Big Variable"
                 font-size="16"
                 font-weight="600"
                 letter-spacing="0em"
@@ -5559,7 +5559,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5579,7 +5579,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5603,7 +5603,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 32"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5627,7 +5627,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 31"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5651,7 +5651,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 30"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5675,7 +5675,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 29"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5699,7 +5699,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5723,7 +5723,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5743,7 +5743,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5767,7 +5767,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 33"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5791,7 +5791,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5815,7 +5815,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5839,7 +5839,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5863,7 +5863,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5887,7 +5887,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5911,7 +5911,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5935,7 +5935,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5959,7 +5959,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5983,7 +5983,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6007,7 +6007,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6031,7 +6031,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6055,7 +6055,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6079,7 +6079,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6103,7 +6103,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6127,7 +6127,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6151,7 +6151,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6175,7 +6175,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6199,7 +6199,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6223,7 +6223,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6247,7 +6247,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6271,7 +6271,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6295,7 +6295,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6319,7 +6319,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6343,7 +6343,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6367,7 +6367,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6391,7 +6391,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6415,7 +6415,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6439,7 +6439,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6463,7 +6463,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6487,7 +6487,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6511,7 +6511,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6535,7 +6535,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6559,7 +6559,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6583,7 +6583,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6607,7 +6607,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6631,7 +6631,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6655,7 +6655,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6679,7 +6679,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6703,7 +6703,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6727,7 +6727,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6751,7 +6751,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6775,7 +6775,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6799,7 +6799,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6823,7 +6823,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6847,7 +6847,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6871,7 +6871,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6895,7 +6895,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6919,7 +6919,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6943,7 +6943,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6967,7 +6967,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6991,7 +6991,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7015,7 +7015,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7039,7 +7039,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7063,7 +7063,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7087,7 +7087,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7111,7 +7111,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7135,7 +7135,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7159,7 +7159,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7183,7 +7183,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7207,7 +7207,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7231,7 +7231,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7255,7 +7255,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7279,7 +7279,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7303,7 +7303,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7327,7 +7327,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7351,7 +7351,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7375,7 +7375,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7399,7 +7399,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7423,7 +7423,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7447,7 +7447,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7471,7 +7471,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7495,7 +7495,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7519,7 +7519,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7543,7 +7543,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7567,7 +7567,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7591,7 +7591,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 29"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7615,7 +7615,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 30"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7639,7 +7639,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7663,7 +7663,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7687,7 +7687,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7711,7 +7711,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7735,7 +7735,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7759,7 +7759,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7783,7 +7783,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7807,7 +7807,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7831,7 +7831,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7855,7 +7855,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7879,7 +7879,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7903,7 +7903,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7927,7 +7927,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7951,7 +7951,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7975,7 +7975,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7999,7 +7999,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8023,7 +8023,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8047,7 +8047,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8071,7 +8071,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8095,7 +8095,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8119,7 +8119,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8143,7 +8143,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8167,7 +8167,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8191,7 +8191,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8215,7 +8215,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8239,7 +8239,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8263,7 +8263,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8287,7 +8287,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8311,7 +8311,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8335,7 +8335,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8359,7 +8359,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 29"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8383,7 +8383,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 30"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8407,7 +8407,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 31"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8431,7 +8431,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 33"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8455,7 +8455,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 34"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8479,7 +8479,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 34_2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8503,7 +8503,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8527,7 +8527,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8551,7 +8551,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8575,7 +8575,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8599,7 +8599,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8623,7 +8623,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 28"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8647,7 +8647,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 30"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8671,7 +8671,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 31"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8695,7 +8695,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 32"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8719,7 +8719,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 27"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8743,7 +8743,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 26"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8767,7 +8767,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 25"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8791,7 +8791,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 24"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8815,7 +8815,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 23"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8839,7 +8839,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 21"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8863,7 +8863,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 20"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8887,7 +8887,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 16"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8911,7 +8911,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 14"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8935,7 +8935,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 12"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8959,7 +8959,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 11"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8983,7 +8983,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 8"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9007,7 +9007,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 7"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9031,7 +9031,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 6"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9055,7 +9055,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 5"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9079,7 +9079,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 3"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9103,7 +9103,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 2"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9127,7 +9127,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9151,7 +9151,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9175,7 +9175,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9199,7 +9199,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9223,7 +9223,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9247,7 +9247,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9271,7 +9271,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9295,7 +9295,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9319,7 +9319,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9343,7 +9343,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9367,7 +9367,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9391,7 +9391,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9415,7 +9415,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9439,7 +9439,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9463,7 +9463,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9487,7 +9487,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9511,7 +9511,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9535,7 +9535,7 @@ const _MapDec2027: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JW 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"

--- a/app/components/StationMap/components/MapDec2029.tsx
+++ b/app/components/StationMap/components/MapDec2029.tsx
@@ -1812,7 +1812,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jur"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1827,7 +1827,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1842,7 +1842,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bbt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1854,7 +1854,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1866,7 +1866,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cck"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1878,7 +1878,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ckw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1893,7 +1893,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tgh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1905,7 +1905,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tgp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1920,7 +1920,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1935,7 +1935,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bbw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1950,7 +1950,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tgn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1965,7 +1965,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jth"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1980,7 +1980,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pdr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1992,7 +1992,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2007,7 +2007,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cpn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2019,7 +2019,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jrw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2034,7 +2034,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bhj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2049,7 +2049,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_etp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2061,7 +2061,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2073,7 +2073,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jrh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2085,7 +2085,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jrp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2097,7 +2097,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_gkp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2112,7 +2112,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tws"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2124,7 +2124,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nyg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2139,7 +2139,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nyc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2154,7 +2154,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pkh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2169,7 +2169,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ywt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2181,7 +2181,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bkp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2193,7 +2193,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kth"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2205,7 +2205,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2217,7 +2217,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnx"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2229,7 +2229,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_snj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2241,7 +2241,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jlp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2253,7 +2253,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sgr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2265,7 +2265,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fjr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2277,7 +2277,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_stk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2289,7 +2289,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cgl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2301,7 +2301,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fmw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2313,7 +2313,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kpg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2325,7 +2325,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2337,7 +2337,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fnv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2349,7 +2349,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lyr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2361,7 +2361,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2373,7 +2373,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rnj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2385,7 +2385,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2397,7 +2397,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2409,7 +2409,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bak"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2421,7 +2421,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rmb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2433,7 +2433,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cpv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2445,7 +2445,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_smg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2457,7 +2457,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nbg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2469,7 +2469,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_smd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2481,7 +2481,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pgp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2493,7 +2493,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2505,7 +2505,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_smk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2517,7 +2517,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dam"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2529,7 +2529,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_oas"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2541,7 +2541,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2553,7 +2553,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_riv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2565,7 +2565,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cre"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2577,7 +2577,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2589,7 +2589,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cov"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2601,7 +2601,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bkt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2613,7 +2613,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2625,7 +2625,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ptr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2637,7 +2637,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_shv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2649,7 +2649,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_krj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2661,7 +2661,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_csw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2673,7 +2673,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hvw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2685,7 +2685,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hme"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2697,7 +2697,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_btw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2709,7 +2709,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kap"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2721,7 +2721,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sav"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2733,7 +2733,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2745,7 +2745,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_msl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2757,7 +2757,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2769,7 +2769,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wdn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2781,7 +2781,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wds"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2793,7 +2793,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_spl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2805,7 +2805,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ltr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2817,7 +2817,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mfl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2829,7 +2829,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_brh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2841,7 +2841,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_uts"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2853,7 +2853,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_npr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2865,7 +2865,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_obv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2877,7 +2877,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_adm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2889,7 +2889,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sbw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2901,7 +2901,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cbr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2913,7 +2913,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_yis"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2925,7 +2925,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ktb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2937,7 +2937,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_yck"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2949,7 +2949,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_amk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2961,7 +2961,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bsh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2973,7 +2973,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lrc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2985,7 +2985,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ser"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2997,7 +2997,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bly"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3009,7 +3009,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tsg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3021,7 +3021,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mps"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3033,7 +3033,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ubi"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3045,7 +3045,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kkb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3057,7 +3057,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3069,7 +3069,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3084,7 +3084,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3099,7 +3099,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tam"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3111,7 +3111,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpe"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3123,7 +3123,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_upc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3135,7 +3135,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_xpo"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3147,7 +3147,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cga"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3162,7 +3162,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_xln"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3174,7 +3174,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sgb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3186,7 +3186,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pyl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3198,7 +3198,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dkt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3210,7 +3210,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mbt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3222,7 +3222,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sdm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3234,7 +3234,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nch"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3246,7 +3246,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pmn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3258,7 +3258,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_epn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3270,7 +3270,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bbs"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3285,7 +3285,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bft"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3297,7 +3297,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3309,7 +3309,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tap"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3321,7 +3321,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_psr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3333,7 +3333,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pgc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3345,7 +3345,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pgl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3357,7 +3357,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_skg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3369,7 +3369,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3381,7 +3381,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hgn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3393,7 +3393,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kvn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3405,7 +3405,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wlh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3417,7 +3417,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ptp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3429,7 +3429,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3441,7 +3441,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_frp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3453,7 +3453,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sim"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3465,7 +3465,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3477,7 +3477,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_eun"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3489,7 +3489,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_alj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3501,7 +3501,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kal"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3513,7 +3513,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lvr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3525,7 +3525,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kem"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3537,7 +3537,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tnm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3549,7 +3549,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nov"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3561,7 +3561,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_new"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3573,7 +3573,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_orc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3585,7 +3585,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_grw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3597,7 +3597,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hvl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3609,7 +3609,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_max"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3621,7 +3621,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_shw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3633,7 +3633,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_som"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3645,7 +3645,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cth"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3660,7 +3660,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3675,7 +3675,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rfp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3690,7 +3690,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3702,7 +3702,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_grb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3714,7 +3714,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_trh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3726,7 +3726,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fdm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3738,7 +3738,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ktp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3750,7 +3750,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3762,7 +3762,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mpr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3774,7 +3774,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mtc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3786,7 +3786,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sgl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3798,7 +3798,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bsr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3810,7 +3810,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bds"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3822,7 +3822,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_msp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3834,7 +3834,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hbf"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3846,7 +3846,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tlb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3858,7 +3858,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lbd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3870,7 +3870,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ppj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3882,7 +3882,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hpv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3894,7 +3894,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_krg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3906,7 +3906,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_onh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3918,7 +3918,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3930,7 +3930,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dvr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3942,7 +3942,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cle"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3954,7 +3954,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lks"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3966,7 +3966,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3978,7 +3978,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3990,7 +3990,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jkn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4002,7 +4002,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_gcl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4014,7 +4014,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tcr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4029,7 +4029,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_twr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4047,7 +4047,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tlk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4059,7 +4059,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hlv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4071,7 +4071,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_frr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4083,7 +4083,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cdt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4095,7 +4095,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4107,7 +4107,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_btn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4122,7 +4122,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_stv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4134,7 +4134,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lti"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4149,7 +4149,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rcr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4161,7 +4161,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4173,7 +4173,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_glb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4185,7 +4185,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mtr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4197,7 +4197,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jlb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4209,7 +4209,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgs"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4221,7 +4221,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dtn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4233,7 +4233,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tla"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4248,7 +4248,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ctn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4260,7 +4260,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_otp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4272,7 +4272,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tib"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4284,7 +4284,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rdh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4296,7 +4296,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_que"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4308,7 +4308,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_com"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4320,7 +4320,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fcn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4332,7 +4332,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bcl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4344,7 +4344,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dbg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4359,7 +4359,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_crq"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4374,7 +4374,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kpl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4386,7 +4386,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ctm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4398,7 +4398,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_per"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4424,7 +4424,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4444,7 +4444,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 15"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4468,7 +4468,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4488,7 +4488,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PTC"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4512,7 +4512,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4532,7 +4532,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="STC"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4556,7 +4556,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4576,7 +4576,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 13"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4600,7 +4600,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4620,7 +4620,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 10"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4644,7 +4644,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4664,7 +4664,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 9"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4688,7 +4688,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4708,7 +4708,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4732,7 +4732,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4752,7 +4752,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 4"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4776,7 +4776,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4796,7 +4796,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CE 1"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4820,7 +4820,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4840,7 +4840,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4864,7 +4864,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4884,7 +4884,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4908,7 +4908,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4928,7 +4928,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4952,7 +4952,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 29"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4972,7 +4972,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4996,7 +4996,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5016,7 +5016,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5036,7 +5036,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 1"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5060,7 +5060,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5080,7 +5080,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5100,7 +5100,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5124,7 +5124,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5144,7 +5144,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5164,7 +5164,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CE 2"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5190,7 +5190,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5228,7 +5228,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5252,7 +5252,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5272,7 +5272,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5292,7 +5292,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5316,7 +5316,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 22"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5336,7 +5336,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5360,7 +5360,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 19"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5380,7 +5380,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5404,7 +5404,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5424,7 +5424,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5448,7 +5448,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5468,7 +5468,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5492,7 +5492,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5512,7 +5512,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 35"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5536,7 +5536,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 31"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5556,7 +5556,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 37"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5580,7 +5580,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5600,7 +5600,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5624,7 +5624,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5644,7 +5644,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5668,7 +5668,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 17"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5688,7 +5688,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5712,7 +5712,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5732,7 +5732,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5752,7 +5752,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5778,7 +5778,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5816,7 +5816,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5841,7 +5841,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
               <text
                 id="EW 2"
                 fill="white"
-                font-family="Radio Canada Big"
+                font-family="Radio Canada Big Variable"
                 font-size="16"
                 font-weight="600"
                 letter-spacing="0em"
@@ -5883,7 +5883,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
               <text
                 id="DT 32"
                 fill="white"
-                font-family="Radio Canada Big"
+                font-family="Radio Canada Big Variable"
                 font-size="16"
                 font-weight="600"
                 letter-spacing="0em"
@@ -5906,7 +5906,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5926,7 +5926,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5950,7 +5950,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 32"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5974,7 +5974,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 31"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5998,7 +5998,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 30"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6022,7 +6022,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 29"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6046,7 +6046,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6070,7 +6070,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6090,7 +6090,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6114,7 +6114,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 33"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6138,7 +6138,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6162,7 +6162,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6186,7 +6186,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6210,7 +6210,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6234,7 +6234,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6258,7 +6258,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6282,7 +6282,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6306,7 +6306,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6330,7 +6330,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6354,7 +6354,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6378,7 +6378,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6402,7 +6402,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6426,7 +6426,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6450,7 +6450,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6474,7 +6474,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6498,7 +6498,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6522,7 +6522,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6546,7 +6546,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6570,7 +6570,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6594,7 +6594,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6618,7 +6618,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6642,7 +6642,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6666,7 +6666,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6690,7 +6690,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6714,7 +6714,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6738,7 +6738,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6762,7 +6762,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6786,7 +6786,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6810,7 +6810,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6834,7 +6834,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6858,7 +6858,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6882,7 +6882,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6906,7 +6906,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6930,7 +6930,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6954,7 +6954,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6978,7 +6978,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7002,7 +7002,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7026,7 +7026,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7050,7 +7050,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7074,7 +7074,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7098,7 +7098,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7122,7 +7122,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7146,7 +7146,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7170,7 +7170,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7194,7 +7194,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7218,7 +7218,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7242,7 +7242,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7266,7 +7266,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7290,7 +7290,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7314,7 +7314,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7338,7 +7338,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7362,7 +7362,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7386,7 +7386,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7410,7 +7410,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7434,7 +7434,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7458,7 +7458,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7482,7 +7482,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7506,7 +7506,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7530,7 +7530,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7554,7 +7554,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7578,7 +7578,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7602,7 +7602,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7626,7 +7626,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7650,7 +7650,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7674,7 +7674,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7698,7 +7698,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7722,7 +7722,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7746,7 +7746,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7770,7 +7770,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7794,7 +7794,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7818,7 +7818,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7842,7 +7842,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7866,7 +7866,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7890,7 +7890,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7914,7 +7914,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7938,7 +7938,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 29"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7962,7 +7962,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 30"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7986,7 +7986,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8010,7 +8010,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8034,7 +8034,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8058,7 +8058,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8082,7 +8082,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8106,7 +8106,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8130,7 +8130,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8154,7 +8154,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8178,7 +8178,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8202,7 +8202,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8226,7 +8226,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8250,7 +8250,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8274,7 +8274,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8298,7 +8298,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8322,7 +8322,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8346,7 +8346,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8370,7 +8370,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8394,7 +8394,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8418,7 +8418,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8442,7 +8442,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8466,7 +8466,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8490,7 +8490,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8514,7 +8514,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8538,7 +8538,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8562,7 +8562,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8586,7 +8586,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8610,7 +8610,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8634,7 +8634,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8658,7 +8658,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8682,7 +8682,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8706,7 +8706,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 29"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8730,7 +8730,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 30"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8754,7 +8754,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 31"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8778,7 +8778,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 33"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8802,7 +8802,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 34"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8826,7 +8826,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 34_2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8850,7 +8850,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8874,7 +8874,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8898,7 +8898,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8922,7 +8922,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8946,7 +8946,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8970,7 +8970,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 28"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8994,7 +8994,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 27"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9018,7 +9018,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 26"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9042,7 +9042,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 25"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9066,7 +9066,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 24"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9090,7 +9090,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 23"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9114,7 +9114,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 21"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9138,7 +9138,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 20"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9162,7 +9162,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 16"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9186,7 +9186,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 14"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9210,7 +9210,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 12"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9234,7 +9234,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 11"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9258,7 +9258,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 8"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9282,7 +9282,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 7"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9306,7 +9306,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 6"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9330,7 +9330,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 5"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9354,7 +9354,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 3"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9378,7 +9378,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 2"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9402,7 +9402,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9426,7 +9426,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9450,7 +9450,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9474,7 +9474,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9498,7 +9498,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9522,7 +9522,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9546,7 +9546,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9570,7 +9570,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9594,7 +9594,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9618,7 +9618,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9642,7 +9642,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9666,7 +9666,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9690,7 +9690,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9714,7 +9714,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9738,7 +9738,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9762,7 +9762,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9786,7 +9786,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9810,7 +9810,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9834,7 +9834,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9858,7 +9858,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9882,7 +9882,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JW 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9906,7 +9906,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9930,7 +9930,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9954,7 +9954,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9978,7 +9978,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10002,7 +10002,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10026,7 +10026,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10050,7 +10050,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10074,7 +10074,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10098,7 +10098,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10122,7 +10122,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10146,7 +10146,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 22A"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10170,7 +10170,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 30"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10194,7 +10194,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 31"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10218,7 +10218,7 @@ const _MapDec2029: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 32"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"

--- a/app/components/StationMap/components/MapDec2030.tsx
+++ b/app/components/StationMap/components/MapDec2030.tsx
@@ -1886,7 +1886,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jur"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1901,7 +1901,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1916,7 +1916,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bbt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1928,7 +1928,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1940,7 +1940,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cck"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1952,7 +1952,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ckw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1967,7 +1967,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tgh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1979,7 +1979,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tgp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1994,7 +1994,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2009,7 +2009,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bbw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2024,7 +2024,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tgn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2039,7 +2039,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jth"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2054,7 +2054,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pdr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2066,7 +2066,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2081,7 +2081,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cpn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2093,7 +2093,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jrw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2108,7 +2108,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bhj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2123,7 +2123,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_etp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2135,7 +2135,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2147,7 +2147,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jrh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2159,7 +2159,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jrp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2171,7 +2171,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_gkp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2186,7 +2186,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tws"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2198,7 +2198,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nyg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2213,7 +2213,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nyc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2228,7 +2228,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pkh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2243,7 +2243,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ywt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2255,7 +2255,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bkp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2267,7 +2267,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kth"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2279,7 +2279,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2291,7 +2291,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnx"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2303,7 +2303,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_snj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2315,7 +2315,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jlp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2327,7 +2327,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sgr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2339,7 +2339,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fjr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2351,7 +2351,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_stk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2363,7 +2363,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cgl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2375,7 +2375,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fmw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2387,7 +2387,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kpg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2399,7 +2399,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2411,7 +2411,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fnv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2423,7 +2423,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lyr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2435,7 +2435,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2447,7 +2447,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rnj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2459,7 +2459,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2471,7 +2471,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2483,7 +2483,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bak"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2495,7 +2495,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rmb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2507,7 +2507,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cpv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2519,7 +2519,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_smg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2531,7 +2531,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nbg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2543,7 +2543,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_smd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2555,7 +2555,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pgp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2567,7 +2567,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2579,7 +2579,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_smk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2591,7 +2591,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dam"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2603,7 +2603,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_oas"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2615,7 +2615,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2627,7 +2627,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_riv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2639,7 +2639,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cre"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2651,7 +2651,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2663,7 +2663,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cov"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2675,7 +2675,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bkt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2687,7 +2687,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2699,7 +2699,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ptr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2711,7 +2711,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_shv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2723,7 +2723,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_krj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2735,7 +2735,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_csw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2747,7 +2747,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hvw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2759,7 +2759,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hme"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2771,7 +2771,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_btw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2783,7 +2783,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kap"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2795,7 +2795,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sav"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2807,7 +2807,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2819,7 +2819,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_msl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2831,7 +2831,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2843,7 +2843,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wdn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2855,7 +2855,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wds"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2867,7 +2867,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_spl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2879,7 +2879,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ltr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2891,7 +2891,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mfl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2903,7 +2903,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_brh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2915,7 +2915,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_uts"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2927,7 +2927,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_npr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2939,7 +2939,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_obv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2951,7 +2951,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_adm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2963,7 +2963,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sbw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2975,7 +2975,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cbr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2987,7 +2987,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_yis"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2999,7 +2999,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ktb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3011,7 +3011,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_yck"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3023,7 +3023,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_amk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3035,7 +3035,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tge"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3047,7 +3047,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bsh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3059,7 +3059,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lrc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3071,7 +3071,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ser"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3083,7 +3083,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bly"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3095,7 +3095,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tsg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3107,7 +3107,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mps"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3119,7 +3119,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ubi"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3131,7 +3131,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kkb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3143,7 +3143,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3155,7 +3155,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3170,7 +3170,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3185,7 +3185,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tam"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3197,7 +3197,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpe"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3209,7 +3209,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_upc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3221,7 +3221,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_xpo"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3233,7 +3233,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cga"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3248,7 +3248,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_xln"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3260,7 +3260,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sgb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3272,7 +3272,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pyl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3284,7 +3284,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dkt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3296,7 +3296,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mbt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3308,7 +3308,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sdm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3320,7 +3320,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nch"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3332,7 +3332,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pmn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3344,7 +3344,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_epn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3356,7 +3356,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bbs"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3371,7 +3371,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bft"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3383,7 +3383,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3395,7 +3395,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tap"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3407,7 +3407,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_psr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3419,7 +3419,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pre"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3434,7 +3434,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lyg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3446,7 +3446,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_avp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3461,7 +3461,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3473,7 +3473,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dfu"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3485,7 +3485,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sgn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3500,7 +3500,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tvk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3512,7 +3512,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pgc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3527,7 +3527,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pgl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3539,7 +3539,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_skg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3551,7 +3551,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3563,7 +3563,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hgn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3575,7 +3575,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kvn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3587,7 +3587,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wlh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3599,7 +3599,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ptp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3611,7 +3611,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3623,7 +3623,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_frp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3635,7 +3635,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sim"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3647,7 +3647,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3659,7 +3659,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_eun"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3671,7 +3671,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_alj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3683,7 +3683,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kal"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3695,7 +3695,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lvr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3707,7 +3707,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kem"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3719,7 +3719,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tnm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3731,7 +3731,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nov"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3743,7 +3743,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_new"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3755,7 +3755,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_orc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3767,7 +3767,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_grw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3779,7 +3779,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hvl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3791,7 +3791,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_max"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3803,7 +3803,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_shw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3815,7 +3815,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_som"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3827,7 +3827,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cth"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3842,7 +3842,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3857,7 +3857,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rfp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3872,7 +3872,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3884,7 +3884,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_grb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3896,7 +3896,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_trh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3908,7 +3908,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fdm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3920,7 +3920,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ktp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3932,7 +3932,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3944,7 +3944,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mpr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3956,7 +3956,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mtc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3968,7 +3968,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sgl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3980,7 +3980,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bsr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3992,7 +3992,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bds"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4004,7 +4004,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_msp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4016,7 +4016,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hbf"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4028,7 +4028,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tlb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4040,7 +4040,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lbd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4052,7 +4052,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ppj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4064,7 +4064,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hpv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4076,7 +4076,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_krg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4088,7 +4088,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_onh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4100,7 +4100,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4112,7 +4112,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dvr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4124,7 +4124,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cle"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4136,7 +4136,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lks"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4148,7 +4148,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4160,7 +4160,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4172,7 +4172,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jkn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4184,7 +4184,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_gcl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4196,7 +4196,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tcr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4211,7 +4211,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_twr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4229,7 +4229,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tlk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4241,7 +4241,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hlv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4253,7 +4253,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_frr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4265,7 +4265,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cdt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4277,7 +4277,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4289,7 +4289,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_btn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4304,7 +4304,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_stv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4316,7 +4316,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lti"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4331,7 +4331,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rcr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4343,7 +4343,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4355,7 +4355,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_glb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4367,7 +4367,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mtr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4379,7 +4379,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jlb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4391,7 +4391,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgs"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4403,7 +4403,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dtn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4415,7 +4415,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tla"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4430,7 +4430,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ctn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4442,7 +4442,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_otp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4454,7 +4454,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tib"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4466,7 +4466,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rdh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4478,7 +4478,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_que"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4490,7 +4490,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_com"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4502,7 +4502,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fcn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4514,7 +4514,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bcl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4526,7 +4526,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dbg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4541,7 +4541,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_crq"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4556,7 +4556,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kpl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4568,7 +4568,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ctm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4580,7 +4580,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_per"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4606,7 +4606,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4626,7 +4626,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 15"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4650,7 +4650,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PTC"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4670,7 +4670,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4694,7 +4694,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4714,7 +4714,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="STC"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4738,7 +4738,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4758,7 +4758,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 13"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4782,7 +4782,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4802,7 +4802,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 10"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4826,7 +4826,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4846,7 +4846,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 9"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4870,7 +4870,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4890,7 +4890,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4914,7 +4914,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4934,7 +4934,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 4"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4958,7 +4958,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4978,7 +4978,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CE 1"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5002,7 +5002,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5022,7 +5022,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5046,7 +5046,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5066,7 +5066,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5090,7 +5090,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5110,7 +5110,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5134,7 +5134,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 29"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5154,7 +5154,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5178,7 +5178,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5198,7 +5198,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5218,7 +5218,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 1"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5242,7 +5242,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5262,7 +5262,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5282,7 +5282,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5306,7 +5306,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5326,7 +5326,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5346,7 +5346,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CE 2"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5372,7 +5372,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5410,7 +5410,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5434,7 +5434,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5454,7 +5454,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5474,7 +5474,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5498,7 +5498,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 22"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5518,7 +5518,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5542,7 +5542,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 19"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5562,7 +5562,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5586,7 +5586,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5606,7 +5606,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5630,7 +5630,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5650,7 +5650,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5674,7 +5674,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5694,7 +5694,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 35"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5718,7 +5718,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 31"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5738,7 +5738,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 37"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5762,7 +5762,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5782,7 +5782,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5806,7 +5806,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5826,7 +5826,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5850,7 +5850,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 17"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5870,7 +5870,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5894,7 +5894,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5914,7 +5914,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5934,7 +5934,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5960,7 +5960,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5998,7 +5998,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6023,7 +6023,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
               <text
                 id="EW 2"
                 fill="white"
-                font-family="Radio Canada Big"
+                font-family="Radio Canada Big Variable"
                 font-size="16"
                 font-weight="600"
                 letter-spacing="0em"
@@ -6065,7 +6065,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
               <text
                 id="DT 32"
                 fill="white"
-                font-family="Radio Canada Big"
+                font-family="Radio Canada Big Variable"
                 font-size="16"
                 font-weight="600"
                 letter-spacing="0em"
@@ -6088,7 +6088,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6108,7 +6108,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6132,7 +6132,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 32"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6156,7 +6156,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 31"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6180,7 +6180,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 30"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6204,7 +6204,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 29"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6228,7 +6228,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6252,7 +6252,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6272,7 +6272,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6296,7 +6296,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 33"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6320,7 +6320,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6344,7 +6344,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6368,7 +6368,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6392,7 +6392,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6416,7 +6416,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6440,7 +6440,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6464,7 +6464,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6488,7 +6488,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6512,7 +6512,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6536,7 +6536,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6560,7 +6560,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6584,7 +6584,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6608,7 +6608,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6632,7 +6632,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6656,7 +6656,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6680,7 +6680,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6704,7 +6704,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6728,7 +6728,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6752,7 +6752,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6776,7 +6776,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6800,7 +6800,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6824,7 +6824,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6848,7 +6848,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6872,7 +6872,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6896,7 +6896,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6920,7 +6920,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6944,7 +6944,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6968,7 +6968,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6992,7 +6992,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7016,7 +7016,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7040,7 +7040,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7064,7 +7064,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7088,7 +7088,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7112,7 +7112,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7136,7 +7136,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7160,7 +7160,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7184,7 +7184,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7208,7 +7208,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7232,7 +7232,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7256,7 +7256,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7280,7 +7280,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7304,7 +7304,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7328,7 +7328,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7352,7 +7352,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7376,7 +7376,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7400,7 +7400,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7424,7 +7424,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7448,7 +7448,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7472,7 +7472,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7496,7 +7496,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7520,7 +7520,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7540,7 +7540,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7564,7 +7564,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7588,7 +7588,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7612,7 +7612,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7636,7 +7636,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7660,7 +7660,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7684,7 +7684,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7708,7 +7708,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7732,7 +7732,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7756,7 +7756,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7780,7 +7780,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7804,7 +7804,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7828,7 +7828,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7852,7 +7852,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7872,7 +7872,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7896,7 +7896,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7920,7 +7920,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7944,7 +7944,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7968,7 +7968,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7992,7 +7992,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8016,7 +8016,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 22A"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8040,7 +8040,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8064,7 +8064,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8088,7 +8088,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8112,7 +8112,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8136,7 +8136,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8160,7 +8160,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 29"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8184,7 +8184,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 30"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8208,7 +8208,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8232,7 +8232,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8256,7 +8256,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8280,7 +8280,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8304,7 +8304,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8328,7 +8328,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8352,7 +8352,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8372,7 +8372,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8396,7 +8396,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8420,7 +8420,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8444,7 +8444,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8468,7 +8468,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8492,7 +8492,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8516,7 +8516,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8540,7 +8540,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8564,7 +8564,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8588,7 +8588,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8612,7 +8612,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8636,7 +8636,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8660,7 +8660,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8684,7 +8684,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8708,7 +8708,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8732,7 +8732,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8756,7 +8756,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8780,7 +8780,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8804,7 +8804,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8828,7 +8828,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8852,7 +8852,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8876,7 +8876,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8900,7 +8900,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8924,7 +8924,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8948,7 +8948,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 29"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8972,7 +8972,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 30"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8996,7 +8996,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 31"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9020,7 +9020,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 33"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9044,7 +9044,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 34"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9068,7 +9068,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 34_2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9092,7 +9092,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9116,7 +9116,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9140,7 +9140,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9164,7 +9164,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9188,7 +9188,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9212,7 +9212,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 28"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9236,7 +9236,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 27"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9260,7 +9260,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 26"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9284,7 +9284,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 25"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9308,7 +9308,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 24"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9332,7 +9332,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 23"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9356,7 +9356,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 21"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9380,7 +9380,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 20"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9404,7 +9404,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 16"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9428,7 +9428,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 14"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9452,7 +9452,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 12"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9476,7 +9476,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 11"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9500,7 +9500,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 8"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9524,7 +9524,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 7"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9548,7 +9548,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 6"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9572,7 +9572,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 5"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9596,7 +9596,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 3"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9620,7 +9620,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 2"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9644,7 +9644,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9668,7 +9668,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9692,7 +9692,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9716,7 +9716,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9740,7 +9740,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9764,7 +9764,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9788,7 +9788,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9812,7 +9812,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9836,7 +9836,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9856,7 +9856,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9880,7 +9880,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9904,7 +9904,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9928,7 +9928,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9952,7 +9952,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9976,7 +9976,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10000,7 +10000,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10024,7 +10024,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10048,7 +10048,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10072,7 +10072,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10096,7 +10096,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10120,7 +10120,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10144,7 +10144,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JW 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10168,7 +10168,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10192,7 +10192,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10216,7 +10216,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10240,7 +10240,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10264,7 +10264,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10288,7 +10288,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10312,7 +10312,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10336,7 +10336,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10360,7 +10360,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10384,7 +10384,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10408,7 +10408,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10432,7 +10432,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10456,7 +10456,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10480,7 +10480,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10504,7 +10504,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10528,7 +10528,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10552,7 +10552,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10576,7 +10576,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10600,7 +10600,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10624,7 +10624,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 30"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10648,7 +10648,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 31"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10672,7 +10672,7 @@ const _MapDec2030: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 32"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"

--- a/app/components/StationMap/components/MapDec2032.tsx
+++ b/app/components/StationMap/components/MapDec2032.tsx
@@ -1940,7 +1940,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jur"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1955,7 +1955,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1970,7 +1970,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bbt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1982,7 +1982,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1994,7 +1994,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cck"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2006,7 +2006,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ckw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2021,7 +2021,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tgh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2033,7 +2033,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tgp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2048,7 +2048,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2063,7 +2063,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bbw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2078,7 +2078,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tgn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2093,7 +2093,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jth"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2108,7 +2108,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pdr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2120,7 +2120,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2135,7 +2135,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cpn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2147,7 +2147,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jrw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2162,7 +2162,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bhj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2177,7 +2177,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_etp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2189,7 +2189,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2201,7 +2201,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jrh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2213,7 +2213,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jrp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2225,7 +2225,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_gkp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2240,7 +2240,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tws"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2252,7 +2252,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nyg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2267,7 +2267,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nyc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2282,7 +2282,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pkh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2297,7 +2297,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ywt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2309,7 +2309,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bkp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2321,7 +2321,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kth"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2333,7 +2333,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2345,7 +2345,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnx"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2357,7 +2357,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_snj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2369,7 +2369,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jlp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2381,7 +2381,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sgr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2393,7 +2393,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fjr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2405,7 +2405,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_stk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2417,7 +2417,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cgl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2429,7 +2429,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fmw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2441,7 +2441,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kpg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2453,7 +2453,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2465,7 +2465,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fnv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2477,7 +2477,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lyr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2489,7 +2489,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2501,7 +2501,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rnj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2513,7 +2513,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2525,7 +2525,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2537,7 +2537,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bak"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2549,7 +2549,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rmb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2561,7 +2561,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cpv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2573,7 +2573,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_smg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2585,7 +2585,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nbg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2597,7 +2597,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_smd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2609,7 +2609,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pgp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2621,7 +2621,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2633,7 +2633,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_smk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2645,7 +2645,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dam"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2657,7 +2657,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_oas"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2669,7 +2669,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2681,7 +2681,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_riv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2693,7 +2693,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cre"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2705,7 +2705,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2717,7 +2717,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cov"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2729,7 +2729,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bkt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2741,7 +2741,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2753,7 +2753,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ptr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2765,7 +2765,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_shv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2777,7 +2777,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_krj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2789,7 +2789,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_csw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2801,7 +2801,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hvw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2813,7 +2813,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hme"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2825,7 +2825,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_btw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2837,7 +2837,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kap"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2849,7 +2849,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sav"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2861,7 +2861,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2873,7 +2873,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_msl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2885,7 +2885,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2897,7 +2897,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wdn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2909,7 +2909,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wds"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2921,7 +2921,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_spl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2933,7 +2933,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ltr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2945,7 +2945,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mfl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2957,7 +2957,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_brh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2969,7 +2969,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_uts"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2981,7 +2981,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_npr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2993,7 +2993,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_obv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3005,7 +3005,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_adm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3017,7 +3017,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sbw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3029,7 +3029,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cbr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3041,7 +3041,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_yis"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3053,7 +3053,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ktb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3065,7 +3065,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_yck"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3077,7 +3077,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_amk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3089,7 +3089,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tge"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3101,7 +3101,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tfc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3113,7 +3113,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_maj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3125,7 +3125,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wsc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3137,7 +3137,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jld"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3149,7 +3149,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bsh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3161,7 +3161,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lrc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3173,7 +3173,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ser"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3185,7 +3185,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bly"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3197,7 +3197,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tsg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3209,7 +3209,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mps"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3221,7 +3221,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ubi"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3233,7 +3233,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kkb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3245,7 +3245,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3257,7 +3257,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3272,7 +3272,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3287,7 +3287,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tam"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3299,7 +3299,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpe"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3311,7 +3311,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_upc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3323,7 +3323,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_xpo"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3335,7 +3335,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cga"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3350,7 +3350,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_xln"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3362,7 +3362,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sgb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3374,7 +3374,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pyl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3386,7 +3386,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dkt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3398,7 +3398,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mbt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3410,7 +3410,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sdm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3422,7 +3422,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nch"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3434,7 +3434,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pmn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3446,7 +3446,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_epn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3458,7 +3458,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bbs"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3473,7 +3473,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bft"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3485,7 +3485,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3497,7 +3497,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tap"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3509,7 +3509,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_psr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3521,7 +3521,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pre"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3536,7 +3536,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lyg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3548,7 +3548,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_avp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3563,7 +3563,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3575,7 +3575,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dfu"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3587,7 +3587,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sgn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3602,7 +3602,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tvk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3614,7 +3614,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_prl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3626,7 +3626,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pgc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3641,7 +3641,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pgl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3653,7 +3653,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_skg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3665,7 +3665,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3677,7 +3677,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hgn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3689,7 +3689,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kvn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3701,7 +3701,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wlh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3713,7 +3713,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ptp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3725,7 +3725,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3737,7 +3737,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_frp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3749,7 +3749,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sim"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3761,7 +3761,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3773,7 +3773,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_eun"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3785,7 +3785,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_alj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3797,7 +3797,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kal"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3809,7 +3809,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lvr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3821,7 +3821,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kem"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3833,7 +3833,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tnm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3845,7 +3845,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nov"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3857,7 +3857,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_new"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3869,7 +3869,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_orc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3881,7 +3881,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_grw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3893,7 +3893,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hvl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3905,7 +3905,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_max"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3917,7 +3917,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_shw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3929,7 +3929,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_som"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3941,7 +3941,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cth"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3956,7 +3956,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3971,7 +3971,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rfp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3986,7 +3986,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3998,7 +3998,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_grb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4010,7 +4010,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_trh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4022,7 +4022,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fdm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4034,7 +4034,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ktp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4046,7 +4046,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4058,7 +4058,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mpr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4070,7 +4070,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mtc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4082,7 +4082,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sgl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4094,7 +4094,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bsr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4106,7 +4106,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bds"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4118,7 +4118,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_msp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4130,7 +4130,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hbf"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4142,7 +4142,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tlb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4154,7 +4154,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lbd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4166,7 +4166,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ppj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4178,7 +4178,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hpv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4190,7 +4190,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_krg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4202,7 +4202,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_onh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4214,7 +4214,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4226,7 +4226,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dvr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4238,7 +4238,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cle"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4250,7 +4250,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lks"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4262,7 +4262,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4274,7 +4274,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4286,7 +4286,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jkn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4298,7 +4298,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_gcl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4310,7 +4310,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tcr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4325,7 +4325,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_twr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4343,7 +4343,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tlk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4355,7 +4355,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hlv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4367,7 +4367,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_frr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4379,7 +4379,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cdt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4391,7 +4391,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4403,7 +4403,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_btn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4418,7 +4418,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_stv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4430,7 +4430,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lti"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4445,7 +4445,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rcr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4457,7 +4457,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4469,7 +4469,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_glb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4481,7 +4481,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mtr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4493,7 +4493,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jlb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4505,7 +4505,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgs"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4517,7 +4517,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dtn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4529,7 +4529,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tla"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4544,7 +4544,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ctn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4556,7 +4556,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_otp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4568,7 +4568,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tib"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4580,7 +4580,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rdh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4592,7 +4592,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_que"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4604,7 +4604,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_com"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4616,7 +4616,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fcn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4628,7 +4628,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bcl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4640,7 +4640,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dbg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4655,7 +4655,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_crq"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4670,7 +4670,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kpl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4682,7 +4682,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ctm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4694,7 +4694,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_per"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -4720,7 +4720,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4740,7 +4740,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 15"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4764,7 +4764,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PTC"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4784,7 +4784,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4804,7 +4804,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CP 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4828,7 +4828,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4848,7 +4848,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="STC"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4872,7 +4872,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4892,7 +4892,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 13"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4916,7 +4916,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4936,7 +4936,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 10"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4960,7 +4960,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4980,7 +4980,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 9"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5004,7 +5004,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5024,7 +5024,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5048,7 +5048,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5068,7 +5068,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 4"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5092,7 +5092,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5112,7 +5112,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CE 1"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5136,7 +5136,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5156,7 +5156,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5180,7 +5180,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5200,7 +5200,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5224,7 +5224,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5244,7 +5244,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5268,7 +5268,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 29"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5288,7 +5288,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5312,7 +5312,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5332,7 +5332,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5352,7 +5352,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 1"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5376,7 +5376,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5396,7 +5396,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5416,7 +5416,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5440,7 +5440,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5460,7 +5460,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5480,7 +5480,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CE 2"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5506,7 +5506,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5544,7 +5544,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5568,7 +5568,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5588,7 +5588,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5608,7 +5608,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5632,7 +5632,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 22"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5652,7 +5652,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5676,7 +5676,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 19"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5696,7 +5696,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5720,7 +5720,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5740,7 +5740,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5764,7 +5764,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5784,7 +5784,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5808,7 +5808,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5828,7 +5828,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 35"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5852,7 +5852,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 31"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5872,7 +5872,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 37"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5896,7 +5896,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5916,7 +5916,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5940,7 +5940,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5960,7 +5960,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5984,7 +5984,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 17"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6004,7 +6004,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6028,7 +6028,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6048,7 +6048,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6068,7 +6068,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6094,7 +6094,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6132,7 +6132,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6157,7 +6157,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
               <text
                 id="EW 2"
                 fill="white"
-                font-family="Radio Canada Big"
+                font-family="Radio Canada Big Variable"
                 font-size="16"
                 font-weight="600"
                 letter-spacing="0em"
@@ -6199,7 +6199,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
               <text
                 id="DT 32"
                 fill="white"
-                font-family="Radio Canada Big"
+                font-family="Radio Canada Big Variable"
                 font-size="16"
                 font-weight="600"
                 letter-spacing="0em"
@@ -6222,7 +6222,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6242,7 +6242,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6266,7 +6266,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 32"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6290,7 +6290,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 31"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6314,7 +6314,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 30"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6338,7 +6338,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 29"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6362,7 +6362,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6386,7 +6386,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6406,7 +6406,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6430,7 +6430,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 33"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6454,7 +6454,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6478,7 +6478,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6502,7 +6502,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6522,7 +6522,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6546,7 +6546,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6570,7 +6570,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6594,7 +6594,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6618,7 +6618,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6642,7 +6642,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6666,7 +6666,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6690,7 +6690,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6714,7 +6714,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6738,7 +6738,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6762,7 +6762,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6786,7 +6786,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6810,7 +6810,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6834,7 +6834,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6858,7 +6858,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6882,7 +6882,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6906,7 +6906,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6930,7 +6930,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6954,7 +6954,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6978,7 +6978,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7002,7 +7002,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7026,7 +7026,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7050,7 +7050,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7074,7 +7074,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7098,7 +7098,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7122,7 +7122,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7146,7 +7146,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7170,7 +7170,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7194,7 +7194,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7218,7 +7218,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7242,7 +7242,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7266,7 +7266,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7290,7 +7290,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7314,7 +7314,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7338,7 +7338,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7362,7 +7362,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7386,7 +7386,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7410,7 +7410,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7434,7 +7434,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7458,7 +7458,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7482,7 +7482,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7506,7 +7506,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7530,7 +7530,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7554,7 +7554,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7578,7 +7578,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7602,7 +7602,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7626,7 +7626,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7650,7 +7650,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7674,7 +7674,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7694,7 +7694,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7718,7 +7718,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7742,7 +7742,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7766,7 +7766,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7790,7 +7790,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7814,7 +7814,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7838,7 +7838,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7862,7 +7862,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7886,7 +7886,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7910,7 +7910,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7934,7 +7934,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7958,7 +7958,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7982,7 +7982,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8006,7 +8006,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8026,7 +8026,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8050,7 +8050,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8074,7 +8074,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8098,7 +8098,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8122,7 +8122,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8146,7 +8146,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8170,7 +8170,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 22A"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8194,7 +8194,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8218,7 +8218,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8242,7 +8242,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8266,7 +8266,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8290,7 +8290,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8314,7 +8314,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 29"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8338,7 +8338,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 30"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8362,7 +8362,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8386,7 +8386,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8410,7 +8410,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8434,7 +8434,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8458,7 +8458,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8482,7 +8482,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8506,7 +8506,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8526,7 +8526,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8550,7 +8550,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8574,7 +8574,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8598,7 +8598,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8622,7 +8622,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8646,7 +8646,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8670,7 +8670,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8694,7 +8694,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8718,7 +8718,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8742,7 +8742,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8766,7 +8766,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8786,7 +8786,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8810,7 +8810,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8834,7 +8834,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8858,7 +8858,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8882,7 +8882,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8906,7 +8906,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8930,7 +8930,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8954,7 +8954,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8978,7 +8978,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9002,7 +9002,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9026,7 +9026,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9050,7 +9050,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9074,7 +9074,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9098,7 +9098,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9122,7 +9122,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 29"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9146,7 +9146,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 30"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9170,7 +9170,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 31"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9194,7 +9194,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 33"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9218,7 +9218,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 34"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9242,7 +9242,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 34_2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9266,7 +9266,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9290,7 +9290,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9314,7 +9314,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9338,7 +9338,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9362,7 +9362,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9386,7 +9386,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 28"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9410,7 +9410,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 27"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9434,7 +9434,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 26"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9458,7 +9458,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 25"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9482,7 +9482,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 24"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9506,7 +9506,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 23"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9530,7 +9530,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 21"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9554,7 +9554,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 20"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9578,7 +9578,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 16"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9602,7 +9602,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 14"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9626,7 +9626,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 12"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9650,7 +9650,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 11"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9674,7 +9674,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 8"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9698,7 +9698,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 7"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9722,7 +9722,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 6"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9746,7 +9746,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 5"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9770,7 +9770,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 3"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9794,7 +9794,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 2"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9818,7 +9818,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9842,7 +9842,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9866,7 +9866,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9890,7 +9890,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9914,7 +9914,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9938,7 +9938,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9962,7 +9962,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -9986,7 +9986,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10010,7 +10010,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CP 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10030,7 +10030,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10050,7 +10050,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10074,7 +10074,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10098,7 +10098,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10122,7 +10122,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10146,7 +10146,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10170,7 +10170,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10194,7 +10194,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10218,7 +10218,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10242,7 +10242,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10266,7 +10266,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10290,7 +10290,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10314,7 +10314,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10338,7 +10338,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JW 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10362,7 +10362,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10386,7 +10386,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10410,7 +10410,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10434,7 +10434,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10458,7 +10458,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10482,7 +10482,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10506,7 +10506,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JS 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10530,7 +10530,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10554,7 +10554,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10578,7 +10578,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="JW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10602,7 +10602,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CP 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10626,7 +10626,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10650,7 +10650,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10674,7 +10674,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10698,7 +10698,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10722,7 +10722,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10746,7 +10746,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10770,7 +10770,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10794,7 +10794,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10818,7 +10818,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10842,7 +10842,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10866,7 +10866,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10890,7 +10890,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CR 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10916,7 +10916,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CP 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10954,7 +10954,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -10978,7 +10978,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 30"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -11002,7 +11002,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 31"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -11026,7 +11026,7 @@ const _MapDec2032: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 32"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"

--- a/app/components/StationMap/components/MapJan2012.tsx
+++ b/app/components/StationMap/components/MapJan2012.tsx
@@ -976,7 +976,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jur"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -988,7 +988,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1003,7 +1003,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bbt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1015,7 +1015,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1027,7 +1027,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cck"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1039,7 +1039,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ywt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1051,7 +1051,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bkp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1066,7 +1066,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kth"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1078,7 +1078,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1090,7 +1090,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnx"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1102,7 +1102,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tmj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1117,7 +1117,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_snj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1129,7 +1129,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jlp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1141,7 +1141,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sgr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1153,7 +1153,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fjr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1165,7 +1165,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fmw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1177,7 +1177,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1189,7 +1189,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fnv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1201,7 +1201,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lyr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1213,7 +1213,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1225,7 +1225,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rnj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1237,7 +1237,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1249,7 +1249,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1261,7 +1261,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bak"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1273,7 +1273,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rmb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1285,7 +1285,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cpv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1297,7 +1297,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dam"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1309,7 +1309,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_oas"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1321,7 +1321,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1333,7 +1333,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_riv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1345,7 +1345,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cre"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1357,7 +1357,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1369,7 +1369,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cov"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1381,7 +1381,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bkt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1393,7 +1393,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1405,7 +1405,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ptr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1417,7 +1417,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_shv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1429,7 +1429,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_krj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1441,7 +1441,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_msl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1453,7 +1453,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1465,7 +1465,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_adm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1477,7 +1477,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sbw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1489,7 +1489,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_yis"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1501,7 +1501,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ktb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1513,7 +1513,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_yck"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1525,7 +1525,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_amk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1537,7 +1537,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bsh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1549,7 +1549,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lrc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1561,7 +1561,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ser"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1573,7 +1573,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bly"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1585,7 +1585,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tsg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1597,7 +1597,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mps"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1609,7 +1609,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tam"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1621,7 +1621,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_xpo"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1633,7 +1633,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cga"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1648,7 +1648,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pyl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1660,7 +1660,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dkt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1672,7 +1672,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mbt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1684,7 +1684,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sdm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1696,7 +1696,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nch"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1708,7 +1708,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pmn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1720,7 +1720,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_epn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1732,7 +1732,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bbs"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1747,7 +1747,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bft"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1759,7 +1759,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1771,7 +1771,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tap"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1783,7 +1783,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_psr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1795,7 +1795,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pgl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1807,7 +1807,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_skg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1819,7 +1819,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1831,7 +1831,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hgn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1843,7 +1843,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kvn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1855,7 +1855,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wlh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1867,7 +1867,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ptp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1879,7 +1879,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1891,7 +1891,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_frp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1903,7 +1903,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sim"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1915,7 +1915,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1927,7 +1927,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_eun"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1939,7 +1939,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_alj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1951,7 +1951,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kal"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1963,7 +1963,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lvr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1975,7 +1975,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kem"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1987,7 +1987,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tnm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1999,7 +1999,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nov"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2011,7 +2011,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_new"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2023,7 +2023,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_orc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2035,7 +2035,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_som"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2047,7 +2047,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cth"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2062,7 +2062,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2077,7 +2077,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rfp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2092,7 +2092,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2104,7 +2104,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hbf"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2116,7 +2116,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tlb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2128,7 +2128,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lbd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2140,7 +2140,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ppj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2152,7 +2152,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hpv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2164,7 +2164,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_krg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2176,7 +2176,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_onh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2188,7 +2188,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2200,7 +2200,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dvr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2212,7 +2212,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cle"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2224,7 +2224,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lks"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2236,7 +2236,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2248,7 +2248,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2260,7 +2260,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jkn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2272,7 +2272,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hlv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2284,7 +2284,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_frr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2296,7 +2296,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cdt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2308,7 +2308,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2320,7 +2320,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_btn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2335,7 +2335,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lti"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2347,7 +2347,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgs"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2359,7 +2359,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ctn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2371,7 +2371,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_otp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2383,7 +2383,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tib"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2395,7 +2395,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rdh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2407,7 +2407,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_que"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2419,7 +2419,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_com"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2431,7 +2431,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dbg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2446,7 +2446,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_crq"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2461,7 +2461,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cgl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2473,7 +2473,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kpg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2496,7 +2496,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -2516,7 +2516,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 15"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -2540,7 +2540,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -2560,7 +2560,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PTC"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -2584,7 +2584,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -2604,7 +2604,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="STC"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -2628,7 +2628,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -2648,7 +2648,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 13"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -2672,7 +2672,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 10"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -2696,7 +2696,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -2716,7 +2716,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 9"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -2740,7 +2740,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -2760,7 +2760,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -2784,7 +2784,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 4"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -2808,7 +2808,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CE 1"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -2832,7 +2832,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -2852,7 +2852,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -2876,7 +2876,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -2896,7 +2896,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -2920,7 +2920,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 29"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -2940,7 +2940,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -2964,7 +2964,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -2984,7 +2984,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3004,7 +3004,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 1"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3028,7 +3028,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3048,7 +3048,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3072,7 +3072,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3092,7 +3092,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CE 2"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3118,7 +3118,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3142,7 +3142,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3162,7 +3162,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3186,7 +3186,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 22"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3206,7 +3206,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3230,7 +3230,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 19"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3254,7 +3254,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3278,7 +3278,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3302,7 +3302,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3326,7 +3326,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3350,7 +3350,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3370,7 +3370,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3394,7 +3394,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3419,7 +3419,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
               <text
                 id="EW 2"
                 fill="white"
-                font-family="Radio Canada Big"
+                font-family="Radio Canada Big Variable"
                 font-size="14"
                 font-weight="600"
                 letter-spacing="0em"
@@ -3442,7 +3442,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 29"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3466,7 +3466,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3490,7 +3490,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3514,7 +3514,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3538,7 +3538,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3562,7 +3562,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3586,7 +3586,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3610,7 +3610,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3634,7 +3634,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3658,7 +3658,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3682,7 +3682,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3706,7 +3706,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3730,7 +3730,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3754,7 +3754,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3778,7 +3778,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3802,7 +3802,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3826,7 +3826,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3850,7 +3850,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3874,7 +3874,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3898,7 +3898,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3922,7 +3922,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3946,7 +3946,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3970,7 +3970,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3994,7 +3994,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4018,7 +4018,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4042,7 +4042,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4066,7 +4066,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4090,7 +4090,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4114,7 +4114,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4138,7 +4138,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4162,7 +4162,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4186,7 +4186,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4210,7 +4210,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4234,7 +4234,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4258,7 +4258,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4282,7 +4282,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4306,7 +4306,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4330,7 +4330,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4354,7 +4354,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4378,7 +4378,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4402,7 +4402,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4426,7 +4426,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4450,7 +4450,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4474,7 +4474,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4498,7 +4498,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4522,7 +4522,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4546,7 +4546,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4570,7 +4570,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4594,7 +4594,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4618,7 +4618,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4642,7 +4642,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4666,7 +4666,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4690,7 +4690,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4714,7 +4714,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4738,7 +4738,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4762,7 +4762,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4786,7 +4786,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4810,7 +4810,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4834,7 +4834,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4858,7 +4858,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4882,7 +4882,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4906,7 +4906,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4930,7 +4930,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4954,7 +4954,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4978,7 +4978,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5002,7 +5002,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5026,7 +5026,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5050,7 +5050,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5074,7 +5074,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 28"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5098,7 +5098,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 27"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5122,7 +5122,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 26"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5146,7 +5146,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 25"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5170,7 +5170,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 24"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5194,7 +5194,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 23"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5218,7 +5218,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 21"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5242,7 +5242,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 20"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5266,7 +5266,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 16"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5290,7 +5290,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 17"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5314,7 +5314,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 14"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5338,7 +5338,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 12"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5362,7 +5362,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 11"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5386,7 +5386,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 8"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5410,7 +5410,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 7"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5434,7 +5434,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 6"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5458,7 +5458,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 5"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5482,7 +5482,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 3"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5506,7 +5506,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 2"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5530,7 +5530,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5554,7 +5554,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5578,7 +5578,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5602,7 +5602,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5626,7 +5626,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5650,7 +5650,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5674,7 +5674,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5698,7 +5698,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5722,7 +5722,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5746,7 +5746,7 @@ const _MapJan2012: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"

--- a/app/components/StationMap/components/MapNov2017.tsx
+++ b/app/components/StationMap/components/MapNov2017.tsx
@@ -1311,7 +1311,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jur"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1323,7 +1323,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1338,7 +1338,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bbt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1350,7 +1350,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1362,7 +1362,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cck"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1374,7 +1374,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ywt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1386,7 +1386,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bkp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1401,7 +1401,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kth"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1413,7 +1413,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1425,7 +1425,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnx"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1437,7 +1437,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tmj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1452,7 +1452,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_snj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1464,7 +1464,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jlp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1476,7 +1476,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sgr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1488,7 +1488,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fjr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1500,7 +1500,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_stk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1512,7 +1512,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cgl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1524,7 +1524,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fmw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1536,7 +1536,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kpg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1548,7 +1548,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1560,7 +1560,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fnv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1572,7 +1572,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lyr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1584,7 +1584,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1596,7 +1596,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rnj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1608,7 +1608,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1620,7 +1620,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1632,7 +1632,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bak"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1644,7 +1644,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rmb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1656,7 +1656,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cpv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1668,7 +1668,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_smg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1680,7 +1680,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nbg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1692,7 +1692,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_smd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1704,7 +1704,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pgp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1716,7 +1716,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1728,7 +1728,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_smk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1740,7 +1740,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dam"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1752,7 +1752,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_oas"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1764,7 +1764,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1776,7 +1776,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_riv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1788,7 +1788,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cre"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1800,7 +1800,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1812,7 +1812,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cov"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1824,7 +1824,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bkt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1836,7 +1836,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1848,7 +1848,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ptr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1860,7 +1860,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_shv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1872,7 +1872,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_krj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1884,7 +1884,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_csw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1896,7 +1896,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hvw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1908,7 +1908,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_btw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1920,7 +1920,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kap"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1932,7 +1932,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sav"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1944,7 +1944,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1956,7 +1956,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_msl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1968,7 +1968,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1980,7 +1980,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_adm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1992,7 +1992,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sbw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2004,7 +2004,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_yis"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2016,7 +2016,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ktb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2028,7 +2028,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_yck"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2040,7 +2040,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_amk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2052,7 +2052,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bsh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2064,7 +2064,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lrc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2076,7 +2076,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ser"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2088,7 +2088,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bly"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2100,7 +2100,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tsg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2112,7 +2112,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mps"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2124,7 +2124,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ubi"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2136,7 +2136,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kkb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2148,7 +2148,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2160,7 +2160,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2175,7 +2175,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2190,7 +2190,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tam"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2202,7 +2202,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpe"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2214,7 +2214,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_upc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2226,7 +2226,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_xpo"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2238,7 +2238,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cga"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2253,7 +2253,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pyl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2265,7 +2265,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dkt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2277,7 +2277,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mbt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2289,7 +2289,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sdm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2301,7 +2301,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nch"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2313,7 +2313,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pmn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2325,7 +2325,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_epn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2337,7 +2337,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bbs"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2352,7 +2352,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bft"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2364,7 +2364,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2376,7 +2376,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tap"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2388,7 +2388,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_psr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2400,7 +2400,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pgl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2412,7 +2412,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_skg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2424,7 +2424,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2436,7 +2436,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hgn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2448,7 +2448,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kvn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2460,7 +2460,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wlh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2472,7 +2472,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ptp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2484,7 +2484,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2496,7 +2496,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_frp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2508,7 +2508,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sim"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2520,7 +2520,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2532,7 +2532,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_eun"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2544,7 +2544,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_alj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2556,7 +2556,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kal"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2568,7 +2568,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lvr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2580,7 +2580,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kem"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2592,7 +2592,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tnm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2604,7 +2604,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nov"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2616,7 +2616,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_new"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2628,7 +2628,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_orc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2640,7 +2640,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_som"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2652,7 +2652,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cth"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2667,7 +2667,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2682,7 +2682,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rfp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2697,7 +2697,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2709,7 +2709,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_msp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2721,7 +2721,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hbf"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2733,7 +2733,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tlb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2745,7 +2745,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lbd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2757,7 +2757,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ppj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2769,7 +2769,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hpv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2781,7 +2781,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_krg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2793,7 +2793,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_onh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2805,7 +2805,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2817,7 +2817,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dvr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2829,7 +2829,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cle"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2841,7 +2841,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lks"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2853,7 +2853,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2865,7 +2865,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2877,7 +2877,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jkn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2889,7 +2889,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_gcl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2901,7 +2901,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tcr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2913,7 +2913,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_twr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2925,7 +2925,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tlk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2937,7 +2937,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hlv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2949,7 +2949,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_frr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2961,7 +2961,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cdt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2973,7 +2973,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2985,7 +2985,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_btn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3000,7 +3000,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_stv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3012,7 +3012,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lti"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3027,7 +3027,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rcr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3039,7 +3039,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3051,7 +3051,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_glb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3063,7 +3063,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mtr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3075,7 +3075,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jlb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3087,7 +3087,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgs"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3099,7 +3099,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dtn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3111,7 +3111,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tla"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3126,7 +3126,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ctn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3138,7 +3138,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_otp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3150,7 +3150,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tib"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3162,7 +3162,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rdh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3174,7 +3174,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_que"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3186,7 +3186,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_com"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3198,7 +3198,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fcn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3210,7 +3210,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bcl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3222,7 +3222,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dbg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3237,7 +3237,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_crq"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3263,7 +3263,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3283,7 +3283,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 15"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3307,7 +3307,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3327,7 +3327,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PTC"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3351,7 +3351,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3371,7 +3371,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="STC"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3395,7 +3395,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3415,7 +3415,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 13"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3439,7 +3439,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3459,7 +3459,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 10"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3483,7 +3483,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3503,7 +3503,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 9"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3527,7 +3527,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3547,7 +3547,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3571,7 +3571,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3591,7 +3591,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 4"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3615,7 +3615,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3635,7 +3635,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CE 1"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3659,7 +3659,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3679,7 +3679,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3703,7 +3703,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3723,7 +3723,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3747,7 +3747,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 29"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3767,7 +3767,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3791,7 +3791,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3811,7 +3811,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3831,7 +3831,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 1"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3855,7 +3855,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3875,7 +3875,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3899,7 +3899,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3919,7 +3919,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CE 2"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3945,7 +3945,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3983,7 +3983,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4007,7 +4007,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4027,7 +4027,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4051,7 +4051,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 22"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4071,7 +4071,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4095,7 +4095,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 19"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4115,7 +4115,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4139,7 +4139,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4159,7 +4159,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4183,7 +4183,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4203,7 +4203,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4227,7 +4227,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4247,7 +4247,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 35"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4271,7 +4271,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4291,7 +4291,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4315,7 +4315,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4335,7 +4335,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4361,7 +4361,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4399,7 +4399,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4424,7 +4424,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
               <text
                 id="EW 2"
                 fill="white"
-                font-family="Radio Canada Big"
+                font-family="Radio Canada Big Variable"
                 font-size="16"
                 font-weight="600"
                 letter-spacing="0em"
@@ -4466,7 +4466,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
               <text
                 id="DT 32"
                 fill="white"
-                font-family="Radio Canada Big"
+                font-family="Radio Canada Big Variable"
                 font-size="16"
                 font-weight="600"
                 letter-spacing="0em"
@@ -4489,7 +4489,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 32"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4513,7 +4513,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 31"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4537,7 +4537,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 30"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4561,7 +4561,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 29"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4585,7 +4585,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4609,7 +4609,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4633,7 +4633,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 33"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4657,7 +4657,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4681,7 +4681,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4705,7 +4705,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4729,7 +4729,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4753,7 +4753,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4777,7 +4777,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4801,7 +4801,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4825,7 +4825,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4849,7 +4849,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4873,7 +4873,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4897,7 +4897,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4921,7 +4921,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4945,7 +4945,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4969,7 +4969,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4993,7 +4993,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5017,7 +5017,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5041,7 +5041,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5065,7 +5065,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5089,7 +5089,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5113,7 +5113,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5137,7 +5137,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5161,7 +5161,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5185,7 +5185,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5209,7 +5209,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5233,7 +5233,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5257,7 +5257,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5281,7 +5281,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5305,7 +5305,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5329,7 +5329,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5353,7 +5353,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5377,7 +5377,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5401,7 +5401,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5425,7 +5425,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5449,7 +5449,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5473,7 +5473,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5497,7 +5497,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5521,7 +5521,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5545,7 +5545,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5569,7 +5569,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5593,7 +5593,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5617,7 +5617,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5641,7 +5641,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5665,7 +5665,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5689,7 +5689,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5713,7 +5713,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5737,7 +5737,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5761,7 +5761,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5785,7 +5785,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5809,7 +5809,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5833,7 +5833,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5857,7 +5857,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5881,7 +5881,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5905,7 +5905,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5929,7 +5929,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5953,7 +5953,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5977,7 +5977,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6001,7 +6001,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6025,7 +6025,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6049,7 +6049,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6073,7 +6073,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6097,7 +6097,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6121,7 +6121,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6145,7 +6145,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6169,7 +6169,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6193,7 +6193,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6217,7 +6217,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6241,7 +6241,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6265,7 +6265,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6289,7 +6289,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6313,7 +6313,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6337,7 +6337,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6361,7 +6361,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6385,7 +6385,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6409,7 +6409,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6433,7 +6433,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6457,7 +6457,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6481,7 +6481,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6505,7 +6505,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6529,7 +6529,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6553,7 +6553,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6577,7 +6577,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6601,7 +6601,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6625,7 +6625,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6649,7 +6649,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6673,7 +6673,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6697,7 +6697,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6721,7 +6721,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 29"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6745,7 +6745,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 30"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6769,7 +6769,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 31"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6793,7 +6793,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 33"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6817,7 +6817,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 34"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6841,7 +6841,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6865,7 +6865,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6889,7 +6889,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6913,7 +6913,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6937,7 +6937,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6961,7 +6961,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 28"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6985,7 +6985,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 27"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7009,7 +7009,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 26"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7033,7 +7033,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 25"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7057,7 +7057,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 24"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7081,7 +7081,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 23"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7105,7 +7105,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 21"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7129,7 +7129,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 20"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7153,7 +7153,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 16"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7177,7 +7177,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 17"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7201,7 +7201,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 14"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7225,7 +7225,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 12"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7249,7 +7249,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 11"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7273,7 +7273,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 8"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7297,7 +7297,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 7"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7321,7 +7321,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 6"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7345,7 +7345,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 5"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7369,7 +7369,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 3"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7393,7 +7393,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 2"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7417,7 +7417,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7441,7 +7441,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7465,7 +7465,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7489,7 +7489,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7513,7 +7513,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7537,7 +7537,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7561,7 +7561,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7585,7 +7585,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7609,7 +7609,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7633,7 +7633,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7676,7 +7676,7 @@ const _MapNov2017: React.ForwardRefRenderFunction<SVGSVGElement> = (
             <text
               id="CLOSED"
               fill="white"
-              font-family="Radio Canada Big"
+              font-family="Radio Canada Big Variable"
               font-size="16"
               font-weight="500"
               letter-spacing="0em"

--- a/app/components/StationMap/components/MapNov2024.tsx
+++ b/app/components/StationMap/components/MapNov2024.tsx
@@ -52,7 +52,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
             <text
               id="U/C"
               fill="white"
-              font-family="Radio Canada Big"
+              font-family="Radio Canada Big Variable"
               font-size="16"
               font-weight="500"
               letter-spacing="0em"
@@ -1618,7 +1618,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jur"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1630,7 +1630,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1645,7 +1645,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bbt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1657,7 +1657,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1669,7 +1669,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cck"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1681,7 +1681,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ywt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1693,7 +1693,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bkp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -1705,7 +1705,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kth"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1717,7 +1717,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1729,7 +1729,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnx"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1741,7 +1741,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_snj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1753,7 +1753,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jlp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1765,7 +1765,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sgr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1777,7 +1777,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fjr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1789,7 +1789,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_stk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1801,7 +1801,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cgl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1813,7 +1813,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fmw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1825,7 +1825,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kpg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1837,7 +1837,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1849,7 +1849,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fnv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1861,7 +1861,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lyr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1873,7 +1873,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1885,7 +1885,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rnj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1897,7 +1897,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rng"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1909,7 +1909,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1921,7 +1921,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bak"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1933,7 +1933,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rmb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1945,7 +1945,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cpv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1957,7 +1957,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_smg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1969,7 +1969,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nbg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1981,7 +1981,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_smd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -1993,7 +1993,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pgp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2005,7 +2005,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2017,7 +2017,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_smk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2029,7 +2029,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dam"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2041,7 +2041,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_oas"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2053,7 +2053,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2065,7 +2065,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_riv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2077,7 +2077,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cre"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2089,7 +2089,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2101,7 +2101,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cov"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2113,7 +2113,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bkt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2125,7 +2125,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2137,7 +2137,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ptr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2149,7 +2149,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_shv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="16"
             font-weight="600"
             letter-spacing="0em"
@@ -2161,7 +2161,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_krj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2173,7 +2173,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_csw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2185,7 +2185,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hvw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2197,7 +2197,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_btw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2209,7 +2209,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kap"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2221,7 +2221,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sav"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2233,7 +2233,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2245,7 +2245,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_msl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2257,7 +2257,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2269,7 +2269,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wdn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2281,7 +2281,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wds"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2293,7 +2293,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_spl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2305,7 +2305,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ltr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2317,7 +2317,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mfl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2329,7 +2329,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_brh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2341,7 +2341,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_uts"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2353,7 +2353,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_npr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2365,7 +2365,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_obv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2377,7 +2377,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_adm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2389,7 +2389,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sbw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2401,7 +2401,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cbr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2413,7 +2413,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_yis"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2425,7 +2425,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ktb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2437,7 +2437,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_yck"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2449,7 +2449,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_amk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2461,7 +2461,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bsh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2473,7 +2473,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lrc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2485,7 +2485,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ser"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2497,7 +2497,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bly"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2509,7 +2509,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tsg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2521,7 +2521,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mps"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2533,7 +2533,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ubi"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2545,7 +2545,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kkb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2557,7 +2557,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2569,7 +2569,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2584,7 +2584,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2599,7 +2599,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tam"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2611,7 +2611,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpe"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2623,7 +2623,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_upc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2635,7 +2635,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_xpo"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2647,7 +2647,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cga"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2662,7 +2662,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_xln"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2674,7 +2674,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sgb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2686,7 +2686,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pyl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2698,7 +2698,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dkt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2710,7 +2710,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mbt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2722,7 +2722,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sdm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2734,7 +2734,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nch"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2746,7 +2746,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pmn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2758,7 +2758,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_epn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2770,7 +2770,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bbs"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2785,7 +2785,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bft"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2797,7 +2797,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2809,7 +2809,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tap"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2821,7 +2821,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_psr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2833,7 +2833,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pgl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2845,7 +2845,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_skg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2857,7 +2857,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2869,7 +2869,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hgn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2881,7 +2881,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kvn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2893,7 +2893,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_wlh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2905,7 +2905,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ptp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2917,7 +2917,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2929,7 +2929,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_frp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2941,7 +2941,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sim"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2953,7 +2953,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2965,7 +2965,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_eun"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2977,7 +2977,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_alj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -2989,7 +2989,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kal"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3001,7 +3001,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lvr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3013,7 +3013,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_kem"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3025,7 +3025,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tnm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3037,7 +3037,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_nov"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3049,7 +3049,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_new"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3061,7 +3061,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_orc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3073,7 +3073,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_grw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3085,7 +3085,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hvl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3097,7 +3097,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_max"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3109,7 +3109,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_shw"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3121,7 +3121,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_som"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3133,7 +3133,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cth"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3148,7 +3148,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tpg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3163,7 +3163,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rfp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3178,7 +3178,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3190,7 +3190,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_grb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3202,7 +3202,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_trh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3214,7 +3214,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ktp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3226,7 +3226,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tkt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3238,7 +3238,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mpr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3250,7 +3250,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mtc"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3262,7 +3262,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_sgl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3274,7 +3274,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bsr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3286,7 +3286,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bds"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3298,7 +3298,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_msp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3310,7 +3310,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hbf"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3322,7 +3322,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tlb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3334,7 +3334,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lbd"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3346,7 +3346,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ppj"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3358,7 +3358,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hpv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3370,7 +3370,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_krg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3382,7 +3382,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_onh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3394,7 +3394,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3406,7 +3406,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dvr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3418,7 +3418,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cle"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3430,7 +3430,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lks"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3442,7 +3442,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bnl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3454,7 +3454,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_pnr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3466,7 +3466,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jkn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3478,7 +3478,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_gcl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3490,7 +3490,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tcr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3502,7 +3502,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_twr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3514,7 +3514,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tlk"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3526,7 +3526,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_hlv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3538,7 +3538,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_frr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3550,7 +3550,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_cdt"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3562,7 +3562,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mrm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3574,7 +3574,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_btn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3589,7 +3589,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_stv"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3601,7 +3601,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_lti"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3616,7 +3616,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rcr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3628,7 +3628,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bdm"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3640,7 +3640,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_glb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3652,7 +3652,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_mtr"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3664,7 +3664,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_jlb"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3676,7 +3676,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bgs"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3688,7 +3688,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dtn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3700,7 +3700,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tla"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3715,7 +3715,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_ctn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3727,7 +3727,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_otp"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3739,7 +3739,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_tib"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3751,7 +3751,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_rdh"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3763,7 +3763,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_que"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3775,7 +3775,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_com"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3787,7 +3787,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_fcn"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3799,7 +3799,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_bcl"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3811,7 +3811,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_dbg"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3826,7 +3826,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
           <text
             id="label_crq"
             fill="#2D2A26"
-            font-family="Radio Canada Big"
+            font-family="Radio Canada Big Variable"
             font-size="20"
             font-weight="600"
             letter-spacing="0em"
@@ -3852,7 +3852,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3872,7 +3872,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 15"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3896,7 +3896,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3916,7 +3916,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PTC"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3940,7 +3940,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3960,7 +3960,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="STC"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -3984,7 +3984,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4004,7 +4004,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 13"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4028,7 +4028,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4048,7 +4048,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 10"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4072,7 +4072,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4092,7 +4092,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 9"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4116,7 +4116,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4136,7 +4136,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4160,7 +4160,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4180,7 +4180,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 4"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4204,7 +4204,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4224,7 +4224,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CE 1"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4248,7 +4248,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4268,7 +4268,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4292,7 +4292,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4312,7 +4312,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4336,7 +4336,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4356,7 +4356,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4380,7 +4380,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 29"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4400,7 +4400,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4424,7 +4424,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4444,7 +4444,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4464,7 +4464,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 1"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4488,7 +4488,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4508,7 +4508,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4528,7 +4528,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4552,7 +4552,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4572,7 +4572,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4592,7 +4592,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CE 2"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4618,7 +4618,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4656,7 +4656,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4680,7 +4680,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4700,7 +4700,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4724,7 +4724,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 22"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4744,7 +4744,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4768,7 +4768,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 19"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4788,7 +4788,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4812,7 +4812,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4832,7 +4832,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4856,7 +4856,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4876,7 +4876,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4900,7 +4900,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4920,7 +4920,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 35"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4944,7 +4944,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 31"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4964,7 +4964,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 37"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -4988,7 +4988,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5008,7 +5008,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5032,7 +5032,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5052,7 +5052,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5076,7 +5076,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 17"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5096,7 +5096,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5120,7 +5120,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5140,7 +5140,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5166,7 +5166,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5204,7 +5204,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5229,7 +5229,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
               <text
                 id="EW 2"
                 fill="white"
-                font-family="Radio Canada Big"
+                font-family="Radio Canada Big Variable"
                 font-size="16"
                 font-weight="600"
                 letter-spacing="0em"
@@ -5271,7 +5271,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
               <text
                 id="DT 32"
                 fill="white"
-                font-family="Radio Canada Big"
+                font-family="Radio Canada Big Variable"
                 font-size="16"
                 font-weight="600"
                 letter-spacing="0em"
@@ -5294,7 +5294,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5314,7 +5314,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="16"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5338,7 +5338,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 32"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5362,7 +5362,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 31"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5386,7 +5386,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 30"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5410,7 +5410,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 29"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5434,7 +5434,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5458,7 +5458,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5482,7 +5482,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 33"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5506,7 +5506,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5530,7 +5530,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5554,7 +5554,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5578,7 +5578,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5602,7 +5602,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5626,7 +5626,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5650,7 +5650,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5674,7 +5674,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5698,7 +5698,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5722,7 +5722,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5746,7 +5746,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5770,7 +5770,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5794,7 +5794,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5818,7 +5818,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5842,7 +5842,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5866,7 +5866,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5890,7 +5890,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="BP 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5914,7 +5914,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5938,7 +5938,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5962,7 +5962,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -5986,7 +5986,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6010,7 +6010,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6034,7 +6034,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6058,7 +6058,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6082,7 +6082,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6106,7 +6106,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6130,7 +6130,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6154,7 +6154,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6178,7 +6178,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6202,7 +6202,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6226,7 +6226,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6250,7 +6250,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6274,7 +6274,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6298,7 +6298,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6322,7 +6322,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6346,7 +6346,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SW 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6370,7 +6370,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6394,7 +6394,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6418,7 +6418,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6442,7 +6442,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6466,7 +6466,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="SE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6490,7 +6490,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6514,7 +6514,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6538,7 +6538,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="PW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="12"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6562,7 +6562,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6586,7 +6586,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6610,7 +6610,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6634,7 +6634,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6658,7 +6658,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 4"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6682,7 +6682,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6706,7 +6706,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6730,7 +6730,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6754,7 +6754,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6778,7 +6778,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6802,7 +6802,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6826,7 +6826,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6850,7 +6850,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6874,7 +6874,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6898,7 +6898,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6922,7 +6922,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6946,7 +6946,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6970,7 +6970,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -6994,7 +6994,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7018,7 +7018,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7042,7 +7042,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7066,7 +7066,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NE 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7090,7 +7090,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7114,7 +7114,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7138,7 +7138,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7162,7 +7162,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7186,7 +7186,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7210,7 +7210,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 26"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7234,7 +7234,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7258,7 +7258,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7282,7 +7282,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 29"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7306,7 +7306,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="TE 30"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7330,7 +7330,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7354,7 +7354,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7378,7 +7378,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 12"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7402,7 +7402,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7426,7 +7426,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 14"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7450,7 +7450,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7474,7 +7474,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 16"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7498,7 +7498,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7522,7 +7522,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7546,7 +7546,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7570,7 +7570,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7594,7 +7594,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="NS 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7618,7 +7618,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7642,7 +7642,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7666,7 +7666,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7690,7 +7690,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7714,7 +7714,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7738,7 +7738,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 8"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7762,7 +7762,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 13"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7786,7 +7786,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7810,7 +7810,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7834,7 +7834,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7858,7 +7858,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 21"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7882,7 +7882,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7906,7 +7906,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 23"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7930,7 +7930,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 24"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7954,7 +7954,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 25"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -7978,7 +7978,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 27"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8002,7 +8002,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 28"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8026,7 +8026,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 29"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8050,7 +8050,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 30"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8074,7 +8074,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 31"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8098,7 +8098,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 33"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8122,7 +8122,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 34"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8146,7 +8146,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="DT 34_2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8170,7 +8170,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 22"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8194,7 +8194,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 20"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8218,7 +8218,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 19"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8242,7 +8242,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 18"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8266,7 +8266,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 17"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8290,7 +8290,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 28"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8314,7 +8314,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 27"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8338,7 +8338,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 26"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8362,7 +8362,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 25"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8386,7 +8386,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 24"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8410,7 +8410,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 23"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8434,7 +8434,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 21"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8458,7 +8458,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 20"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8482,7 +8482,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 16"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8506,7 +8506,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 14"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8530,7 +8530,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 12"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8554,7 +8554,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 11"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8578,7 +8578,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 8"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8602,7 +8602,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 7"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8626,7 +8626,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 6"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8650,7 +8650,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 5"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8674,7 +8674,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 3"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8698,7 +8698,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CC 2"
                   fill="#383A37"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8722,7 +8722,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 15"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8746,7 +8746,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 11"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8770,7 +8770,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 10"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8794,7 +8794,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 9"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8818,7 +8818,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 7"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8842,7 +8842,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 6"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8866,7 +8866,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 5"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8890,7 +8890,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 3"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8914,7 +8914,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="EW 1"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8938,7 +8938,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
                 <text
                   id="CG 2"
                   fill="white"
-                  font-family="Radio Canada Big"
+                  font-family="Radio Canada Big Variable"
                   font-size="14"
                   font-weight="600"
                   letter-spacing="0em"
@@ -8981,7 +8981,7 @@ const _MapNov2024: React.ForwardRefRenderFunction<SVGSVGElement> = (
             <text
               id="CLOSED"
               fill="white"
-              font-family="Radio Canada Big"
+              font-family="Radio Canada Big Variable"
               font-size="16"
               font-weight="500"
               letter-spacing="0em"

--- a/app/index.css
+++ b/app/index.css
@@ -1,11 +1,12 @@
 /* Workaround for https://github.com/TanStack/router/issues/5812, which causes flash of unstyled content before hydration */
 @import "tailwindcss" source("./");
 
-html {
-    font-family: "Radio Canada Big", sans-serif;
-}
+@import '@fontsource-variable/radio-canada-big/wght.css';
+@import '@fontsource-variable/radio-canada-big/wght-italic.css';
 
 @theme {
+    --font-sans: 'Radio Canada Big Variable', sans-serif;
+
     --color-disruption-light: var(--color-red-600);
     --color-disruption-dark: var(--color-red-400);
 

--- a/app/routes/__root.tsx
+++ b/app/routes/__root.tsx
@@ -5,8 +5,8 @@ import {
   Scripts,
   useRouterState,
 } from '@tanstack/react-router';
-import { LANGUAGES } from '~/constants';
 import { RouteWebVitals } from '~/components/RouteWebVitals';
+import { LANGUAGES } from '~/constants';
 import { getPosthogOptions } from '~/helpers/getPosthogOptions';
 import { OptionalPostHogProvider } from '~/helpers/OptionalPostHogProvider';
 import stylesheet from '../index.css?url';
@@ -22,16 +22,6 @@ export const Route = createRootRoute({
         { charSet: 'utf-8' },
       ],
       links: [
-        { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
-        {
-          rel: 'preconnect',
-          href: 'https://fonts.gstatic.com',
-          crossOrigin: 'anonymous',
-        },
-        {
-          rel: 'stylesheet',
-          href: 'https://fonts.googleapis.com/css2?family=Radio+Canada+Big:ital,wght@0,400..700;1,400..700&display=swap',
-        },
         { rel: 'stylesheet', href: stylesheet },
         {
           rel: 'apple-touch-icon',

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mrtdown-site",
       "version": "0.0.0",
       "dependencies": {
+        "@fontsource-variable/radio-canada-big": "^5.2.7",
         "@heroicons/react": "^2.2.0",
         "@mrtdown/core": "^2.0.0-alpha.26",
         "@mrtdown/fs": "^2.0.0-alpha.26",
@@ -1213,6 +1214,15 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource-variable/radio-canada-big": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/radio-canada-big/-/radio-canada-big-5.2.7.tgz",
+      "integrity": "sha512-fcKOJr81utVytGqer+B4CsZijCX+LS2z7IRaq28eZtT0fyxR2b8kM5JCj+7BocBznnEIxsHfGbp5HTBNEuGekQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@formatjs/cli": {
       "version": "6.6.3",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "cf-typegen": "wrangler types"
   },
   "dependencies": {
+    "@fontsource-variable/radio-canada-big": "^5.2.7",
     "@heroicons/react": "^2.2.0",
     "@mrtdown/core": "^2.0.0-alpha.26",
     "@mrtdown/fs": "^2.0.0-alpha.26",


### PR DESCRIPTION
## Summary

- self-host Radio Canada Big through Fontsource instead of loading it from Google Fonts
- configure Tailwind's sans font token to use the Fontsource variable family
- update station map font-family references to the Fontsource variable family name

## Impact

This removes the runtime Google Fonts stylesheet/preconnects and keeps app text plus station map SVG text on the bundled Radio Canada Big variable font.

## Validation

- `npm run verify`