### PR TITLE
chore: document D1 no-import cutover

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -203,7 +203,7 @@ jobs:
           set -euo pipefail
 
           if [ "${D1_CUTOVER_READY}" != "true" ]; then
-            echo "::error::Set the production D1_CUTOVER_READY environment variable to true only after site-local state has been imported, the canonical pull has completed, public holidays have synced, and route checks have passed against the production D1 database."
+            echo "::error::Set the production D1_CUTOVER_READY environment variable to true only after the no-import site-local checks have passed, the canonical pull has completed, public holidays have synced, and route checks have passed against the production D1 database."
             exit 1
           fi
         env:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,10 +43,8 @@ canonical pull workflow after deployment so the preview D1 read model can be
 validated before staging or production cutover. Staging and production deploys
 require `D1_CUTOVER_READY=true` in the matching GitHub environment. Set it only
 after the canonical pull, public-holiday sync, and route checks have passed
-against that environment's D1 database. Production currently has no
-crowd-report rows to import; if any appear before the freeze, pause cutover and
-prepare a one-off migration plan after the canonical pull has populated
-`lines` and `stations`.
+against that environment's D1 database. For production, also confirm the
+site-local no-import checks in the cutover runbook before enabling the gate.
 
 The staging/production deploy workflow is serialized per branch so D1
 migrations and Worker deploys advance together. A newer run waits for the

--- a/docs/DATA_PIPELINE.md
+++ b/docs/DATA_PIPELINE.md
@@ -48,13 +48,13 @@ processed per scheduled run.
 
 ## Site-Local Cutover
 
-Production D1 cutover normally does not import site-local state from Postgres:
-production currently has no crowd reports, and public holidays are refreshed
-from data.gov.sg by the public-holiday workflow. If crowd-report rows appear
-before the production freeze, pause cutover and prepare a one-off migration plan
-for those rows. The canonical pull must run before any such import because
-crowd-report line and station joins reference the canonical `lines` and
-`stations` tables. See `docs/runbooks/d1-cutover.md`.
+D1 cutover does not import rows from Postgres. Canonical transit rows are
+rebuilt from `mrtdown-data`, and public holidays are refreshed through the
+public-holiday workflow. During the production freeze, confirm the old Postgres
+crowd-report tables are empty before enabling D1 traffic. If they are not empty,
+pause cutover and decide whether those reports can be discarded, manually
+recreated through the D1-backed UI, or handled by a separate one-off migration.
+See `docs/runbooks/d1-cutover.md`.
 
 ## Staging Tables
 

--- a/docs/plans/active/d1-migration.md
+++ b/docs/plans/active/d1-migration.md
@@ -143,7 +143,7 @@ Stacked branches:
    - Base: previous stack branch.
    - PR title: `chore: cut over production data store to D1`
    - Scope: Wrangler bindings, deployment configuration, migration runbook,
-     export/import scripts for site-local state, and revert notes.
+     no-import site-local checks, and revert notes.
 
 Each stacked PR should update this plan's progress log. Rebase stacked branches
 forward after review changes so the final history reads as a deliberate
@@ -260,22 +260,23 @@ Exit criteria:
 
 ### Phase 6: Site-Local State Migration
 
-- Export site-local mutable tables from Postgres:
-  - public holidays;
-  - crowd report tables;
-  - moderation events;
-  - rate limits and abuse events if they are still operationally useful;
-  - dispatch status and dispatch payload/error fields.
-- Import into D1 with foreign-key-safe ordering.
+- Do not import rows from Postgres during cutover.
+- Rebuild public holidays through the D1 public-holiday workflow.
+- Confirm old Postgres crowd-report tables are empty during the production
+  freeze before enabling D1 traffic.
+- If crowd-report rows exist before cutover, pause and decide whether they can
+  be discarded, manually recreated through the D1-backed UI, or handled by a
+  separate one-off migration.
 - Rebuild canonical tables from `mrtdown-data` instead of importing them from
   Postgres.
-- Run consistency checks after import.
+- Run consistency checks after the canonical pull and public-holiday sync.
 
 Exit criteria:
 
-- D1 contains all required site-local state.
-- Canonical and derived rows can be rebuilt from the archive after import.
-- A revert/import recovery path is documented.
+- D1 contains rebuilt canonical rows and refreshed public holidays.
+- The no-import decision for old crowd-report state is explicitly validated.
+- Canonical and derived rows can be rebuilt from the archive.
+- A revert recovery path is documented.
 
 ### Phase 7: Preview And Cutover
 
@@ -285,7 +286,8 @@ Exit criteria:
 - Compare route data and timings against the Postgres-backed environment.
 - Cut production bindings to D1 only after preview has passed.
 - Keep the production cutover small: merge the stack, apply D1 migrations,
-  import site-local state, run the canonical pull, then deploy D1 bindings.
+  run the canonical pull and public-holiday sync, validate no-import
+  site-local checks, then deploy D1 bindings.
 - Document how to revert the stack and restore the previous Postgres-backed
   deployment if cutover fails.
 
@@ -339,7 +341,8 @@ Exit criteria:
   D1 database IDs from GitHub environment variables before remote Wrangler
   commands, adding preview public-holiday sync before the preview canonical
   pull, and blocking production deploy until `D1_CUTOVER_READY=true` confirms
-  site-local import, canonical pull, public-holiday sync, and route checks.
+  no-import site-local checks, canonical pull, public-holiday sync, and route
+  checks.
 - 2026-06-27: Extended the D1 cutover readiness gate to staging so staging
   deploys cannot serve from a freshly migrated but unpopulated D1 database.
 - 2026-06-27: Moved the staging readiness gate after the staging migration job
