### PR TITLE
fix: omit default locale from footer language link

### DIFF
--- a/app/components/LocaleSwitcher/helpers.test.ts
+++ b/app/components/LocaleSwitcher/helpers.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
+import { removeLocalePrefix } from './helpers';
+
+describe('LocaleSwitcher helpers', () => {
+  it('removes supported locale prefixes', () => {
+    expect(removeLocalePrefix('/en-SG')).toBe('/');
+    expect(removeLocalePrefix('/en-SG/history')).toBe('/history');
+    expect(removeLocalePrefix('/zh-Hans/lines/BPLRT')).toBe('/lines/BPLRT');
+    expect(removeLocalePrefix('/ms')).toBe('/');
+  });
+
+  it('keeps unprefixed paths unchanged', () => {
+    expect(removeLocalePrefix('/')).toBe('/');
+    expect(removeLocalePrefix('/history')).toBe('/history');
+    expect(removeLocalePrefix('statistics')).toBe('/statistics');
+  });
+
+  it('builds default-locale footer links without en-SG in the path', () => {
+    expect(
+      buildLocaleAwareLink(removeLocalePrefix('/zh-Hans/history'), 'en-SG'),
+    ).toBe('/history');
+    expect(buildLocaleAwareLink(removeLocalePrefix('/history'), 'en-SG')).toBe(
+      '/history',
+    );
+    expect(buildLocaleAwareLink(removeLocalePrefix('/ta'), 'en-SG')).toBe('/');
+  });
+
+  it('builds non-default locale footer links with locale prefixes', () => {
+    expect(
+      buildLocaleAwareLink(removeLocalePrefix('/en-SG/history'), 'zh-Hans'),
+    ).toBe('/zh-Hans/history');
+    expect(buildLocaleAwareLink(removeLocalePrefix('/'), 'ms')).toBe('/ms/');
+  });
+});

--- a/app/components/LocaleSwitcher/helpers.ts
+++ b/app/components/LocaleSwitcher/helpers.ts
@@ -1,0 +1,17 @@
+import { LOCALES } from './constants';
+
+export function removeLocalePrefix(path: string) {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  const locale = LOCALES.find(
+    (candidate) =>
+      normalizedPath === `/${candidate}` ||
+      normalizedPath.startsWith(`/${candidate}/`),
+  );
+
+  if (locale == null) {
+    return normalizedPath;
+  }
+
+  const pathWithoutLocale = normalizedPath.slice(locale.length + 1);
+  return pathWithoutLocale === '' ? '/' : pathWithoutLocale;
+}

--- a/app/components/LocaleSwitcher/index.tsx
+++ b/app/components/LocaleSwitcher/index.tsx
@@ -1,16 +1,22 @@
-import { Link } from '@tanstack/react-router';
+import { Link, useRouterState } from '@tanstack/react-router';
 import classNames from 'classnames';
 import type React from 'react';
+import { buildLocaleAwareLink } from '~/helpers/buildLocaleAwareLink';
 import { LOCALES } from './constants';
+import { removeLocalePrefix } from './helpers';
 
 export const LocaleSwitcher: React.FC = () => {
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  });
+  const pathWithoutLocale = removeLocalePrefix(pathname);
+
   return (
     <div className="flex flex-col items-start justify-center gap-y-2">
       {LOCALES.map((locale) => (
         <Link
           key={locale}
-          to="."
-          params={{ lang: locale }}
+          to={buildLocaleAwareLink(pathWithoutLocale, locale)}
           className={classNames(
             'font-medium text-gray-300 text-xs transition-colors hover:text-blue-400 [&.active]:text-blue-400',
           )}


### PR DESCRIPTION
## Summary

- Updates the footer language switcher to derive links from the current pathname instead of route params that serialize the optional `en-SG` segment.
- Strips any existing locale prefix before passing the canonical path to the shared `buildLocaleAwareLink` helper.
- Adds focused tests for default-locale and non-default-locale footer link generation.

## Impact

English language links in the footer now point to unprefixed default-locale URLs such as `/history` instead of `/en-SG/history`, while non-default languages continue to use their locale prefixes.

## Validation

- `npm run test:run -- app/components/LocaleSwitcher/helpers.test.ts`
- `npm run verify`