### PR TITLE
fix: canonicalize pages to en-SG

### DIFF
--- a/app/helpers/seo.test.ts
+++ b/app/helpers/seo.test.ts
@@ -38,16 +38,13 @@ describe('SEO helpers', () => {
     ]);
   });
 
-  it('uses the same localized URL for canonical and og:url', () => {
+  it('uses the en-SG URL for canonical and og:url', () => {
     const metadata = buildSeoMetadata({
-      lang: 'ta',
       path: '/history/2026/',
       rootUrl: ROOT_URL,
     });
 
-    expect(metadata.canonicalUrl).toBe(
-      'https://www.mrtdown.org/ta/history/2026',
-    );
+    expect(metadata.canonicalUrl).toBe('https://www.mrtdown.org/history/2026');
     expect(metadata.ogUrl).toBe(metadata.canonicalUrl);
     expect(metadata.ogImage).toBe('https://www.mrtdown.org/og_image.png');
     expect(metadata.links).toContainEqual({
@@ -58,6 +55,25 @@ describe('SEO helpers', () => {
       rel: 'alternate',
       hrefLang: 'x-default',
       href: 'https://www.mrtdown.org/history/2026',
+    });
+  });
+
+  it('keeps locale alternates when canonicalizing to en-SG', () => {
+    const metadata = buildSeoMetadata({
+      path: '/lines/BPLRT/',
+      rootUrl: ROOT_URL,
+    });
+
+    expect(metadata.canonicalUrl).toBe('https://www.mrtdown.org/lines/BPLRT');
+    expect(metadata.ogUrl).toBe(metadata.canonicalUrl);
+    expect(metadata.links).toContainEqual({
+      rel: 'canonical',
+      href: 'https://www.mrtdown.org/lines/BPLRT',
+    });
+    expect(metadata.links).toContainEqual({
+      rel: 'alternate',
+      hrefLang: 'ta',
+      href: 'https://www.mrtdown.org/ta/lines/BPLRT',
     });
   });
 });

--- a/app/helpers/seo.ts
+++ b/app/helpers/seo.ts
@@ -3,6 +3,8 @@ import { buildLocaleAwareLink } from './buildLocaleAwareLink';
 
 type SeoLanguage = (typeof LANGUAGES)[number];
 
+const CANONICAL_LANG = 'en-SG';
+
 export interface LocaleAlternate {
   href: string;
   hreflang: SeoLanguage | 'x-default';
@@ -26,16 +28,18 @@ export interface SeoHeadMetadata {
 }
 
 export function buildSeoMetadata({
-  lang = 'en-SG',
   path,
   rootUrl,
 }: {
-  lang?: string;
   path: string;
   rootUrl: string;
 }): SeoHeadMetadata {
   const normalizedPath = normalizeSeoPath(path);
-  const canonicalUrl = buildLocalizedAbsoluteUrl(normalizedPath, lang, rootUrl);
+  const canonicalUrl = buildLocalizedAbsoluteUrl(
+    normalizedPath,
+    CANONICAL_LANG,
+    rootUrl,
+  );
 
   return {
     canonicalUrl,

--- a/app/routes/{-$lang}/about.tsx
+++ b/app/routes/{-$lang}/about.tsx
@@ -10,7 +10,7 @@ export const Route = createFileRoute('/{-$lang}/about')({
 
     const rootUrl = import.meta.env.VITE_ROOT_URL;
 
-    const seo = buildSeoMetadata({ path: '/about', lang, rootUrl });
+    const seo = buildSeoMetadata({ path: '/about', rootUrl });
 
     const intl = createIntl({
       locale: lang,

--- a/app/routes/{-$lang}/community-reports/$kind/$sourceId.tsx
+++ b/app/routes/{-$lang}/community-reports/$kind/$sourceId.tsx
@@ -96,7 +96,6 @@ export const Route = createFileRoute(
       path: `/community-reports/${encodeURIComponent(kind)}/${encodeURIComponent(
         sourceId,
       )}`,
-      lang,
       rootUrl,
     });
 

--- a/app/routes/{-$lang}/history/$year/$month.tsx
+++ b/app/routes/{-$lang}/history/$year/$month.tsx
@@ -79,7 +79,6 @@ export const Route = createFileRoute('/{-$lang}/history/$year/$month')({
 
     const seo = buildSeoMetadata({
       path: `/history/${year}/${month}`,
-      lang,
       rootUrl,
     });
 

--- a/app/routes/{-$lang}/history/$year/index.tsx
+++ b/app/routes/{-$lang}/history/$year/index.tsx
@@ -49,7 +49,6 @@ export const Route = createFileRoute('/{-$lang}/history/$year/')({
 
     const seo = buildSeoMetadata({
       path: `/history/${ctx.params.year}`,
-      lang,
       rootUrl,
     });
 

--- a/app/routes/{-$lang}/index.tsx
+++ b/app/routes/{-$lang}/index.tsx
@@ -73,7 +73,7 @@ export const Route = createFileRoute('/{-$lang}/')({
     const rootUrl = import.meta.env.VITE_ROOT_URL;
     assert(rootUrl != null, 'VITE_ROOT_URL is not set');
 
-    const seo = buildSeoMetadata({ path: '/', lang, rootUrl });
+    const seo = buildSeoMetadata({ path: '/', rootUrl });
 
     return {
       links: seo.links,

--- a/app/routes/{-$lang}/issues/$issueId/index.tsx
+++ b/app/routes/{-$lang}/issues/$issueId/index.tsx
@@ -106,7 +106,6 @@ export const Route = createFileRoute('/{-$lang}/issues/$issueId/')({
     const rootUrl = import.meta.env.VITE_ROOT_URL;
     const seo = buildSeoMetadata({
       path: `/issues/${issueId}`,
-      lang,
       rootUrl,
     });
 

--- a/app/routes/{-$lang}/lines/$lineId/index.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/index.tsx
@@ -119,7 +119,6 @@ export const Route = createFileRoute('/{-$lang}/lines/$lineId/')({
 
     const seo = buildSeoMetadata({
       path: `/lines/${lineId}`,
-      lang,
       rootUrl,
     });
 

--- a/app/routes/{-$lang}/operators/$operatorId/index.tsx
+++ b/app/routes/{-$lang}/operators/$operatorId/index.tsx
@@ -107,7 +107,6 @@ export const Route = createFileRoute('/{-$lang}/operators/$operatorId/')({
 
     const seo = buildSeoMetadata({
       path: `/operators/${ctx.params.operatorId}`,
-      lang,
       rootUrl,
     });
 

--- a/app/routes/{-$lang}/report.tsx
+++ b/app/routes/{-$lang}/report.tsx
@@ -254,7 +254,7 @@ export const Route = createFileRoute('/{-$lang}/report')({
       defaultMessage:
         'Share a concise community report about MRT or LRT delays, crowding, skipped stops, or service issues.',
     });
-    const seo = buildSeoMetadata({ path: '/report', lang, rootUrl });
+    const seo = buildSeoMetadata({ path: '/report', rootUrl });
 
     return {
       links: seo.links,

--- a/app/routes/{-$lang}/stations/$stationId.tsx
+++ b/app/routes/{-$lang}/stations/$stationId.tsx
@@ -156,7 +156,6 @@ export const Route = createFileRoute('/{-$lang}/stations/$stationId')({
     const rootUrl = import.meta.env.VITE_ROOT_URL;
     const seo = buildSeoMetadata({
       path: `/stations/${stationId}`,
-      lang,
       rootUrl,
     });
 

--- a/app/routes/{-$lang}/statistics/index.tsx
+++ b/app/routes/{-$lang}/statistics/index.tsx
@@ -18,7 +18,7 @@ export const Route = createFileRoute('/{-$lang}/statistics/')({
 
     const rootUrl = import.meta.env.VITE_ROOT_URL;
 
-    const seo = buildSeoMetadata({ path: '/statistics', lang, rootUrl });
+    const seo = buildSeoMetadata({ path: '/statistics', rootUrl });
 
     const intl = createIntl({
       locale: lang,

--- a/app/routes/{-$lang}/system-map.tsx
+++ b/app/routes/{-$lang}/system-map.tsx
@@ -44,7 +44,7 @@ export const Route = createFileRoute('/{-$lang}/system-map')({
 
     const rootUrl = import.meta.env.VITE_ROOT_URL;
 
-    const seo = buildSeoMetadata({ path: '/system-map', lang, rootUrl });
+    const seo = buildSeoMetadata({ path: '/system-map', rootUrl });
 
     const intl = createIntl({
       locale: lang,


### PR DESCRIPTION
## Summary

- Make `buildSeoMetadata` use `en-SG` as the site-wide canonical locale.
- Keep hreflang alternates for localized pages while canonical and `og:url` point at the en-SG URL.
- Remove now-redundant `lang` arguments from SEO metadata callers.

## Validation

- `npm run test:run -- app/helpers/seo.test.ts`
- `npm run verify`

## Notes

`npm run verify` required an escalated run in this Codex sandbox because `tsx` opens an IPC pipe under the system temp directory for the Drizzle migration check.