@@ -354,11 +357,10 @@ Exit criteria:
   direct `pg` dependencies after the D1 runtime and Wrangler migration commands
   became the only supported database entrypoints, and switched crowd-report SQL
   rendering tests to SQLite/D1 dialect coverage.
-- 2026-06-28: Started Phase 6 by documenting the production D1 cutover runbook
-  under `docs/runbooks` and simplifying the default cutover path to skip
-  Postgres site-local import while production crowd-report tables remain empty.
-  If crowd-report rows appear before the freeze, cutover should pause for a
-  one-off migration plan.
+- 2026-06-28: Refined Phase 6 to avoid Postgres row imports during cutover.
+  Canonical rows are rebuilt from `mrtdown-data`, public holidays are refreshed
+  by the D1 workflow, and old Postgres crowd-report tables must be confirmed
+  empty or explicitly dispositioned before `D1_CUTOVER_READY=true`.
 
 ## Decision Log
 

--- a/docs/runbooks/d1-cutover.md
+++ b/docs/runbooks/d1-cutover.md
@@ -2,22 +2,28 @@
 
 This runbook covers the production switch from the old Postgres/Hyperdrive
 database to Cloudflare D1. Canonical transit rows are rebuilt from
-`mrtdown-data`.
-
-As of the D1 migration work, production has no crowd-report rows. The default
-cutover path therefore does not import Postgres site-local state. Public
-holidays are refreshed from data.gov.sg by the D1 public-holiday workflow.
-
-If crowd-report rows appear before the production freeze, pause cutover and
-prepare a one-off migration plan for those rows.
+`mrtdown-data`. The cutover does not import rows from Postgres.
 
 ## Inputs
 
-- A deployed D1 database with all Wrangler migrations applied.
+- A production D1 database with all Wrangler migrations applied.
 - The production `D1_DATABASE_ID` GitHub environment variable.
 - `D1_CUTOVER_READY=false` until every validation step below passes.
+- Temporary read access to the old Postgres database for no-import checks.
+- Cloudflare credentials for `wrangler d1 execute` validation queries.
 
-## Default Production Sequence
+## No-Import Policy
+
+Do not copy canonical or site-local rows from Postgres into D1 during cutover.
+Canonical transit rows are rebuilt from `mrtdown-data`; public holidays are
+refreshed from data.gov.sg by the public-holiday workflow.
+
+During the production freeze, confirm old Postgres crowd-report tables are
+empty. If any rows exist, pause cutover and decide whether those reports can be
+discarded, manually recreated through the D1-backed UI, or handled by a separate
+one-off migration.
+
+## Production Sequence
 
 1. Keep `D1_CUTOVER_READY=false`.
 2. Apply production D1 migrations through the deploy workflow preflight.
@@ -30,15 +36,38 @@ prepare a one-off migration plan for those rows.
    ```sql
    select count(*) as crowd_reports from crowd_reports;
    select count(*) as crowd_report_clusters from crowd_report_clusters;
+   select count(*) as crowd_report_cluster_lines from crowd_report_cluster_lines;
+   select count(*) as crowd_report_cluster_stations from crowd_report_cluster_stations;
+   select count(*) as crowd_report_lines from crowd_report_lines;
+   select count(*) as crowd_report_stations from crowd_report_stations;
    select count(*) as crowd_report_moderation_events from crowd_report_moderation_events;
    select count(*) as crowd_report_rate_limits from crowd_report_rate_limits;
    select count(*) as crowd_report_abuse_events from crowd_report_abuse_events;
    ```
 
-8. If every count is zero, skip Postgres site-local import.
-9. Run route checks for `/`, `/statistics`, `/history`, representative line,
-   station, operator, issue, Markdown, and sitemap routes.
-10. Run a crowd-report dispatch dry run:
+8. Inject the real production D1 database ID into the local Wrangler config:
+
+   ```sh
+   CLOUDFLARE_ENV=production \
+   D1_DATABASE_ID="$D1_DATABASE_ID" \
+   npm run cf:prepare-d1-config
+   ```
+
+9. Confirm D1 has rebuilt canonical/public state and has no pre-cutover
+   crowd-report rows:
+
+    ```sh
+    npx wrangler d1 execute DB --env production --remote --command \
+      "select 'lines' as table_name, count(*) as rows from lines
+       union all select 'stations', count(*) from stations
+       union all select 'public_holidays', count(*) from public_holidays
+       union all select 'crowd_reports', count(*) from crowd_reports
+       union all select 'crowd_report_clusters', count(*) from crowd_report_clusters;"
+    ```
+
+10. Run route checks for `/`, `/statistics`, `/history`, representative line,
+    station, operator, issue, Markdown, and sitemap routes.
+11. Run a crowd-report dispatch dry run:
 
     ```sh
     curl -X POST "$VITE_ROOT_URL/internal/api/tasks/crowd-report-dispatch" \
@@ -46,8 +75,9 @@ prepare a one-off migration plan for those rows.
       --data '{"dryRun":true}'
     ```
 
-11. Set `D1_CUTOVER_READY=true` only after row-count and route validation pass.
-12. Run the production deploy.
+12. Set `D1_CUTOVER_READY=true` only after no-import checks, route validation,
+    and dispatch dry run pass.
+13. Run the production deploy.
 
 ## Recovery
 


### PR DESCRIPTION
## Summary

- Document the D1 production cutover as a no-import path from Postgres.
- Require old Postgres crowd-report tables to be empty or explicitly dispositioned before enabling `D1_CUTOVER_READY`.
- Align architecture, data pipeline, active D1 plan, runbook, and deploy readiness messaging around the no-import cutover gate.

## Validation

- `npm run verify`