### PR TITLE
ci: harden manual D1 migrations

### DIFF
--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -40,6 +40,36 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Inject D1 database ID
+        run: npm run cf:prepare-d1-config
+        env:
+          CLOUDFLARE_ENV: ${{ inputs.environment }}
+          D1_DATABASE_ID: ${{ vars.D1_DATABASE_ID }}
+
+      - name: Build production preflight
+        if: inputs.environment == 'production'
+        run: npm run build
+        env:
+          # Used by the Cloudflare Vite plugin for wrangler env key https://developers.cloudflare.com/workers/vite-plugin/reference/cloudflare-environments/
+          CLOUDFLARE_ENV: production
+          GIT_SHA: ${{ github.sha }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+          SENTRY_RELEASE: ${{ github.sha }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          TIER: production
+          VITE_PUBLIC_POSTHOG_KEY: ${{ secrets.VITE_PUBLIC_POSTHOG_KEY }}
+          VITE_PUBLIC_POSTHOG_HOST: ${{ secrets.VITE_PUBLIC_POSTHOG_HOST }}
+          VITE_ROOT_URL: "https://www.mrtdown.org"
+
+      - name: Validate production deploy bundle
+        if: inputs.environment == 'production'
+        run: npx wrangler deploy --env production --dry-run
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
       - name: Run database migrations
         run: npm run db:migrate -- --env ${{ inputs.environment }}
         env:

--- a/docs/plans/active/d1-migration.md
+++ b/docs/plans/active/d1-migration.md
@@ -361,6 +361,11 @@ Exit criteria:
   Canonical rows are rebuilt from `mrtdown-data`, public holidays are refreshed
   by the D1 workflow, and old Postgres crowd-report tables must be confirmed
   empty or explicitly dispositioned before `D1_CUTOVER_READY=true`.
+- 2026-06-28: Hardened the manual D1 migration workflow so staging and
+  production migrations inject the real environment D1 database ID before
+  running Wrangler, and production manual migrations use the same build and
+  Wrangler dry-run preflight as the production deploy workflow before applying
+  remote schema changes.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- inject the real environment `D1_DATABASE_ID` in the manual D1 migration workflow before Wrangler runs
- add the production build and Wrangler deploy dry-run preflight to manual production migrations
- record the D1 plan progress entry for this cutover hardening step

## Why

The main deploy workflow already prepared environment-specific D1 config and guarded production migrations with a deployability preflight. The manual migration workflow still used the checked-in placeholder D1 IDs and could apply production schema changes without proving the Worker bundle was deployable first.

## Validation

- `npm run verify`

Note: the first verify attempt failed before dependencies were installed, then a sandboxed rerun hit a `tsx` IPC `EPERM` under `/var/folders`. After `npm ci`, the elevated rerun passed: typecheck, lint, format check, migration drift check, and 31 Vitest files / 241 tests.