### PR TITLE
ci: verify D1 readiness before deploy

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -116,6 +116,19 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
+      - name: Check preview D1 readiness
+        run: npm run d1:check-readiness -- preview
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          D1_MIN_LINES: ${{ vars.D1_MIN_LINES }}
+          D1_MIN_STATIONS: ${{ vars.D1_MIN_STATIONS }}
+          D1_MIN_SERVICES: ${{ vars.D1_MIN_SERVICES }}
+          D1_MIN_SERVICE_REVISIONS: ${{ vars.D1_MIN_SERVICE_REVISIONS }}
+          D1_MIN_PUBLIC_HOLIDAYS: ${{ vars.D1_MIN_PUBLIC_HOLIDAYS }}
+          D1_MIN_LINE_DAY_FACTS: ${{ vars.D1_MIN_LINE_DAY_FACTS }}
+          D1_MIN_STATISTICS_SNAPSHOTS: ${{ vars.D1_MIN_STATISTICS_SNAPSHOTS }}
+
       - name: Check preview D1 routes
         run: npm run perf:routes -- "$DEPLOYMENT_URL"
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,6 +90,19 @@ jobs:
           CLOUDFLARE_ENV: staging
           D1_DATABASE_ID: ${{ vars.D1_DATABASE_ID }}
 
+      - name: Check staging D1 readiness
+        run: npm run d1:check-readiness -- staging
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          D1_MIN_LINES: ${{ vars.D1_MIN_LINES }}
+          D1_MIN_STATIONS: ${{ vars.D1_MIN_STATIONS }}
+          D1_MIN_SERVICES: ${{ vars.D1_MIN_SERVICES }}
+          D1_MIN_SERVICE_REVISIONS: ${{ vars.D1_MIN_SERVICE_REVISIONS }}
+          D1_MIN_PUBLIC_HOLIDAYS: ${{ vars.D1_MIN_PUBLIC_HOLIDAYS }}
+          D1_MIN_LINE_DAY_FACTS: ${{ vars.D1_MIN_LINE_DAY_FACTS }}
+          D1_MIN_STATISTICS_SNAPSHOTS: ${{ vars.D1_MIN_STATISTICS_SNAPSHOTS }}
+
       - name: Build
         run: npm run build
         env:
@@ -221,6 +234,19 @@ jobs:
         env:
           CLOUDFLARE_ENV: production
           D1_DATABASE_ID: ${{ vars.D1_DATABASE_ID }}
+
+      - name: Check production D1 readiness
+        run: npm run d1:check-readiness -- production
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          D1_MIN_LINES: ${{ vars.D1_MIN_LINES }}
+          D1_MIN_STATIONS: ${{ vars.D1_MIN_STATIONS }}
+          D1_MIN_SERVICES: ${{ vars.D1_MIN_SERVICES }}
+          D1_MIN_SERVICE_REVISIONS: ${{ vars.D1_MIN_SERVICE_REVISIONS }}
+          D1_MIN_PUBLIC_HOLIDAYS: ${{ vars.D1_MIN_PUBLIC_HOLIDAYS }}
+          D1_MIN_LINE_DAY_FACTS: ${{ vars.D1_MIN_LINE_DAY_FACTS }}
+          D1_MIN_STATISTICS_SNAPSHOTS: ${{ vars.D1_MIN_STATISTICS_SNAPSHOTS }}
 
       - name: Build
         run: npm run build

