### PR TITLE
ci: check preview D1 routes after population

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -115,3 +115,10 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Check preview D1 routes
+        run: npm run perf:routes -- "$DEPLOYMENT_URL"
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
+          PROBES: all
+          SAMPLES: 1

--- a/app/scripts/checkRouteTimings.ts
+++ b/app/scripts/checkRouteTimings.ts
@@ -1,10 +1,11 @@
-type ProbeGroup = 'html' | 'markdown';
+type ProbeGroup = 'html' | 'markdown' | 'xml';
 
 type RouteProbe = {
   group: ProbeGroup;
   label: string;
   route: string;
   accept: string;
+  expectedStatuses?: readonly number[];
 };
 
 const HTML_PROBES = [
@@ -12,7 +13,11 @@ const HTML_PROBES = [
   '/?viewport=md',
   '/?viewport=lg',
   '/statistics',
+  '/history',
   '/about',
+  '/lines/BPLRT',
+  '/stations/BKP',
+  '/operators/SMRT_TRAINS',
 ].map(
   (route) =>
     ({
@@ -53,16 +58,19 @@ const MARKDOWN_PROBES = [
     label: 'line .md alias attempt',
     route: '/lines/BPLRT.md',
     accept: 'text/markdown',
+    expectedStatuses: [404],
   },
   {
     label: 'station .md alias attempt',
     route: '/stations/BKP.md',
     accept: 'text/markdown',
+    expectedStatuses: [404],
   },
   {
     label: 'HTML route with Markdown Accept',
     route: '/lines/BPLRT',
     accept: 'text/markdown',
+    expectedStatuses: [406],
   },
 ].map(
   (probe) =>
@@ -72,12 +80,22 @@ const MARKDOWN_PROBES = [
     }) satisfies RouteProbe,
 );
 
-const DEFAULT_PROBES = [...HTML_PROBES, ...MARKDOWN_PROBES] as const;
+const XML_PROBES = [
+  {
+    group: 'xml',
+    label: 'sitemap.xml',
+    route: '/sitemap.xml',
+    accept: 'application/xml, text/xml;q=0.9, */*;q=0.1',
+  },
+] satisfies RouteProbe[];
+
+const DEFAULT_PROBES = [...HTML_PROBES, ...MARKDOWN_PROBES, ...XML_PROBES];
 
 type ProbeTiming = {
   group: ProbeGroup;
   label: string;
   route: string;
+  expectedStatuses: readonly number[];
   status: number;
   ttfbMs: number;
   totalMs: number;
@@ -112,14 +130,14 @@ function getProbeGroups() {
     .filter((group) => group !== '');
 
   if (groups.includes('all')) {
-    return new Set<ProbeGroup>(['html', 'markdown']);
+    return new Set<ProbeGroup>(['html', 'markdown', 'xml']);
   }
 
   const selectedGroups = new Set<ProbeGroup>();
   for (const group of groups) {
-    if (group !== 'html' && group !== 'markdown') {
+    if (group !== 'html' && group !== 'markdown' && group !== 'xml') {
       throw new Error(
-        'PROBES must be "all", "html", "markdown", or a comma list.',
+        'PROBES must be "all", "html", "markdown", "xml", or a comma list.',
       );
     }
     selectedGroups.add(group);
@@ -157,6 +175,7 @@ async function timeRoute(
     group: probe.group,
     label: probe.label,
     route: probe.route,
+    expectedStatuses: probe.expectedStatuses ?? [200],
     status: response.status,
     ttfbMs: Number(ttfbMs.toFixed(1)),
     totalMs: Number(totalMs.toFixed(1)),
@@ -168,6 +187,27 @@ async function timeRoute(
     serverTiming: response.headers.get('server-timing') ?? '',
     render: response.headers.get('x-mrtdown-render') ?? '',
   };
+}
+
+function getRouteCheckFailures(results: TimingResult[]) {
+  const failures: string[] = [];
+
+  for (const result of results) {
+    if (!result.expectedStatuses.includes(result.status)) {
+      failures.push(
+        `${result.label} sample ${result.sample} returned ${result.status}; expected ${result.expectedStatuses.join(
+          ' or ',
+        )}`,
+      );
+      continue;
+    }
+
+    if (result.status >= 200 && result.status < 300 && result.bytes === 0) {
+      failures.push(`${result.label} sample ${result.sample} returned 0 bytes`);
+    }
+  }
+
+  return failures;
 }
 
 async function main() {
@@ -195,6 +235,7 @@ async function main() {
       group: result.group,
       label: result.label,
       route: result.route,
+      expected: result.expectedStatuses.join('/'),
       status: result.status,
       ttfbMs: result.ttfbMs,
       totalMs: result.totalMs,
@@ -207,6 +248,17 @@ async function main() {
       serverTiming: result.serverTiming,
     })),
   );
+
+  const failures = getRouteCheckFailures(results);
+  if (failures.length > 0) {
+    console.error(
+      [
+        'Route smoke checks failed:',
+        ...failures.map((failure) => `- ${failure}`),
+      ].join('\n'),
+    );
+    process.exitCode = 1;
+  }
 }
 
 main().catch((error) => {

--- a/docs/plans/active/d1-migration.md
+++ b/docs/plans/active/d1-migration.md
@@ -366,6 +366,10 @@ Exit criteria:
   running Wrangler, and production manual migrations use the same build and
   Wrangler dry-run preflight as the production deploy workflow before applying
   remote schema changes.
+- 2026-06-28: Added a preview D1 route smoke check after public-holiday sync
+  and canonical pull workflow completion. The repeatable route timing script
+  now covers representative public HTML, Markdown, and sitemap routes and fails
+  CI when a probe returns an unexpected status or an empty successful body.
 
 ## Decision Log
 


### PR DESCRIPTION
## Summary

- run the route timing smoke check after the preview D1 public-holiday and canonical pull workflows complete
- extend the route timing script to cover representative public HTML, Markdown, and sitemap probes
- fail the smoke check on unexpected statuses or empty successful responses while allowing intentional Markdown alias 404/406 responses
- update the D1 migration plan progress log

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run verify`