### PR TITLE
feat: port canonical pull workflow to D1

### DIFF
--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -43,7 +43,7 @@ import {
 /*
  * Pull staging (`*_next`): snapshot of manifest data between workflow steps.
  * Spreads below pair staging with live tables so column definitions stay in sync.
- * Staging has no FKs; nested data is JSONB where live uses child tables.
+ * Staging has no FKs; nested data is JSON text where live uses child tables.
  */
 
 /** Shared by `operators` and `operators_next` (same logical fields). */
@@ -110,7 +110,7 @@ export const metadataTable = sqliteTable('metadata', {
   value: text('value').notNull(),
 });
 
-/** Staging for pull workflow — no FKs; JSONB holds nested child data. */
+/** Staging for pull workflow — no FKs; JSON text holds nested child data. */
 export const operatorsNextTable = sqliteTable('operators_next', {
   id: text('id').primaryKey(),
   ...operatorEntitySharedColumns,

--- a/app/scripts/seedFixtures.ts
+++ b/app/scripts/seedFixtures.ts
@@ -21,7 +21,7 @@ import {
   syncOperatorsTownsLandmarks,
   syncServices,
   syncStations,
-  truncateStagingTables,
+  clearStagingTables,
 } from '../workflows/pull/helpers/stagingSync.js';
 
 const { Pool } = pg;
@@ -30,7 +30,7 @@ const DEFAULT_FIXTURES_BASE_URL =
   'https://foldaway.github.io/mrtdown-data/fixtures';
 const OPERATIONAL_FACTS_REBUILD_DAYS = 400;
 
-type Db = Parameters<typeof truncateStagingTables>[0];
+type Db = Parameters<typeof clearStagingTables>[0];
 
 async function stageFixtures(db: Db, baseUrl: string): Promise<void> {
   const manifest = await fetchManifest(baseUrl);
@@ -48,7 +48,7 @@ async function stageFixtures(db: Db, baseUrl: string): Promise<void> {
     return hash;
   };
 
-  await truncateStagingTables(db);
+  await clearStagingTables(db);
 
   const stations = repo.stations.list().map((station) => ({
     ...station,

--- a/app/workflows/pull/helpers/stagingSync.test.ts
+++ b/app/workflows/pull/helpers/stagingSync.test.ts
@@ -12,11 +12,11 @@ import {
   insertLinesStaging,
   insertOperatorsStaging,
   insertStationsStaging,
-  truncateStagingTables,
+  clearStagingTables,
 } from './stagingSync';
 
 type InsertDb = Parameters<typeof insertOperatorsStaging>[0];
-type TruncateDb = Parameters<typeof truncateStagingTables>[0];
+type ClearDb = Parameters<typeof clearStagingTables>[0];
 
 function createInsertDb() {
   const inserts: Array<{
@@ -49,7 +49,7 @@ function createDeleteDb() {
       deletes.push(table);
       return Promise.resolve();
     },
-  } as unknown as TruncateDb;
+  } as unknown as ClearDb;
 
   return { db, deletes };
 }
@@ -97,7 +97,7 @@ describe('pull staging inserts', () => {
   it('clears staging tables with SQLite-compatible deletes', async () => {
     const { db, deletes } = createDeleteDb();
 
-    await truncateStagingTables(db);
+    await clearStagingTables(db);
 
     expect(deletes).toEqual([
       operatorsNextTable,

--- a/app/workflows/pull/helpers/stagingSync.ts
+++ b/app/workflows/pull/helpers/stagingSync.ts
@@ -17,15 +17,16 @@ import {
   type Town,
 } from '@mrtdown/core';
 import {
+  and,
   asc,
   eq,
   type InferInsertModel,
   inArray,
+  isNotNull,
   isNull,
   ne,
   notExists,
   or,
-  sql,
 } from 'drizzle-orm';
 import type { AppDb } from '../../../db/index.js';
 import {
@@ -133,7 +134,7 @@ async function deleteStagingTables(db: DeleteDb): Promise<void> {
 }
 
 /** Clears all pull staging tables before a new parse run. */
-export async function truncateStagingTables(db: Db): Promise<void> {
+export async function clearStagingTables(db: Db): Promise<void> {
   await deleteStagingTables(db);
 }
 
@@ -391,27 +392,27 @@ async function upsertChangedOperators(
       .from(operatorsNextTable)
       .where(inArray(operatorsNextTable.id, ids));
     if (full.length === 0) continue;
-    await tx
-      .insert(operatorsTable)
-      .values(
-        full.map((row) => ({
+    for (const row of full) {
+      await tx
+        .insert(operatorsTable)
+        .values({
           id: row.id,
           hash: row.hash,
           name: row.name,
           founded_at: row.founded_at,
           url: row.url,
-        })),
-      )
-      .onConflictDoUpdate({
-        target: [operatorsTable.id],
-        set: {
-          hash: sql.raw(`excluded.${operatorsTable.hash.name}`),
-          name: sql.raw(`excluded.${operatorsTable.name.name}`),
-          founded_at: sql.raw(`excluded.${operatorsTable.founded_at.name}`),
-          url: sql.raw(`excluded.${operatorsTable.url.name}`),
-          updated_at: new Date().toISOString(),
-        },
-      });
+        })
+        .onConflictDoUpdate({
+          target: [operatorsTable.id],
+          set: {
+            hash: row.hash,
+            name: row.name,
+            founded_at: row.founded_at,
+            url: row.url,
+            updated_at: new Date().toISOString(),
+          },
+        });
+    }
   }
 }
 
@@ -707,13 +708,19 @@ export async function deleteLineOrphans(db: Db): Promise<void> {
     await tx
       .update(impactEventEntityFacilitiesTable)
       .set({ line_id: null })
-      .where(sql`
-        ${impactEventEntityFacilitiesTable.line_id} IS NOT NULL
-        AND NOT EXISTS (
-          SELECT 1 FROM ${linesNextTable}
-          WHERE ${linesNextTable.id} = ${impactEventEntityFacilitiesTable.line_id}
-        )
-      `);
+      .where(
+        and(
+          isNotNull(impactEventEntityFacilitiesTable.line_id),
+          notExists(
+            tx
+              .select()
+              .from(linesNextTable)
+              .where(
+                eq(linesNextTable.id, impactEventEntityFacilitiesTable.line_id),
+              ),
+          ),
+        ),
+      );
     await tx
       .delete(linesTable)
       .where(
@@ -847,20 +854,54 @@ export async function deleteStationOrphans(db: Db): Promise<void> {
             ),
         ),
       );
-    await tx.delete(impactEventServiceScopesTable).where(sql`
-        (${impactEventServiceScopesTable.station_id} IS NOT NULL AND NOT EXISTS (
-          SELECT 1 FROM ${stationsNextTable}
-          WHERE ${stationsNextTable.id} = ${impactEventServiceScopesTable.station_id}
-        ))
-        OR (${impactEventServiceScopesTable.from_station_id} IS NOT NULL AND NOT EXISTS (
-          SELECT 1 FROM ${stationsNextTable}
-          WHERE ${stationsNextTable.id} = ${impactEventServiceScopesTable.from_station_id}
-        ))
-        OR (${impactEventServiceScopesTable.to_station_id} IS NOT NULL AND NOT EXISTS (
-          SELECT 1 FROM ${stationsNextTable}
-          WHERE ${stationsNextTable.id} = ${impactEventServiceScopesTable.to_station_id}
-        ))
-      `);
+    await tx
+      .delete(impactEventServiceScopesTable)
+      .where(
+        or(
+          and(
+            isNotNull(impactEventServiceScopesTable.station_id),
+            notExists(
+              tx
+                .select()
+                .from(stationsNextTable)
+                .where(
+                  eq(
+                    stationsNextTable.id,
+                    impactEventServiceScopesTable.station_id,
+                  ),
+                ),
+            ),
+          ),
+          and(
+            isNotNull(impactEventServiceScopesTable.from_station_id),
+            notExists(
+              tx
+                .select()
+                .from(stationsNextTable)
+                .where(
+                  eq(
+                    stationsNextTable.id,
+                    impactEventServiceScopesTable.from_station_id,
+                  ),
+                ),
+            ),
+          ),
+          and(
+            isNotNull(impactEventServiceScopesTable.to_station_id),
+            notExists(
+              tx
+                .select()
+                .from(stationsNextTable)
+                .where(
+                  eq(
+                    stationsNextTable.id,
+                    impactEventServiceScopesTable.to_station_id,
+                  ),
+                ),
+            ),
+          ),
+        ),
+      );
     await tx
       .delete(impactEventEntityFacilitiesTable)
       .where(
@@ -1043,25 +1084,23 @@ export async function syncServices(db: Db): Promise<void> {
             },
           );
           for (const rows of chunk(pathEntryRows, BATCH)) {
-            await tx
-              .insert(serviceRevisionPathStationEntriesTable)
-              .values(rows)
-              .onConflictDoUpdate({
-                target: [
-                  serviceRevisionPathStationEntriesTable.service_revision_id,
-                  serviceRevisionPathStationEntriesTable.service_id,
-                  serviceRevisionPathStationEntriesTable.station_id,
-                  serviceRevisionPathStationEntriesTable.path_index,
-                ],
-                set: {
-                  display_code: sql.raw(
-                    `excluded.${serviceRevisionPathStationEntriesTable.display_code.name}`,
-                  ),
-                  path_index: sql.raw(
-                    `excluded.${serviceRevisionPathStationEntriesTable.path_index.name}`,
-                  ),
-                },
-              });
+            for (const pathEntryRow of rows) {
+              await tx
+                .insert(serviceRevisionPathStationEntriesTable)
+                .values(pathEntryRow)
+                .onConflictDoUpdate({
+                  target: [
+                    serviceRevisionPathStationEntriesTable.service_revision_id,
+                    serviceRevisionPathStationEntriesTable.service_id,
+                    serviceRevisionPathStationEntriesTable.station_id,
+                    serviceRevisionPathStationEntriesTable.path_index,
+                  ],
+                  set: {
+                    display_code: pathEntryRow.display_code,
+                    path_index: pathEntryRow.path_index,
+                  },
+                });
+            }
           }
         }
       }
@@ -1350,19 +1389,21 @@ async function syncIssueIds(tx: Tx, issueIds: string[]): Promise<void> {
     }
 
     for (const rows of chunk(issueRows, BATCH)) {
-      await tx
-        .insert(issuesTable)
-        .values(rows)
-        .onConflictDoUpdate({
-          target: [issuesTable.id],
-          set: {
-            hash: sql.raw(`excluded.${issuesTable.hash.name}`),
-            type: sql.raw(`excluded.${issuesTable.type.name}`),
-            title: sql.raw(`excluded.${issuesTable.title.name}`),
-            title_meta: sql.raw(`excluded.${issuesTable.title_meta.name}`),
-            updated_at: new Date().toISOString(),
-          },
-        });
+      for (const row of rows) {
+        await tx
+          .insert(issuesTable)
+          .values(row)
+          .onConflictDoUpdate({
+            target: [issuesTable.id],
+            set: {
+              hash: row.hash,
+              type: row.type,
+              title: row.title,
+              title_meta: row.title_meta,
+              updated_at: new Date().toISOString(),
+            },
+          });
+      }
     }
     if (evidenceRows.length > 0) {
       const dedupedEvidenceRows = uniqueBy(

--- a/app/workflows/pull/index.ts
+++ b/app/workflows/pull/index.ts
@@ -32,7 +32,7 @@ import {
   syncOperatorsTownsLandmarksUpserts,
   syncServices,
   syncStations,
-  truncateStagingTables,
+  clearStagingTables,
 } from './helpers/stagingSync.js';
 
 type Params = Record<string, never>;
@@ -47,7 +47,7 @@ const parseStepConfig = {
   timeout: '5 minutes' as const,
 };
 
-/** DB promotion steps: retries for transient Hyperdrive / Postgres errors. */
+/** DB promotion steps: retry transient D1 or Worker runtime failures. */
 const syncStepConfig = {
   retries: {
     limit: 3,
@@ -56,7 +56,8 @@ const syncStepConfig = {
   },
 };
 
-const ISSUE_SYNC_BATCH_SIZE = 500;
+/** Keep each changed-issue step comfortably below D1 per-invocation query limits. */
+const ISSUE_SYNC_BATCH_SIZE = 100;
 const OPERATIONAL_FACTS_REBUILD_DAYS = 400;
 
 const factsStepConfig = {
@@ -70,7 +71,7 @@ const factsStepConfig = {
 
 /**
  * Durable pull pipeline: manifest → parse into staging → promote by domain →
- * truncate staging + metadata. Staging is the handoff between steps (no large step returns).
+ * clear staging + metadata. Staging is the handoff between steps (no large step returns).
  */
 class PullWorkflowBase extends WorkflowEntrypoint<Env, Params> {
   async run(_event: WorkflowEvent<Params>, step: WorkflowStep) {
@@ -88,7 +89,7 @@ class PullWorkflowBase extends WorkflowEntrypoint<Env, Params> {
 
       const repo = new MRTDownRepository({ store });
       const db = getDb();
-      await truncateStagingTables(db);
+      await clearStagingTables(db);
 
       // Stage one repository domain at a time so the workflow does not retain
       // the full parsed dataset in memory between inserts.

--- a/docs/plans/active/d1-migration.md
+++ b/docs/plans/active/d1-migration.md
@@ -310,6 +310,15 @@ Exit criteria:
   latitude/longitude columns, replacing Postgres JSON/timestamp/enum/interval
   storage with D1-compatible columns, and generating a fresh SQLite baseline
   migration.
+- 2026-06-25: Started Phase 3 on `codex/d1-migration-pull-workflow` by
+  replacing remaining pull-workflow `excluded.*` and raw orphan-cleanup SQL with
+  D1-safe Drizzle expressions, keeping staging cleanup on SQLite-compatible
+  deletes, and renaming the staging cleanup entrypoint away from `truncate`.
+- 2026-06-25: Verified that a fresh local D1 database applies all generated
+  migrations. The local dev pull endpoint accepts workflow creation at
+  `/internal/api/tasks/pull/`, but did not execute the workflow in the local
+  runtime during validation; D1 row counts remained zero, so end-to-end pull
+  validation still needs a preview or workflow-capable runtime.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Replace remaining pull-workflow `excluded.*` and raw orphan-cleanup SQL with D1-safe Drizzle expressions.
- Rename the staging cleanup entrypoint from `truncateStagingTables` to `clearStagingTables` and update callers/tests.
- Reduce changed-issue workflow batches to keep D1 query counts conservative, and record Phase 3 validation notes in the D1 migration plan.

## Validation

- `npm run verify`
- `npx wrangler d1 migrations apply DB --local`

Local workflow note: `/internal/api/tasks/pull/` returned `202`, but the local dev runtime did not execute the workflow; D1 row counts remained zero. End-to-end pull validation still needs preview or another workflow-capable runtime.