### PR TITLE
fix: handle D1 missing-table read fallbacks

### DIFF
--- a/app/util/db.queries.test.ts
+++ b/app/util/db.queries.test.ts
@@ -4,8 +4,10 @@ import type { Issue, Line, Station } from '~/types';
 import {
   buildLineSummary,
   deriveServiceScopeStationIds,
+  isMissingTableError,
   parseStatisticsSnapshotPayload,
   selectIncludedEntities,
+  selectLegacyHistoryFallback,
   selectServiceBranchSourceEvents,
   type SystemAnalytics,
 } from './db.queries';
@@ -397,6 +399,76 @@ describe('parseStatisticsSnapshotPayload', () => {
       }),
     ).toBeNull();
     expect(parseStatisticsSnapshotPayload({})).toBeNull();
+  });
+});
+
+describe('isMissingTableError', () => {
+  it('recognizes Postgres undefined-table errors', () => {
+    expect(isMissingTableError({ code: '42P01' })).toBe(true);
+  });
+
+  it('recognizes D1 missing-table errors', () => {
+    expect(
+      isMissingTableError(
+        new Error(
+          'D1_ERROR: no such table: statistics_snapshots: SQLITE_ERROR',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('recognizes wrapped SQLite missing-table causes', () => {
+    expect(
+      isMissingTableError(
+        new Error('Failed query', {
+          cause: {
+            code: 'SQLITE_ERROR',
+            message: 'no such table: line_day_facts',
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('ignores unrelated database errors', () => {
+    expect(
+      isMissingTableError({
+        code: 'SQLITE_CONSTRAINT',
+        message: 'FOREIGN KEY constraint failed',
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('selectLegacyHistoryFallback', () => {
+  const TODAY = DateTime.fromISO('2026-06-25T00:00:00+08:00');
+  const PAST_START = DateTime.fromISO('2026-05-01T00:00:00+08:00');
+  const PAST_END = DateTime.fromISO('2026-05-31T00:00:00+08:00');
+
+  it('uses the legacy fallback when operational fact tables are absent', () => {
+    expect(
+      selectLegacyHistoryFallback(
+        PAST_START,
+        PAST_END,
+        TODAY,
+        [],
+        { status: 'missing_table' },
+        'history month 2026-05',
+      ),
+    ).toBe(true);
+  });
+
+  it('keeps throwing for missing coverage from an existing empty fact table', () => {
+    expect(() =>
+      selectLegacyHistoryFallback(
+        PAST_START,
+        PAST_END,
+        TODAY,
+        [],
+        { status: 'available', startDate: null },
+        'history month 2026-05',
+      ),
+    ).toThrow('Missing operational fact coverage for history month 2026-05');
   });
 });
 

--- a/app/util/db.queries.ts
+++ b/app/util/db.queries.ts
@@ -300,6 +300,15 @@ type OperationalFactRowsForDate = {
   lineRows: (typeof lineDayFactsTable.$inferInsert)[];
 };
 
+type OperationalFactCoverageStart =
+  | {
+      status: 'available';
+      startDate: string | null;
+    }
+  | {
+      status: 'missing_table';
+    };
+
 function nowSg() {
   return DateTime.now().setZone(SG_TIMEZONE);
 }
@@ -2780,13 +2789,48 @@ function buildDurationChartsFromIssueFacts(rows: IssueDayFactRow[]) {
   });
 }
 
-function isUndefinedTableError(error: unknown) {
-  return (
-    error != null &&
-    typeof error === 'object' &&
-    'code' in error &&
-    error.code === '42P01'
-  );
+function readStringField(value: unknown, field: string) {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const fieldValue = value[field];
+  return typeof fieldValue === 'string' ? fieldValue : null;
+}
+
+export function isMissingTableError(error: unknown) {
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+
+  for (let depth = 0; current != null && depth < 6; depth++) {
+    if (seen.has(current)) {
+      break;
+    }
+    seen.add(current);
+
+    const code = readStringField(current, 'code');
+    if (code === '42P01') {
+      return true;
+    }
+
+    const message =
+      current instanceof Error
+        ? current.message
+        : readStringField(current, 'message');
+    if (
+      message != null &&
+      /\bno such table\b/i.test(message) &&
+      (message.includes('D1_ERROR') ||
+        message.includes('SQLITE_ERROR') ||
+        code === 'SQLITE_ERROR')
+    ) {
+      return true;
+    }
+
+    current = isRecord(current) ? current.cause : null;
+  }
+
+  return false;
 }
 
 async function getIssueDayFactsInRange(
@@ -2814,7 +2858,7 @@ async function getIssueDayFactsInRange(
         ),
     );
   } catch (error) {
-    if (isUndefinedTableError(error)) {
+    if (isMissingTableError(error)) {
       return [];
     }
     throw error;
@@ -2843,14 +2887,14 @@ async function getOperationalFactCoverageDatesInRange(
         .groupBy(lineDayFactsTable.date),
     );
   } catch (error) {
-    if (isUndefinedTableError(error)) {
+    if (isMissingTableError(error)) {
       return [];
     }
     throw error;
   }
 }
 
-async function getOperationalFactCoverageStartDate() {
+async function getOperationalFactCoverageStart(): Promise<OperationalFactCoverageStart> {
   const db = await getDefaultDb();
   try {
     const [row] = await timeServerSpan('fact_coverage_start_query', () =>
@@ -2860,10 +2904,15 @@ async function getOperationalFactCoverageStartDate() {
         })
         .from(lineDayFactsTable),
     );
-    return row?.startDate ?? null;
+    return {
+      status: 'available',
+      startDate: row?.startDate ?? null,
+    };
   } catch (error) {
-    if (isUndefinedTableError(error)) {
-      return null;
+    if (isMissingTableError(error)) {
+      return {
+        status: 'missing_table',
+      };
     }
     throw error;
   }
@@ -2884,6 +2933,44 @@ function hasFullDateCoverage(
   return dates.size === expectedDays;
 }
 
+export function selectLegacyHistoryFallback(
+  start: DateTime,
+  end: DateTime,
+  today: DateTime,
+  coverageRows: Array<{ date: string }>,
+  coverageStart: OperationalFactCoverageStart,
+  context: string,
+) {
+  if (end.startOf('day') >= today) {
+    return true;
+  }
+
+  const coverageEnd = end.startOf('day') < today ? end.startOf('day') : today;
+  if (coverageEnd < start.startOf('day')) {
+    return false;
+  }
+
+  if (hasFullDateCoverage(coverageRows, start, coverageEnd)) {
+    return false;
+  }
+
+  if (coverageStart.status === 'missing_table') {
+    return true;
+  }
+
+  if (
+    coverageStart.startDate != null &&
+    start.startOf('day') <
+      DateTime.fromISO(coverageStart.startDate, { zone: SG_TIMEZONE })
+  ) {
+    return true;
+  }
+
+  throw new Error(
+    `Missing operational fact coverage for ${context}: ${start.toISODate()} to ${coverageEnd.toISODate()}`,
+  );
+}
+
 async function shouldUseLegacyHistoryFallback(
   start: DateTime,
   end: DateTime,
@@ -2895,29 +2982,19 @@ async function shouldUseLegacyHistoryFallback(
   }
 
   const coverageEnd = end.startOf('day') < today ? end.startOf('day') : today;
-  if (coverageEnd < start.startOf('day')) {
-    return false;
-  }
+  const coverageRows =
+    coverageEnd < start.startOf('day')
+      ? []
+      : await getOperationalFactCoverageDatesInRange(start, coverageEnd);
+  const coverageStart = await getOperationalFactCoverageStart();
 
-  const coverageRows = await getOperationalFactCoverageDatesInRange(
+  return selectLegacyHistoryFallback(
     start,
-    coverageEnd,
-  );
-  if (hasFullDateCoverage(coverageRows, start, coverageEnd)) {
-    return false;
-  }
-
-  const coverageStart = await getOperationalFactCoverageStartDate();
-  if (
-    coverageStart != null &&
-    start.startOf('day') <
-      DateTime.fromISO(coverageStart, { zone: SG_TIMEZONE })
-  ) {
-    return true;
-  }
-
-  throw new Error(
-    `Missing operational fact coverage for ${context}: ${start.toISODate()} to ${coverageEnd.toISODate()}`,
+    end,
+    today,
+    coverageRows,
+    coverageStart,
+    context,
   );
 }
 
@@ -4036,7 +4113,7 @@ async function getLatestStatisticsSnapshot(db?: AppDb) {
     );
     return parseStatisticsSnapshotPayload(snapshot?.data);
   } catch (error) {
-    if (isUndefinedTableError(error)) {
+    if (isMissingTableError(error)) {
       return null;
     }
     throw error;
@@ -4343,8 +4420,11 @@ export async function getSitemapData() {
     monthEarliestDateTime,
     monthLatestDateTime.endOf('month'),
   );
+  const operationalFactCoverageStart = await getOperationalFactCoverageStart();
   const operationalFactCoverageStartDate =
-    await getOperationalFactCoverageStartDate();
+    operationalFactCoverageStart.status === 'available'
+      ? operationalFactCoverageStart.startDate
+      : null;
 
   return {
     lineIds: Object.keys(dataset.included.lines).sort(),
@@ -4354,6 +4434,8 @@ export async function getSitemapData() {
     monthEarliest,
     monthLatest,
     operationalFactCoverageDates: coverageRows.map((row) => row.date),
+    operationalFactCoverageMissing:
+      operationalFactCoverageStart.status === 'missing_table',
     operationalFactCoverageStartDate,
     currentDate: isoDate(nowSg()),
   };

--- a/app/util/sitemap.functions.test.ts
+++ b/app/util/sitemap.functions.test.ts
@@ -100,6 +100,25 @@ describe('agent Markdown discovery', () => {
     expect(paths).toContain('/history/2026/06');
   });
 
+  it('includes historical months when D1 fact tables are absent', () => {
+    const paths = buildSitemapPaths({
+      lineIds: [],
+      stationIds: [],
+      operatorIds: [],
+      issueIds: [],
+      monthEarliest: '2026-04-01',
+      monthLatest: '2026-05-01',
+      operationalFactCoverageDates: [],
+      operationalFactCoverageMissing: true,
+      operationalFactCoverageStartDate: null,
+      currentDate: '2026-06-21',
+    });
+
+    expect(paths).toContain('/history/2026');
+    expect(paths).toContain('/history/2026/04');
+    expect(paths).toContain('/history/2026/05');
+  });
+
   it('only includes history year paths when the full year can render', () => {
     const paths = buildSitemapPaths({
       lineIds: [],

--- a/app/util/sitemap.functions.ts
+++ b/app/util/sitemap.functions.ts
@@ -14,6 +14,7 @@ interface SitemapPathData {
   monthLatest: string;
   operationalFactCoverageDates: string[];
   operationalFactCoverageStartDate: string | null;
+  operationalFactCoverageMissing?: boolean;
   currentDate: string;
 }
 
@@ -99,6 +100,7 @@ export function buildSitemapPaths({
   monthEarliest,
   monthLatest,
   operationalFactCoverageDates,
+  operationalFactCoverageMissing = false,
   operationalFactCoverageStartDate,
   currentDate,
 }: SitemapPathData) {
@@ -138,6 +140,7 @@ export function buildSitemapPaths({
     if (
       !isHistoryMonthRenderable({
         coverageDates,
+        operationalFactCoverageMissing,
         coverageStartDateTime,
         currentDateTime,
         monthDateTime,
@@ -151,6 +154,7 @@ export function buildSitemapPaths({
       !paths.includes(yearPath) &&
       isHistoryYearRenderable({
         coverageDates,
+        operationalFactCoverageMissing,
         coverageStartDateTime,
         currentDateTime,
         yearDateTime: monthDateTime.startOf('year'),
@@ -168,11 +172,13 @@ export function buildSitemapPaths({
 
 function isHistoryMonthRenderable({
   coverageDates,
+  operationalFactCoverageMissing,
   coverageStartDateTime,
   currentDateTime,
   monthDateTime,
 }: {
   coverageDates: Set<string>;
+  operationalFactCoverageMissing: boolean;
   coverageStartDateTime: DateTime | null;
   currentDateTime: DateTime;
   monthDateTime: DateTime;
@@ -182,6 +188,7 @@ function isHistoryMonthRenderable({
 
   return isHistoryDateRangeRenderable({
     coverageDates,
+    operationalFactCoverageMissing,
     coverageStartDateTime,
     currentDateTime,
     rangeStart: monthStart,
@@ -191,11 +198,13 @@ function isHistoryMonthRenderable({
 
 function isHistoryYearRenderable({
   coverageDates,
+  operationalFactCoverageMissing,
   coverageStartDateTime,
   currentDateTime,
   yearDateTime,
 }: {
   coverageDates: Set<string>;
+  operationalFactCoverageMissing: boolean;
   coverageStartDateTime: DateTime | null;
   currentDateTime: DateTime;
   yearDateTime: DateTime;
@@ -205,6 +214,7 @@ function isHistoryYearRenderable({
 
   return isHistoryDateRangeRenderable({
     coverageDates,
+    operationalFactCoverageMissing,
     coverageStartDateTime,
     currentDateTime,
     rangeStart: yearStart,
@@ -214,12 +224,14 @@ function isHistoryYearRenderable({
 
 function isHistoryDateRangeRenderable({
   coverageDates,
+  operationalFactCoverageMissing,
   coverageStartDateTime,
   currentDateTime,
   rangeStart,
   rangeEnd,
 }: {
   coverageDates: Set<string>;
+  operationalFactCoverageMissing: boolean;
   coverageStartDateTime: DateTime | null;
   currentDateTime: DateTime;
   rangeStart: DateTime;
@@ -230,6 +242,10 @@ function isHistoryDateRangeRenderable({
   const today = currentDateTime.startOf('day');
 
   if (end >= today) {
+    return true;
+  }
+
+  if (operationalFactCoverageMissing) {
     return true;
   }
 

--- a/docs/plans/active/d1-migration.md
+++ b/docs/plans/active/d1-migration.md
@@ -319,6 +319,12 @@ Exit criteria:
   `/internal/api/tasks/pull/`, but did not execute the workflow in the local
   runtime during validation; D1 row counts remained zero, so end-to-end pull
   validation still needs a preview or workflow-capable runtime.
+- 2026-06-25: Started Phase 4 read-path hardening by making public statistics
+  and fact-table fallbacks recognize D1/SQLite missing-table errors in addition
+  to Postgres `42P01`, with focused coverage for D1-style wrapped errors.
+- 2026-06-26: Extended Phase 4 sitemap read-path handling so a missing D1
+  operational fact table keeps legacy-renderable history paths discoverable
+  instead of treating the state like an existing empty facts table.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- Add a dialect-neutral missing-table detector for public read fallbacks.
- Keep statistics snapshots and operational fact-table reads falling back cleanly when D1 reports `no such table` errors during rollout.
- Treat absent D1 operational fact tables as an explicit legacy-history fallback signal, while keeping existing empty fact tables as missing-coverage errors.
- Keep sitemap history paths discoverable when D1 fact tables are absent but history routes can render through the legacy dataset path.
- Add focused unit coverage for Postgres `42P01`, D1/SQLite messages, wrapped SQLite causes, history fallback selection, and sitemap path generation.
- Update the D1 migration plan progress log for this Phase 4 read-path slice.

## Validation

- `npm run test:run -- app/util/db.queries.test.ts`
- `npm run test:run -- app/util/sitemap.functions.test.ts app/util/db.queries.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run verify`

Note: sandboxed verification needed elevated permissions because `tsx` creates/listens on a temporary IPC pipe during `db:generate:check`. The elevated `npm run verify` run passed.