### PR TITLE
fix: constrain history navigation year bounds

### DIFF
--- a/app/routes/{-$lang}/history/$year/$month.tsx
+++ b/app/routes/{-$lang}/history/$year/$month.tsx
@@ -22,6 +22,11 @@ import {
   getIssuesHistoryYearMonthFn,
   parseHistoryYearMonthParams,
 } from '~/util/history.functions';
+import {
+  getHistoryNavigationYearOptions,
+  HISTORY_YEAR_BOUNDS,
+  isHistoryYearInBounds,
+} from '~/util/historyYearBounds';
 
 export const Route = createFileRoute('/{-$lang}/history/$year/$month')({
   component: HistoryMonthPage,
@@ -127,15 +132,17 @@ function HistoryMonthPage() {
     return DateTime.fromISO(startAt).setZone('Asia/Singapore');
   }, [startAt]);
 
-  const yearOptions = useMemo(() => {
-    const currentYear = new Date().getFullYear();
-    const startYear = 2010;
-    const years = [];
-    for (let y = currentYear; y >= startYear; y--) {
-      years.push(y);
-    }
-    return years;
-  }, []);
+  const yearOptions = getHistoryNavigationYearOptions();
+  const previousMonthDateTime = dateTimeStartAt.minus({ month: 1 });
+  const nextMonthDateTime = dateTimeStartAt.plus({ month: 1 });
+  const canNavigateToPreviousMonth = isHistoryYearInBounds(
+    previousMonthDateTime.year,
+    HISTORY_YEAR_BOUNDS,
+  );
+  const canNavigateToNextMonth = isHistoryYearInBounds(
+    nextMonthDateTime.year,
+    HISTORY_YEAR_BOUNDS,
+  );
 
   const monthOptions = useMemo(() => {
     return Array.from({ length: 12 }, (_, i) => i + 1);
@@ -201,16 +208,21 @@ function HistoryMonthPage() {
               <button
                 type="button"
                 className="rounded-lg p-2 text-gray-700 transition-colors hover:bg-gray-100 disabled:pointer-events-none disabled:opacity-40 dark:text-gray-50 dark:hover:bg-gray-800"
+                disabled={!canNavigateToPreviousMonth}
               >
-                <Link
-                  to="/{-$lang}/history/$year/$month"
-                  params={{
-                    year: dateTimeStartAt.minus({ month: 1 }).year.toString(),
-                    month: dateTimeStartAt.minus({ month: 1 }).toFormat('MM'),
-                  }}
-                >
+                {canNavigateToPreviousMonth ? (
+                  <Link
+                    to="/{-$lang}/history/$year/$month"
+                    params={{
+                      year: previousMonthDateTime.year.toString(),
+                      month: previousMonthDateTime.toFormat('MM'),
+                    }}
+                  >
+                    <ArrowLeftIcon className="size-4" />
+                  </Link>
+                ) : (
                   <ArrowLeftIcon className="size-4" />
-                </Link>
+                )}
               </button>
 
               <div className="flex items-center justify-center gap-x-2 sm:min-w-64">
@@ -317,16 +329,21 @@ function HistoryMonthPage() {
               <button
                 type="button"
                 className="rounded-lg p-2 text-gray-700 transition-colors hover:bg-gray-100 disabled:pointer-events-none disabled:opacity-40 dark:text-gray-50 dark:hover:bg-gray-800"
+                disabled={!canNavigateToNextMonth}
               >
-                <Link
-                  to="/{-$lang}/history/$year/$month"
-                  params={{
-                    year: dateTimeStartAt.plus({ month: 1 }).year.toString(),
-                    month: dateTimeStartAt.plus({ month: 1 }).toFormat('MM'),
-                  }}
-                >
+                {canNavigateToNextMonth ? (
+                  <Link
+                    to="/{-$lang}/history/$year/$month"
+                    params={{
+                      year: nextMonthDateTime.year.toString(),
+                      month: nextMonthDateTime.toFormat('MM'),
+                    }}
+                  >
+                    <ArrowRightIcon className="size-4" />
+                  </Link>
+                ) : (
                   <ArrowRightIcon className="size-4" />
-                </Link>
+                )}
               </button>
             </div>
           </div>
@@ -383,16 +400,21 @@ function HistoryMonthPage() {
           <button
             type="button"
             className="rounded p-1.5 text-gray-600 transition-colors hover:bg-gray-100 disabled:pointer-events-none disabled:opacity-40 dark:text-gray-400 dark:hover:bg-gray-800"
+            disabled={!canNavigateToPreviousMonth}
           >
-            <Link
-              to="/{-$lang}/history/$year/$month"
-              params={{
-                year: dateTimeStartAt.minus({ month: 1 }).year.toString(),
-                month: dateTimeStartAt.minus({ month: 1 }).toFormat('MM'),
-              }}
-            >
+            {canNavigateToPreviousMonth ? (
+              <Link
+                to="/{-$lang}/history/$year/$month"
+                params={{
+                  year: previousMonthDateTime.year.toString(),
+                  month: previousMonthDateTime.toFormat('MM'),
+                }}
+              >
+                <ArrowLeftIcon className="size-4" />
+              </Link>
+            ) : (
               <ArrowLeftIcon className="size-4" />
-            </Link>
+            )}
           </button>
 
           <div className="flex min-w-52 items-center justify-center gap-x-2">
@@ -499,16 +521,21 @@ function HistoryMonthPage() {
           <button
             type="button"
             className="rounded p-1.5 text-gray-600 transition-colors hover:bg-gray-100 disabled:pointer-events-none disabled:opacity-40 dark:text-gray-400 dark:hover:bg-gray-800"
+            disabled={!canNavigateToNextMonth}
           >
-            <Link
-              to="/{-$lang}/history/$year/$month"
-              params={{
-                year: dateTimeStartAt.plus({ month: 1 }).year.toString(),
-                month: dateTimeStartAt.plus({ month: 1 }).toFormat('MM'),
-              }}
-            >
+            {canNavigateToNextMonth ? (
+              <Link
+                to="/{-$lang}/history/$year/$month"
+                params={{
+                  year: nextMonthDateTime.year.toString(),
+                  month: nextMonthDateTime.toFormat('MM'),
+                }}
+              >
+                <ArrowRightIcon className="size-4" />
+              </Link>
+            ) : (
               <ArrowRightIcon className="size-4" />
-            </Link>
+            )}
           </button>
         </div>
       </div>

--- a/app/routes/{-$lang}/history/$year/index.tsx
+++ b/app/routes/{-$lang}/history/$year/index.tsx
@@ -22,6 +22,11 @@ import {
   getIssuesHistoryYearFn,
   parseHistoryYearParam,
 } from '~/util/history.functions';
+import {
+  getHistoryNavigationYearOptions,
+  HISTORY_YEAR_BOUNDS,
+  isHistoryYearInBounds,
+} from '~/util/historyYearBounds';
 
 export const Route = createFileRoute('/{-$lang}/history/$year/')({
   component: HistoryYearPage,
@@ -127,15 +132,17 @@ function HistoryYearPage() {
     return DateTime.fromISO(startAt).setZone('Asia/Singapore');
   }, [startAt]);
 
-  const yearOptions = useMemo(() => {
-    const currentYear = new Date().getFullYear();
-    const startYear = 2010;
-    const years = [];
-    for (let y = currentYear; y >= startYear; y--) {
-      years.push(y);
-    }
-    return years;
-  }, []);
+  const yearOptions = getHistoryNavigationYearOptions();
+  const previousYear = dateTimeStartAt.minus({ year: 1 }).year;
+  const nextYear = dateTimeStartAt.plus({ year: 1 }).year;
+  const canNavigateToPreviousYear = isHistoryYearInBounds(
+    previousYear,
+    HISTORY_YEAR_BOUNDS,
+  );
+  const canNavigateToNextYear = isHistoryYearInBounds(
+    nextYear,
+    HISTORY_YEAR_BOUNDS,
+  );
 
   const isHydrated = useHydrated();
 
@@ -187,15 +194,20 @@ function HistoryYearPage() {
                 type="button"
                 className="rounded-lg p-3 text-gray-700 transition-all hover:bg-white hover:shadow-md disabled:pointer-events-none disabled:opacity-40 dark:text-gray-50 dark:hover:bg-gray-600"
                 aria-label="Previous year"
+                disabled={!canNavigateToPreviousYear}
               >
-                <Link
-                  to="/{-$lang}/history/$year"
-                  params={{
-                    year: dateTimeStartAt.minus({ year: 1 }).year.toString(),
-                  }}
-                >
+                {canNavigateToPreviousYear ? (
+                  <Link
+                    to="/{-$lang}/history/$year"
+                    params={{
+                      year: previousYear.toString(),
+                    }}
+                  >
+                    <ArrowLeftIcon className="size-5" />
+                  </Link>
+                ) : (
                   <ArrowLeftIcon className="size-5" />
-                </Link>
+                )}
               </button>
 
               <div className="flex min-w-48 flex-col items-center">
@@ -251,15 +263,20 @@ function HistoryYearPage() {
                 type="button"
                 className="rounded-lg p-3 text-gray-700 transition-all hover:bg-white hover:shadow-md disabled:pointer-events-none disabled:opacity-40 dark:text-gray-50 dark:hover:bg-gray-600"
                 aria-label="Next year"
+                disabled={!canNavigateToNextYear}
               >
-                <Link
-                  to="/{-$lang}/history/$year"
-                  params={{
-                    year: dateTimeStartAt.plus({ year: 1 }).year.toString(),
-                  }}
-                >
+                {canNavigateToNextYear ? (
+                  <Link
+                    to="/{-$lang}/history/$year"
+                    params={{
+                      year: nextYear.toString(),
+                    }}
+                  >
+                    <ArrowRightIcon className="size-5" />
+                  </Link>
+                ) : (
                   <ArrowRightIcon className="size-5" />
-                </Link>
+                )}
               </button>
             </div>
           </div>
@@ -379,15 +396,20 @@ function HistoryYearPage() {
             type="button"
             className="rounded-lg p-3 text-gray-600 transition-all hover:bg-gray-100 hover:shadow-sm disabled:pointer-events-none disabled:opacity-40 dark:text-gray-400 dark:hover:bg-gray-800"
             aria-label="Previous year"
+            disabled={!canNavigateToPreviousYear}
           >
-            <Link
-              to="/{-$lang}/history/$year"
-              params={{
-                year: dateTimeStartAt.minus({ year: 1 }).year.toString(),
-              }}
-            >
+            {canNavigateToPreviousYear ? (
+              <Link
+                to="/{-$lang}/history/$year"
+                params={{
+                  year: previousYear.toString(),
+                }}
+              >
+                <ArrowLeftIcon className="size-5" />
+              </Link>
+            ) : (
               <ArrowLeftIcon className="size-5" />
-            </Link>
+            )}
           </button>
 
           <div className="flex min-w-48 flex-col items-center">
@@ -443,15 +465,20 @@ function HistoryYearPage() {
             type="button"
             className="rounded-lg p-3 text-gray-600 transition-all hover:bg-gray-100 hover:shadow-sm disabled:pointer-events-none disabled:opacity-40 dark:text-gray-400 dark:hover:bg-gray-800"
             aria-label="Next year"
+            disabled={!canNavigateToNextYear}
           >
-            <Link
-              to="/{-$lang}/history/$year"
-              params={{
-                year: dateTimeStartAt.plus({ year: 1 }).year.toString(),
-              }}
-            >
+            {canNavigateToNextYear ? (
+              <Link
+                to="/{-$lang}/history/$year"
+                params={{
+                  year: nextYear.toString(),
+                }}
+              >
+                <ArrowRightIcon className="size-5" />
+              </Link>
+            ) : (
               <ArrowRightIcon className="size-5" />
-            </Link>
+            )}
           </button>
         </div>
       </div>

--- a/app/util/history.functions.test.ts
+++ b/app/util/history.functions.test.ts
@@ -1,9 +1,9 @@
-import { DateTime } from 'luxon';
 import { describe, expect, it } from 'vitest';
 import {
   parseHistoryYearMonthParams,
   parseHistoryYearParam,
 } from './history.functions';
+import { getHistoryYearMax, HISTORY_YEAR_BOUNDS } from './historyYearBounds';
 
 describe('parseHistoryYearParam', () => {
   it('coerces valid year route params', () => {
@@ -11,11 +11,11 @@ describe('parseHistoryYearParam', () => {
   });
 
   it('rejects invalid year route params', () => {
-    const maxYear = DateTime.now().year + 10;
+    const maxYear = getHistoryYearMax(HISTORY_YEAR_BOUNDS);
 
     expect(parseHistoryYearParam('not-a-year')).toBeNull();
     expect(parseHistoryYearParam('2025.5')).toBeNull();
-    expect(parseHistoryYearParam('1979')).toBeNull();
+    expect(parseHistoryYearParam('2009')).toBeNull();
     expect(parseHistoryYearParam((maxYear + 1).toString())).toBeNull();
   });
 });

--- a/app/util/history.functions.ts
+++ b/app/util/history.functions.ts
@@ -1,15 +1,16 @@
 import { createServerFn } from '@tanstack/react-start';
-import { DateTime } from 'luxon';
 import z from 'zod';
 import {
   getHistoryYearMonthData,
   getHistoryYearSummaryData,
 } from './db.queries';
+import {
+  HISTORY_YEAR_BOUNDS,
+  isHistoryYearInBounds,
+} from './historyYearBounds';
 
 function isHistoryYearInRange(year: number) {
-  const minYear = 1980;
-  const maxYear = DateTime.now().year + 10;
-  return year >= minYear && year <= maxYear;
+  return isHistoryYearInBounds(year, HISTORY_YEAR_BOUNDS);
 }
 
 function isHistoryMonthInRange(month: number) {

--- a/app/util/historyYearBounds.test.ts
+++ b/app/util/historyYearBounds.test.ts
@@ -1,0 +1,29 @@
+import { DateTime } from 'luxon';
+import { describe, expect, it } from 'vitest';
+import {
+  getHistoryNavigationYearOptions,
+  getHistoryYearMax,
+  HISTORY_YEAR_BOUNDS,
+  isHistoryYearInBounds,
+} from './historyYearBounds';
+
+const now = DateTime.fromISO('2026-06-30T12:00:00+08:00');
+
+describe('history year bounds', () => {
+  it('computes max year from the configured offset', () => {
+    expect(getHistoryYearMax(HISTORY_YEAR_BOUNDS, now)).toBe(2026);
+  });
+
+  it('checks years against the supplied bounds', () => {
+    expect(isHistoryYearInBounds(2010, HISTORY_YEAR_BOUNDS, now)).toBe(true);
+    expect(isHistoryYearInBounds(2009, HISTORY_YEAR_BOUNDS, now)).toBe(false);
+    expect(isHistoryYearInBounds(2027, HISTORY_YEAR_BOUNDS, now)).toBe(false);
+  });
+
+  it('builds navigation years from newest to oldest', () => {
+    expect(getHistoryNavigationYearOptions(now)).toEqual([
+      2026, 2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015,
+      2014, 2013, 2012, 2011, 2010,
+    ]);
+  });
+});

--- a/app/util/historyYearBounds.test.ts
+++ b/app/util/historyYearBounds.test.ts
@@ -14,6 +14,17 @@ describe('history year bounds', () => {
     expect(getHistoryYearMax(HISTORY_YEAR_BOUNDS, now)).toBe(2026);
   });
 
+  it('uses Singapore time for the current-year boundary', () => {
+    const utcNewYearWindow = DateTime.fromISO('2026-12-31T16:30:00Z', {
+      zone: 'utc',
+    });
+
+    expect(getHistoryYearMax(HISTORY_YEAR_BOUNDS, utcNewYearWindow)).toBe(2027);
+    expect(
+      isHistoryYearInBounds(2027, HISTORY_YEAR_BOUNDS, utcNewYearWindow),
+    ).toBe(true);
+  });
+
   it('checks years against the supplied bounds', () => {
     expect(isHistoryYearInBounds(2010, HISTORY_YEAR_BOUNDS, now)).toBe(true);
     expect(isHistoryYearInBounds(2009, HISTORY_YEAR_BOUNDS, now)).toBe(false);

--- a/app/util/historyYearBounds.ts
+++ b/app/util/historyYearBounds.ts
@@ -1,0 +1,39 @@
+import { DateTime } from 'luxon';
+
+type HistoryYearBounds = {
+  minYear: number;
+  maxYearOffset: number;
+};
+
+export const HISTORY_YEAR_BOUNDS = {
+  minYear: 2010,
+  maxYearOffset: 0,
+} as const satisfies HistoryYearBounds;
+
+export function getHistoryYearMax(
+  bounds: HistoryYearBounds,
+  now: DateTime = DateTime.now(),
+) {
+  return now.year + bounds.maxYearOffset;
+}
+
+export function isHistoryYearInBounds(
+  year: number,
+  bounds: HistoryYearBounds,
+  now: DateTime = DateTime.now(),
+) {
+  return year >= bounds.minYear && year <= getHistoryYearMax(bounds, now);
+}
+
+export function getHistoryNavigationYearOptions(
+  now: DateTime = DateTime.now(),
+) {
+  const years = [];
+  const maxYear = getHistoryYearMax(HISTORY_YEAR_BOUNDS, now);
+
+  for (let year = maxYear; year >= HISTORY_YEAR_BOUNDS.minYear; year--) {
+    years.push(year);
+  }
+
+  return years;
+}

--- a/app/util/historyYearBounds.ts
+++ b/app/util/historyYearBounds.ts
@@ -5,6 +5,8 @@ type HistoryYearBounds = {
   maxYearOffset: number;
 };
 
+export const HISTORY_TIME_ZONE = 'Asia/Singapore';
+
 export const HISTORY_YEAR_BOUNDS = {
   minYear: 2010,
   maxYearOffset: 0,
@@ -12,21 +14,21 @@ export const HISTORY_YEAR_BOUNDS = {
 
 export function getHistoryYearMax(
   bounds: HistoryYearBounds,
-  now: DateTime = DateTime.now(),
+  now: DateTime = DateTime.now().setZone(HISTORY_TIME_ZONE),
 ) {
-  return now.year + bounds.maxYearOffset;
+  return now.setZone(HISTORY_TIME_ZONE).year + bounds.maxYearOffset;
 }
 
 export function isHistoryYearInBounds(
   year: number,
   bounds: HistoryYearBounds,
-  now: DateTime = DateTime.now(),
+  now: DateTime = DateTime.now().setZone(HISTORY_TIME_ZONE),
 ) {
   return year >= bounds.minYear && year <= getHistoryYearMax(bounds, now);
 }
 
 export function getHistoryNavigationYearOptions(
-  now: DateTime = DateTime.now(),
+  now: DateTime = DateTime.now().setZone(HISTORY_TIME_ZONE),
 ) {
   const years = [];
   const maxYear = getHistoryYearMax(HISTORY_YEAR_BOUNDS, now);

--- a/app/util/sitemap.functions.test.ts
+++ b/app/util/sitemap.functions.test.ts
@@ -117,6 +117,28 @@ describe('agent Markdown discovery', () => {
     expect(paths).not.toContain('/history/2025');
   });
 
+  it('keeps history sitemap URLs within route year bounds', () => {
+    const paths = buildSitemapPaths({
+      lineIds: [],
+      stationIds: [],
+      operatorIds: [],
+      issueIds: [],
+      monthEarliest: '2009-12-01',
+      monthLatest: '2027-01-01',
+      operationalFactCoverageDates: [
+        ...buildCoverageDates('2009-12'),
+        ...buildCoverageDates('2026-12'),
+        ...buildCoverageDates('2027-01'),
+      ],
+      operationalFactCoverageStartDate: '2009-12-01',
+      currentDate: '2026-06-21',
+    });
+
+    expect(paths).not.toContain('/history/2009/12');
+    expect(paths).toContain('/history/2026/12');
+    expect(paths).not.toContain('/history/2027/01');
+  });
+
   it('keeps sitemap generation alive when history date bounds are invalid', () => {
     const paths = buildSitemapPaths({
       lineIds: ['EWL'],

--- a/app/util/sitemap.functions.ts
+++ b/app/util/sitemap.functions.ts
@@ -3,6 +3,10 @@ import type { Element, Root } from 'xast';
 import { toXml } from 'xast-util-to-xml';
 import { buildLocaleAlternates } from '~/helpers/seo';
 import { getSitemapData } from './db.queries';
+import {
+  HISTORY_YEAR_BOUNDS,
+  isHistoryYearInBounds,
+} from './historyYearBounds';
 
 interface SitemapPathData {
   lineIds: string[];
@@ -245,6 +249,16 @@ export function buildSitemapPaths({
   for (const monthInterval of interval.splitBy({ month: 1 })) {
     const monthDateTime = monthInterval.start;
     if (monthDateTime == null) {
+      continue;
+    }
+
+    if (
+      !isHistoryYearInBounds(
+        monthDateTime.year,
+        HISTORY_YEAR_BOUNDS,
+        currentDateTime,
+      )
+    ) {
       continue;
     }
 


### PR DESCRIPTION
## Summary

- Add a shared `HISTORY_YEAR_BOUNDS` helper for history routes.
- Use that single boundary for history route validation, year dropdown options, and previous/next disabled states.
- Add focused tests for the year-bound helper and update existing route-param validation tests.

## Impact

History pages now reject and stop navigating outside the same configured year range (`2010..current year`), instead of route validation and UI controls using separate limits.

## Validation

- `npm run verify`