### PR TITLE
chore: continue db query split

### DIFF
--- a/app/routes/api.issues-day.tsx
+++ b/app/routes/api.issues-day.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { DateTime } from 'luxon';
-import { getHistoryDayData } from '../util/db.queries';
+import { getHistoryDayData } from '../util/db/queries';
 
 function parseDatePart(value: string) {
   const parsed = Number(value);

--- a/app/routes/internal.api.tasks.facts.ts
+++ b/app/routes/internal.api.tasks.facts.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import {
   rebuildOperationalFactsRange,
   rebuildStatisticsSnapshot,
-} from '~/util/db.queries';
+} from '~/util/db/queries';
 import { internalMiddleware } from '~/util/internal.middleware';
 
 const RequestSchema = z.object({

--- a/app/routes/{-$lang}/lines/$lineId/components/LineSchematicCard/components/BranchItem.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/components/LineSchematicCard/components/BranchItem.tsx
@@ -1,6 +1,6 @@
 import { FormattedDate, FormattedMessage, useIntl } from 'react-intl';
 import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
-import type { LineBranch } from '~/util/db.queries';
+import type { LineBranch } from '~/util/db/queries';
 
 interface Props {
   branch: LineBranch;

--- a/app/routes/{-$lang}/lines/$lineId/components/LineSchematicCard/index.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/components/LineSchematicCard/index.tsx
@@ -6,7 +6,7 @@ import { Fragment, useMemo, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useIncludedEntities } from '~/contexts/IncludedEntities';
 import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
-import type { LineBranch } from '~/util/db.queries';
+import type { LineBranch } from '~/util/db/queries';
 import type { Line } from '~/types';
 import { BranchItem } from './components/BranchItem';
 

--- a/app/routes/{-$lang}/lines/$lineId/components/LineSystemMapCard.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/components/LineSystemMapCard.tsx
@@ -1,7 +1,7 @@
 import { DateTime } from 'luxon';
 import { FormattedMessage } from 'react-intl';
 import { StationMap } from '~/components/StationMap';
-import type { LineBranch } from '~/util/db.queries';
+import type { LineBranch } from '~/util/db/queries';
 import type { Line } from '~/types';
 
 interface Props {

--- a/app/routes/{-$lang}/lines/$lineId/components/QuickFactsCard.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/components/QuickFactsCard.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-intl';
 import { useIncludedEntities } from '~/contexts/IncludedEntities';
 import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
-import type { LineBranch } from '~/util/db.queries';
+import type { LineBranch } from '~/util/db/queries';
 import type { Line } from '~/types';
 
 interface Props {

--- a/app/routes/{-$lang}/lines/$lineId/index.tsx
+++ b/app/routes/{-$lang}/lines/$lineId/index.tsx
@@ -23,7 +23,7 @@ import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 import { buildSeoMetadata } from '~/helpers/seo';
 import type { Station } from '~/types';
 import { assert } from '~/util/assert';
-import type { LineBranch } from '~/util/db.queries';
+import type { LineBranch } from '~/util/db/queries';
 import { getLineProfileFn } from '~/util/lines.functions';
 import { CurrentStatusCard } from './components/CurrentStatusCard';
 import { LineSchematicCard } from './components/LineSchematicCard';

--- a/app/routes/{-$lang}/operators/$operatorId/components/OperatorCurrentStatusCard.tsx
+++ b/app/routes/{-$lang}/operators/$operatorId/components/OperatorCurrentStatusCard.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import { FormattedMessage } from 'react-intl';
-import type { OperatorProfile } from '~/util/db.queries';
+import type { OperatorProfile } from '~/util/db/queries';
 
 interface Props {
   currentOperationalStatus: OperatorProfile['currentOperationalStatus'];

--- a/app/routes/{-$lang}/operators/$operatorId/components/OperatorLinePerformanceCard.tsx
+++ b/app/routes/{-$lang}/operators/$operatorId/components/OperatorLinePerformanceCard.tsx
@@ -4,7 +4,7 @@ import { FormattedMessage, FormattedNumber, useIntl } from 'react-intl';
 import { LineSummaryStatusLabels } from '~/constants';
 import { useIncludedEntities } from '~/contexts/IncludedEntities';
 import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
-import type { OperatorProfile } from '~/util/db.queries';
+import type { OperatorProfile } from '~/util/db/queries';
 
 interface Props {
   linePerformanceComparison: OperatorProfile['linePerformanceComparison'];

--- a/app/routes/{-$lang}/operators/$operatorId/components/OperatorQuickFactsCard.tsx
+++ b/app/routes/{-$lang}/operators/$operatorId/components/OperatorQuickFactsCard.tsx
@@ -1,7 +1,7 @@
 import { FormattedMessage, FormattedNumber } from 'react-intl';
 import { Duration } from 'luxon';
 import { FormattedDuration } from '~/components/FormattedDuration';
-import type { OperatorProfile } from '~/util/db.queries';
+import type { OperatorProfile } from '~/util/db/queries';
 
 interface Props {
   operatorProfile: OperatorProfile;

--- a/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/DisruptionsHeatmap/index.tsx
+++ b/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/DisruptionsHeatmap/index.tsx
@@ -5,7 +5,7 @@ import type React from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { IncludedEntitiesContext } from '~/contexts/IncludedEntities';
-import type { SystemAnalytics } from '~/util/db.queries';
+import type { SystemAnalytics } from '~/util/db/queries';
 import { DayIssuesList } from './components/DayIssuesList';
 import { useDayIssues } from './hooks/useDayIssues';
 

--- a/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/LinesIssueCountCard/index.tsx
+++ b/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/LinesIssueCountCard/index.tsx
@@ -10,7 +10,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
-import type { SystemAnalytics } from '~/util/db.queries';
+import type { SystemAnalytics } from '~/util/db/queries';
 
 import { Tick } from './components/Tick';
 import { TooltipContent } from './components/TooltipContent';

--- a/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/StationsIssueCountCard/index.tsx
+++ b/app/routes/{-$lang}/statistics/components/StatisticsGrid/components/StationsIssueCountCard/index.tsx
@@ -10,7 +10,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
-import type { SystemAnalytics } from '~/util/db.queries';
+import type { SystemAnalytics } from '~/util/db/queries';
 import { Tick } from './components/Tick';
 import { TooltipContent } from './components/TooltipContent';
 

--- a/app/routes/{-$lang}/statistics/components/StatisticsGrid/index.tsx
+++ b/app/routes/{-$lang}/statistics/components/StatisticsGrid/index.tsx
@@ -1,6 +1,6 @@
 import { lazy } from 'react';
 import { DeferredViewportWidget } from '~/components/DeferredViewportWidget';
-import type { SystemAnalytics } from '~/util/db.queries';
+import type { SystemAnalytics } from '~/util/db/queries';
 import {
   BarChartCardSkeleton,
   HeatmapCardSkeleton,

--- a/app/util/agentMarkdownContent/types.ts
+++ b/app/util/agentMarkdownContent/types.ts
@@ -4,7 +4,7 @@ import type {
   getOperatorProfileData,
   getOverviewData,
   getStationProfileData,
-} from '../db.queries';
+} from '../db/queries';
 
 export const DEFAULT_ROOT_URL = 'https://www.mrtdown.org';
 

--- a/app/util/db/queries/root.test.ts
+++ b/app/util/db/queries/root.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import { linesTable, metadataTable, operatorsTable } from '~/db/schema';
+import {
+  getRootDataFromDb,
+  ROOT_LAST_UPDATED_METADATA_KEY,
+  type RootDataDb,
+} from './root';
+
+type QueryCall = {
+  selectionKeys: string[];
+  table: unknown;
+  whereCalls: number;
+  orderByCalls: number;
+};
+
+function createDbStub(rowsByTable: Map<unknown, unknown[]>) {
+  const calls: QueryCall[] = [];
+  const select = vi.fn((selection: Record<string, unknown>) => {
+    const call: QueryCall = {
+      selectionKeys: Object.keys(selection),
+      table: undefined,
+      whereCalls: 0,
+      orderByCalls: 0,
+    };
+    calls.push(call);
+
+    const builder = {
+      from: vi.fn(),
+      where: vi.fn(),
+      orderBy: vi.fn(),
+    };
+
+    builder.from.mockImplementation((table: unknown) => {
+      call.table = table;
+      return builder;
+    });
+    builder.where.mockImplementation(() => {
+      call.whereCalls += 1;
+      return builder;
+    });
+    builder.orderBy.mockImplementation(() => {
+      call.orderByCalls += 1;
+      return Promise.resolve(rowsByTable.get(call.table) ?? []);
+    });
+
+    return builder;
+  });
+
+  return {
+    calls,
+    db: { select } as unknown as RootDataDb,
+    select,
+  };
+}
+
+describe('getRootDataFromDb', () => {
+  it('fetches only the compact root navigation data shape', async () => {
+    const lineRows = [
+      {
+        id: 'BPLRT',
+        name: { 'en-SG': 'Bukit Panjang LRT' },
+        color: '#748274',
+      },
+    ];
+    const metadataRows = [
+      {
+        key: ROOT_LAST_UPDATED_METADATA_KEY,
+        value: '2026-07-01T00:00:00+08:00',
+      },
+    ];
+    const operatorRows = [{ id: 'SMRT', name: 'SMRT' }];
+    const { calls, db, select } = createDbStub(
+      new Map<unknown, unknown[]>([
+        [linesTable, lineRows],
+        [metadataTable, metadataRows],
+        [operatorsTable, operatorRows],
+      ]),
+    );
+
+    await expect(getRootDataFromDb(db)).resolves.toEqual({
+      lineNavItems: lineRows,
+      metadata: metadataRows,
+      operatorNavItems: operatorRows,
+    });
+
+    expect(select).toHaveBeenCalledTimes(3);
+    expect(calls).toEqual([
+      {
+        selectionKeys: ['id', 'name', 'color'],
+        table: linesTable,
+        whereCalls: 0,
+        orderByCalls: 1,
+      },
+      {
+        selectionKeys: ['key', 'value'],
+        table: metadataTable,
+        whereCalls: 1,
+        orderByCalls: 1,
+      },
+      {
+        selectionKeys: ['id', 'name'],
+        table: operatorsTable,
+        whereCalls: 0,
+        orderByCalls: 1,
+      },
+    ]);
+  });
+});

--- a/app/util/db/queries/root.ts
+++ b/app/util/db/queries/root.ts
@@ -1,8 +1,11 @@
 import { asc, eq } from 'drizzle-orm';
+import type { AppDb } from '~/db';
 import { linesTable, metadataTable, operatorsTable } from '~/db/schema';
 import { timeServerSpan } from '~/util/serverTiming';
 
-const ROOT_LAST_UPDATED_METADATA_KEY = 'manifest_last_pulled_at';
+export const ROOT_LAST_UPDATED_METADATA_KEY = 'manifest_last_pulled_at';
+
+export type RootDataDb = Pick<AppDb, 'select'>;
 
 async function getDefaultDb() {
   const { getDb } = await import('~/db');
@@ -12,46 +15,50 @@ async function getDefaultDb() {
 export async function getRootData() {
   return timeServerSpan('root_data', async () => {
     const db = await getDefaultDb();
-    const [lineRows, metadataRows, operatorRows] = await timeServerSpan(
-      'root_nav_queries',
-      () =>
-        Promise.all([
-          timeServerSpan('root_q_lines', () =>
-            db
-              .select({
-                id: linesTable.id,
-                name: linesTable.name,
-                color: linesTable.color,
-              })
-              .from(linesTable)
-              .orderBy(asc(linesTable.id)),
-          ),
-          timeServerSpan('root_q_metadata', () =>
-            db
-              .select({
-                key: metadataTable.key,
-                value: metadataTable.value,
-              })
-              .from(metadataTable)
-              .where(eq(metadataTable.key, ROOT_LAST_UPDATED_METADATA_KEY))
-              .orderBy(asc(metadataTable.key)),
-          ),
-          timeServerSpan('root_q_operators', () =>
-            db
-              .select({
-                id: operatorsTable.id,
-                name: operatorsTable.name,
-              })
-              .from(operatorsTable)
-              .orderBy(asc(operatorsTable.id)),
-          ),
-        ]),
-    );
-
-    return {
-      lineNavItems: lineRows,
-      metadata: metadataRows,
-      operatorNavItems: operatorRows,
-    };
+    return getRootDataFromDb(db);
   });
+}
+
+export async function getRootDataFromDb(db: RootDataDb) {
+  const [lineRows, metadataRows, operatorRows] = await timeServerSpan(
+    'root_nav_queries',
+    () =>
+      Promise.all([
+        timeServerSpan('root_q_lines', () =>
+          db
+            .select({
+              id: linesTable.id,
+              name: linesTable.name,
+              color: linesTable.color,
+            })
+            .from(linesTable)
+            .orderBy(asc(linesTable.id)),
+        ),
+        timeServerSpan('root_q_metadata', () =>
+          db
+            .select({
+              key: metadataTable.key,
+              value: metadataTable.value,
+            })
+            .from(metadataTable)
+            .where(eq(metadataTable.key, ROOT_LAST_UPDATED_METADATA_KEY))
+            .orderBy(asc(metadataTable.key)),
+        ),
+        timeServerSpan('root_q_operators', () =>
+          db
+            .select({
+              id: operatorsTable.id,
+              name: operatorsTable.name,
+            })
+            .from(operatorsTable)
+            .orderBy(asc(operatorsTable.id)),
+        ),
+      ]),
+  );
+
+  return {
+    lineNavItems: lineRows,
+    metadata: metadataRows,
+    operatorNavItems: operatorRows,
+  };
 }

--- a/app/util/history.functions.ts
+++ b/app/util/history.functions.ts
@@ -3,7 +3,7 @@ import z from 'zod';
 import {
   getHistoryYearMonthData,
   getHistoryYearSummaryData,
-} from './db.queries';
+} from './db/queries';
 import {
   HISTORY_YEAR_BOUNDS,
   isHistoryYearInBounds,

--- a/app/util/issue.functions.ts
+++ b/app/util/issue.functions.ts
@@ -1,6 +1,6 @@
 import { createServerFn } from '@tanstack/react-start';
 import { z } from 'zod';
-import { getIssueData } from './db.queries';
+import { getIssueData } from './db/queries';
 
 const InputSchema = z.object({
   issueId: z.string(),

--- a/app/util/lines.functions.ts
+++ b/app/util/lines.functions.ts
@@ -5,7 +5,7 @@ import {
   type CrowdReportFeatureEnv,
   isCrowdReportsFeatureEnabled,
 } from './crowdReportFeatureFlag';
-import { getLineProfileData } from './db.queries';
+import { getLineProfileData } from './db/queries';
 
 const InputSchema = z.object({
   lineId: z.string(),

--- a/app/util/operator.functions.ts
+++ b/app/util/operator.functions.ts
@@ -1,6 +1,6 @@
 import { createServerFn } from '@tanstack/react-start';
 import { z } from 'zod';
-import { getOperatorProfileData } from './db.queries';
+import { getOperatorProfileData } from './db/queries';
 
 const InputSchema = z.object({
   operatorId: z.string(),

--- a/app/util/overview.functions.ts
+++ b/app/util/overview.functions.ts
@@ -6,7 +6,7 @@ import {
   type CrowdReportFeatureEnv,
   isCrowdReportsFeatureEnabled,
 } from './crowdReportFeatureFlag';
-import { getOverviewData } from './db.queries';
+import { getOverviewData } from './db/queries';
 import { timeServerSpan } from './serverTiming';
 
 const RequestSchema = z.object({

--- a/app/util/sitemap.functions.test.ts
+++ b/app/util/sitemap.functions.test.ts
@@ -8,7 +8,7 @@ vi.mock('@tanstack/react-start', () => ({
   }),
 }));
 
-vi.mock('./db.queries', () => ({
+vi.mock('./db/queries', () => ({
   getSitemapData: vi.fn(),
 }));
 

--- a/app/util/sitemap.functions.ts
+++ b/app/util/sitemap.functions.ts
@@ -2,7 +2,7 @@ import { DateTime, Interval } from 'luxon';
 import type { Element, Root } from 'xast';
 import { toXml } from 'xast-util-to-xml';
 import { buildLocaleAlternates } from '~/helpers/seo';
-import { getSitemapData } from './db.queries';
+import { getSitemapData } from './db/queries';
 import {
   HISTORY_YEAR_BOUNDS,
   isHistoryYearInBounds,

--- a/app/util/station.functions.ts
+++ b/app/util/station.functions.ts
@@ -5,7 +5,7 @@ import {
   type CrowdReportFeatureEnv,
   isCrowdReportsFeatureEnabled,
 } from './crowdReportFeatureFlag';
-import { getStationProfileData } from './db.queries';
+import { getStationProfileData } from './db/queries';
 
 const InputSchema = z.object({
   stationId: z.string(),

--- a/app/util/statistics.functions.ts
+++ b/app/util/statistics.functions.ts
@@ -1,5 +1,5 @@
 import { createServerFn } from '@tanstack/react-start';
-import { getStatisticsData } from './db.queries';
+import { getStatisticsData } from './db/queries';
 import { timeServerSpan } from './serverTiming';
 
 export const getStatisticsFn = createServerFn({ method: 'GET' }).handler(() =>

--- a/app/util/system-map.functions.ts
+++ b/app/util/system-map.functions.ts
@@ -1,5 +1,5 @@
 import { createServerFn } from '@tanstack/react-start';
-import { getSystemMapData } from './db.queries';
+import { getSystemMapData } from './db/queries';
 
 export const getSystemMapFn = createServerFn({ method: 'GET' }).handler(() =>
   getSystemMapData(),

--- a/app/workflows/publicHolidays/index.ts
+++ b/app/workflows/publicHolidays/index.ts
@@ -5,7 +5,7 @@ import {
 } from 'cloudflare:workers';
 import * as Sentry from '@sentry/cloudflare';
 import { getDb } from '~/db/index.js';
-import { rebuildOperationalFactsForDates } from '~/util/db.queries.js';
+import { rebuildOperationalFactsForDates } from '~/util/db/queries/index.js';
 import {
   clearPendingPublicHolidayRebuildDates,
   syncPublicHolidaysFromDataGov,

--- a/app/workflows/pull/index.ts
+++ b/app/workflows/pull/index.ts
@@ -9,7 +9,7 @@ import { ZipStore } from '~/helpers/ZipStore.js';
 import {
   rebuildOperationalFactsRange,
   rebuildStatisticsSnapshot,
-} from '~/util/db.queries.js';
+} from '~/util/db/queries/index.js';
 import { getDb } from '../../db/index.js';
 import { fetchArchive } from './helpers/fetchArchive.js';
 import { fetchManifest } from './helpers/fetchManifest.js';

--- a/docs/plans/active/read-query-decomposition.md
+++ b/docs/plans/active/read-query-decomposition.md
@@ -338,6 +338,12 @@ done
   `app/util/db/queries/root.ts` and changing the root metadata read to fetch
   only `manifest_last_pulled_at`, which is the only metadata key currently used
   by the root layout.
+- 2026-07-01: Continued Phase 1/2 by moving production callers from the
+  temporary `app/util/db.queries.ts` compatibility barrel to
+  `~/util/db/queries`, keeping only compatibility tests and the barrel itself on
+  the old path. Added `getRootDataFromDb` and a focused
+  `app/util/db/queries/root.test.ts` guard for the compact root navigation query
+  shape.
 - 2026-06-30: Drafted plan after identifying `buildDataset` as the broad base
   dataset assembly path and confirming this container cannot reach the preview
   deployment because the outbound proxy returns `403 Forbidden`.


### PR DESCRIPTION
## Summary

- Move production imports from the temporary `app/util/db.queries.ts` compatibility barrel to the canonical `~/util/db/queries` package.
- Add an injectable `getRootDataFromDb` seam for root navigation reads while preserving the existing `getRootData` entry point and timing spans.
- Add focused root query coverage for the compact navigation data shape and update the read-query decomposition plan log.

## Impact

This keeps the DB query split moving without changing route behavior. Production callers now depend on the new query package path, while the old barrel remains covered by its compatibility test until the legacy surface is removed later.

## Validation

- `npm run test:run -- app/util/db/queries/root.test.ts app/util/db.queries.test.ts app/util/sitemap.functions.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run verify` passed after rerunning with escalation because sandboxed `tsx` could not create its IPC pipe during `db:generate:check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multiple data-loading and workflow references so API routes, pages, and background jobs continue resolving shared data correctly.
  * Added a dedicated root data query path with the same output, improving reliability without changing what users see.

* **Tests**
  * Added coverage for root navigation data fetching to help prevent regressions.

* **Documentation**
  * Updated the development plan to reflect the latest migration progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->