--- a/app/scripts/checkD1Readiness.test.ts
+++ b/app/scripts/checkD1Readiness.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractJsonPayload,
+  parseD1ExecuteResult,
+} from './checkD1Readiness.js';
+
+describe('extractJsonPayload', () => {
+  it('extracts Wrangler JSON after proxy warning prelude text', () => {
+    const stdout = [
+      'Proxy environment variables detected. We will use your proxy.',
+      '[{"results":[{"lines":10}],"success":true,"meta":{"rows_read":1}}]',
+      '',
+    ].join('\n');
+
+    expect(extractJsonPayload(stdout)).toBe(
+      '[{"results":[{"lines":10}],"success":true,"meta":{"rows_read":1}}]',
+    );
+  });
+
+  it('preserves nested JSON payloads without consuming trailing text', () => {
+    const stdout =
+      'warning\n[{"results":[{"value":"} text"}],"meta":{"duration":1}}]\nextra';
+
+    expect(JSON.parse(extractJsonPayload(stdout))).toEqual([
+      {
+        results: [{ value: '} text' }],
+        meta: { duration: 1 },
+      },
+    ]);
+  });
+});
+
+describe('parseD1ExecuteResult', () => {
+  it('parses the first Wrangler D1 result object from noisy stdout', () => {
+    expect(
+      parseD1ExecuteResult(
+        'Proxy environment variables detected.\n[{"results":[{"lines":10}],"success":true}]',
+      ),
+    ).toEqual({
+      results: [{ lines: 10 }],
+      success: true,
+    });
+  });
+});

--- a/app/scripts/checkD1Readiness.ts
+++ b/app/scripts/checkD1Readiness.ts
@@ -1,0 +1,240 @@
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+type D1ReadinessCounts = {
+  line_day_facts: number;
+  lines: number;
+  public_holidays: number;
+  service_revisions: number;
+  services: number;
+  statistics_snapshots: number;
+  stations: number;
+};
+
+type D1ExecuteResult = {
+  results?: Record<string, unknown>[];
+  success?: boolean;
+  error?: string;
+  meta?: Record<string, unknown>;
+};
+
+const COUNT_QUERY = `
+select
+  (select count(*) from lines) as lines,
+  (select count(*) from stations) as stations,
+  (select count(*) from services) as services,
+  (select count(*) from service_revisions) as service_revisions,
+  (select count(*) from public_holidays) as public_holidays,
+  (select count(*) from line_day_facts) as line_day_facts,
+  (select count(*) from statistics_snapshots) as statistics_snapshots;
+`;
+
+function getTargetEnv() {
+  const targetEnv = process.argv[2] ?? process.env.CLOUDFLARE_ENV;
+  if (targetEnv == null || targetEnv.length === 0) {
+    throw new Error(
+      'Pass a Cloudflare environment, or set CLOUDFLARE_ENV before checking D1 readiness.',
+    );
+  }
+  return targetEnv;
+}
+
+function getMinimumCount(name: string) {
+  const rawValue = process.env[name];
+  if (rawValue == null || rawValue === '') {
+    throw new Error(`${name} must be set to a realistic environment minimum.`);
+  }
+
+  const parsedValue = Number.parseInt(rawValue, 10);
+  if (!Number.isFinite(parsedValue) || parsedValue < 0) {
+    throw new Error(`${name} must be a non-negative integer.`);
+  }
+  return parsedValue;
+}
+
+function getMinimumCounts(): D1ReadinessCounts {
+  return {
+    lines: getMinimumCount('D1_MIN_LINES'),
+    stations: getMinimumCount('D1_MIN_STATIONS'),
+    services: getMinimumCount('D1_MIN_SERVICES'),
+    service_revisions: getMinimumCount('D1_MIN_SERVICE_REVISIONS'),
+    public_holidays: getMinimumCount('D1_MIN_PUBLIC_HOLIDAYS'),
+    line_day_facts: getMinimumCount('D1_MIN_LINE_DAY_FACTS'),
+    statistics_snapshots: getMinimumCount('D1_MIN_STATISTICS_SNAPSHOTS'),
+  };
+}
+
+export function extractJsonPayload(stdout: string) {
+  const startIndex = stdout.search(/[[{]/);
+  if (startIndex === -1) {
+    throw new Error('Wrangler D1 output did not contain JSON.');
+  }
+
+  const stack: string[] = [];
+  let inString = false;
+  let escaped = false;
+
+  for (let index = startIndex; index < stdout.length; index++) {
+    const char = stdout[index];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (char === '\\') {
+      escaped = inString;
+      continue;
+    }
+
+    if (char === '"') {
+      inString = !inString;
+      continue;
+    }
+
+    if (inString) {
+      continue;
+    }
+
+    if (char === '[' || char === '{') {
+      stack.push(char === '[' ? ']' : '}');
+      continue;
+    }
+
+    if (char === ']' || char === '}') {
+      if (stack.at(-1) !== char) {
+        throw new Error('Wrangler D1 output contained invalid JSON.');
+      }
+
+      stack.pop();
+      if (stack.length === 0) {
+        return stdout.slice(startIndex, index + 1);
+      }
+    }
+  }
+
+  throw new Error('Wrangler D1 output contained incomplete JSON.');
+}
+
+export function parseD1ExecuteResult(stdout: string): D1ExecuteResult {
+  const parsed = JSON.parse(extractJsonPayload(stdout)) as unknown;
+  const result = Array.isArray(parsed) ? parsed[0] : parsed;
+  if (result == null || typeof result !== 'object') {
+    throw new Error('Wrangler D1 JSON output did not contain a result object.');
+  }
+  return result as D1ExecuteResult;
+}
+
+function getCountValue(
+  row: Record<string, unknown>,
+  key: keyof D1ReadinessCounts,
+) {
+  const value = row[key];
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsedValue = Number.parseInt(value, 10);
+    if (Number.isFinite(parsedValue)) {
+      return parsedValue;
+    }
+  }
+  throw new Error(`D1 readiness query returned an invalid ${key} count.`);
+}
+
+function extractCounts(result: D1ExecuteResult): D1ReadinessCounts {
+  if (result.success === false) {
+    throw new Error(result.error ?? 'Wrangler D1 readiness query failed.');
+  }
+
+  const row = result.results?.[0];
+  if (row == null) {
+    throw new Error('D1 readiness query returned no rows.');
+  }
+
+  return {
+    lines: getCountValue(row, 'lines'),
+    stations: getCountValue(row, 'stations'),
+    services: getCountValue(row, 'services'),
+    service_revisions: getCountValue(row, 'service_revisions'),
+    public_holidays: getCountValue(row, 'public_holidays'),
+    line_day_facts: getCountValue(row, 'line_day_facts'),
+    statistics_snapshots: getCountValue(row, 'statistics_snapshots'),
+  };
+}
+
+function getReadinessFailures(
+  counts: D1ReadinessCounts,
+  minimumCounts: D1ReadinessCounts,
+) {
+  return Object.entries(minimumCounts).flatMap(([tableName, minimum]) => {
+    const count = counts[tableName as keyof D1ReadinessCounts];
+    if (count >= minimum) {
+      return [];
+    }
+    return [`${tableName} has ${count} rows; expected at least ${minimum}`];
+  });
+}
+
+function main() {
+  const targetEnv = getTargetEnv();
+  const minimumCounts = getMinimumCounts();
+  const result = spawnSync(
+    'npx',
+    [
+      'wrangler',
+      'd1',
+      'execute',
+      'DB',
+      '--yes',
+      '--remote',
+      '--env',
+      targetEnv,
+      '--command',
+      COUNT_QUERY,
+      '--json',
+    ],
+    {
+      encoding: 'utf8',
+    },
+  );
+
+  if (result.error != null) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    console.error(result.stdout);
+    console.error(result.stderr);
+    throw new Error(`Wrangler D1 readiness query exited ${result.status}`);
+  }
+
+  const queryResult = parseD1ExecuteResult(result.stdout);
+  const counts = extractCounts(queryResult);
+  console.table(
+    Object.entries(counts).map(([tableName, count]) => ({
+      table: tableName,
+      rows: count,
+      minimum: minimumCounts[tableName as keyof D1ReadinessCounts],
+    })),
+  );
+
+  if (queryResult.meta != null) {
+    console.log('D1 query metrics:', JSON.stringify(queryResult.meta));
+  }
+
+  const failures = getReadinessFailures(counts, minimumCounts);
+  if (failures.length > 0) {
+    console.error(
+      [
+        `D1 readiness check failed for ${targetEnv}:`,
+        ...failures.map((failure) => `- ${failure}`),
+      ].join('\n'),
+    );
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/docs/plans/active/d1-migration.md
+++ b/docs/plans/active/d1-migration.md
@@ -373,6 +373,12 @@ Exit criteria:
 - 2026-06-28: Extended D1 route smoke checks to staging and production deploys
   so the live Worker URL is probed after the readiness gate and deploy
   complete.
+- 2026-06-28: Added automated D1 readiness checks for preview, staging, and
+  production deploys. The check queries remote D1 table counts for canonical
+  rows, public holidays, line day facts, and statistics snapshots, prints
+  Wrangler D1 query metrics, requires environment-specific `D1_MIN_*`
+  thresholds, and fails deploy validation before route checks if the database
+  is still empty or underpopulated.
 
 ## Decision Log
 

--- a/docs/runbooks/d1-cutover.md
+++ b/docs/runbooks/d1-cutover.md
@@ -8,6 +8,10 @@ database to Cloudflare D1. Canonical transit rows are rebuilt from
 
 - A production D1 database with all Wrangler migrations applied.
 - The production `D1_DATABASE_ID` GitHub environment variable.
+- Realistic production D1 readiness minimums in GitHub environment variables:
+  `D1_MIN_LINES`, `D1_MIN_STATIONS`, `D1_MIN_SERVICES`,
+  `D1_MIN_SERVICE_REVISIONS`, `D1_MIN_PUBLIC_HOLIDAYS`,
+  `D1_MIN_LINE_DAY_FACTS`, and `D1_MIN_STATISTICS_SNAPSHOTS`.
 - `D1_CUTOVER_READY=false` until every validation step below passes.
 - Temporary read access to the old Postgres database for no-import checks.
 - Cloudflare credentials for `wrangler d1 execute` validation queries.
@@ -56,14 +60,20 @@ one-off migration.
 9. Confirm D1 has rebuilt canonical/public state and has no pre-cutover
    crowd-report rows:
 
-    ```sh
-    npx wrangler d1 execute DB --env production --remote --command \
-      "select 'lines' as table_name, count(*) as rows from lines
-       union all select 'stations', count(*) from stations
-       union all select 'public_holidays', count(*) from public_holidays
-       union all select 'crowd_reports', count(*) from crowd_reports
-       union all select 'crowd_report_clusters', count(*) from crowd_report_clusters;"
-    ```
+   ```sh
+   D1_MIN_LINES="$D1_MIN_LINES" \
+   D1_MIN_STATIONS="$D1_MIN_STATIONS" \
+   D1_MIN_SERVICES="$D1_MIN_SERVICES" \
+   D1_MIN_SERVICE_REVISIONS="$D1_MIN_SERVICE_REVISIONS" \
+   D1_MIN_PUBLIC_HOLIDAYS="$D1_MIN_PUBLIC_HOLIDAYS" \
+   D1_MIN_LINE_DAY_FACTS="$D1_MIN_LINE_DAY_FACTS" \
+   D1_MIN_STATISTICS_SNAPSHOTS="$D1_MIN_STATISTICS_SNAPSHOTS" \
+     npm run d1:check-readiness -- production
+
+   npx wrangler d1 execute DB --env production --remote --command \
+     "select 'crowd_reports' as table_name, count(*) as rows from crowd_reports
+      union all select 'crowd_report_clusters', count(*) from crowd_report_clusters;"
+   ```
 
 10. Run route checks for `/`, `/statistics`, `/history`, representative line,
     station, operator, issue, Markdown, and sitemap routes.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "format:check": "biome format .",
     "seo:check": "tsx app/scripts/checkSeo.ts",
     "perf:routes": "tsx app/scripts/checkRouteTimings.ts",
+    "d1:check-readiness": "tsx app/scripts/checkD1Readiness.ts",
     "verify": "npm run typecheck && npm run lint && npm run format:check && npm run db:generate:check && npm run test:run",
     "verify:strict": "npm run typecheck && npm run lint && npm run format:check && npm run db:generate:check && npm run test:run",
     "dev:pull": "curl -i -X POST http://localhost:3000/internal/api/tasks/pull",


### PR DESCRIPTION
## Summary

- add a Wrangler-backed D1 readiness check for remote environment table counts
- run the check in preview, staging, and production deploy workflows before route smoke checks
- update the D1 cutover runbook and active migration plan with the new validation step

## Why

Migrations and Worker deploys can succeed while a D1 database is still underpopulated. This gives CI a direct database-level guard before route probes rely on the D1-backed Worker.

## Validation

- `npm run verify`