### PR TITLE
feat: add programmatic crowd reports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,10 @@ CROWD_REPORT_DISPATCH_GITHUB_REPO=mrtdown-data
 CROWD_REPORT_DISPATCH_GITHUB_EVENT_TYPE=ingest
 CROWD_REPORT_DISPATCH_LIMIT=10
 
+# JSON map of authenticated crowd-report producers. Keep this credential set
+# separate from INTERNAL_API_TOKENS so each producer can be rotated or revoked.
+CROWD_REPORT_PRODUCERS={"reddit-monitor":{"token":"replace-with-at-least-16-characters","sourceOrigins":["https://www.reddit.com"]}}
+
 MRTDOWN_DATA_URL=https://data.mrtdown.org/mrtdown-data
 
 # Bearer token auth for internal APIs

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -38,6 +38,7 @@ import {
   primaryKey,
   text,
   timestamp,
+  uniqueIndex,
 } from 'drizzle-orm/pg-core';
 import { enumToPgEnum, timestampColumns } from './columns.helpers.js';
 
@@ -279,6 +280,10 @@ export const crowdReportsTable = pgTable(
     }),
     dispatch_payload: jsonb('dispatch_payload').$type<unknown>(),
     dispatch_error: text('dispatch_error'),
+    producer: text('producer').notNull().default('public'),
+    external_report_id: text('external_report_id'),
+    source_url: text('source_url'),
+    request_payload_digest: text('request_payload_digest'),
     ...timestampColumns,
   },
   (table) => {
@@ -290,6 +295,10 @@ export const crowdReportsTable = pgTable(
       index('crowd_reports_status_idx').on(table.status),
       index('crowd_reports_cluster_id_idx').on(table.cluster_id),
       index('crowd_reports_duplicate_of_id_idx').on(table.duplicate_of_id),
+      uniqueIndex('crowd_reports_producer_external_report_id_uidx').on(
+        table.producer,
+        table.external_report_id,
+      ),
       check(
         'crowd_reports_delay_minutes_check',
         sql`${table.delay_minutes} is null or (${table.delay_minutes} >= 0 and ${table.delay_minutes} <= 180)`,

--- a/app/routeTree.gen.ts
+++ b/app/routeTree.gen.ts
@@ -30,6 +30,7 @@ import { Route as StationsStationIdIndexDotmdRouteImport } from './routes/statio
 import { Route as OperatorsOperatorIdIndexDotmdRouteImport } from './routes/operators/$operatorId/index[.]md'
 import { Route as LinesLineIdIndexDotmdRouteImport } from './routes/lines/$lineId/index[.]md'
 import { Route as IssuesIssueIdIndexDotmdRouteImport } from './routes/issues/$issueId/index[.]md'
+import { Route as InternalApiCrowdReportsRouteImport } from './routes/internal.api.crowd-reports'
 import { Route as ApiPhSplatRouteImport } from './routes/api.ph.$'
 import { Route as Char123LangChar125TownsTownIdIndexRouteImport } from './routes/{-$lang}/towns/$townId/index'
 import { Route as Char123LangChar125StatusLineIdIndexRouteImport } from './routes/{-$lang}/status/$lineId/index'
@@ -163,6 +164,11 @@ const IssuesIssueIdIndexDotmdRoute = IssuesIssueIdIndexDotmdRouteImport.update({
   path: '/issues/$issueId/index.md',
   getParentRoute: () => rootRouteImport,
 } as any)
+const InternalApiCrowdReportsRoute = InternalApiCrowdReportsRouteImport.update({
+  id: '/internal/api/crowd-reports',
+  path: '/internal/api/crowd-reports',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiPhSplatRoute = ApiPhSplatRouteImport.update({
   id: '/api/ph/$',
   path: '/api/ph/$',
@@ -268,6 +274,7 @@ export interface FileRoutesByFullPath {
   '/{-$lang}/sitemap.xml': typeof Char123LangChar125SitemapDotxmlRoute
   '/{-$lang}/': typeof Char123LangChar125IndexRoute
   '/api/ph/$': typeof ApiPhSplatRoute
+  '/internal/api/crowd-reports': typeof InternalApiCrowdReportsRoute
   '/issues/$issueId/index.md': typeof IssuesIssueIdIndexDotmdRoute
   '/lines/$lineId/index.md': typeof LinesLineIdIndexDotmdRoute
   '/operators/$operatorId/index.md': typeof OperatorsOperatorIdIndexDotmdRoute
@@ -306,6 +313,7 @@ export interface FileRoutesByTo {
   '/{-$lang}/sitemap.xml': typeof Char123LangChar125SitemapDotxmlRoute
   '/{-$lang}': typeof Char123LangChar125IndexRoute
   '/api/ph/$': typeof ApiPhSplatRoute
+  '/internal/api/crowd-reports': typeof InternalApiCrowdReportsRoute
   '/issues/$issueId/index.md': typeof IssuesIssueIdIndexDotmdRoute
   '/lines/$lineId/index.md': typeof LinesLineIdIndexDotmdRoute
   '/operators/$operatorId/index.md': typeof OperatorsOperatorIdIndexDotmdRoute
@@ -346,6 +354,7 @@ export interface FileRoutesById {
   '/{-$lang}/sitemap.xml': typeof Char123LangChar125SitemapDotxmlRoute
   '/{-$lang}/': typeof Char123LangChar125IndexRoute
   '/api/ph/$': typeof ApiPhSplatRoute
+  '/internal/api/crowd-reports': typeof InternalApiCrowdReportsRoute
   '/issues/$issueId/index.md': typeof IssuesIssueIdIndexDotmdRoute
   '/lines/$lineId/index.md': typeof LinesLineIdIndexDotmdRoute
   '/operators/$operatorId/index.md': typeof OperatorsOperatorIdIndexDotmdRoute
@@ -387,6 +396,7 @@ export interface FileRouteTypes {
     | '/{-$lang}/sitemap.xml'
     | '/{-$lang}/'
     | '/api/ph/$'
+    | '/internal/api/crowd-reports'
     | '/issues/$issueId/index.md'
     | '/lines/$lineId/index.md'
     | '/operators/$operatorId/index.md'
@@ -425,6 +435,7 @@ export interface FileRouteTypes {
     | '/{-$lang}/sitemap.xml'
     | '/{-$lang}'
     | '/api/ph/$'
+    | '/internal/api/crowd-reports'
     | '/issues/$issueId/index.md'
     | '/lines/$lineId/index.md'
     | '/operators/$operatorId/index.md'
@@ -464,6 +475,7 @@ export interface FileRouteTypes {
     | '/{-$lang}/sitemap.xml'
     | '/{-$lang}/'
     | '/api/ph/$'
+    | '/internal/api/crowd-reports'
     | '/issues/$issueId/index.md'
     | '/lines/$lineId/index.md'
     | '/operators/$operatorId/index.md'
@@ -502,6 +514,7 @@ export interface RootRouteChildren {
   ApiReportsRoute: typeof ApiReportsRoute
   ApiSentryAnonymousUserRoute: typeof ApiSentryAnonymousUserRoute
   ApiPhSplatRoute: typeof ApiPhSplatRoute
+  InternalApiCrowdReportsRoute: typeof InternalApiCrowdReportsRoute
   IssuesIssueIdIndexDotmdRoute: typeof IssuesIssueIdIndexDotmdRoute
   LinesLineIdIndexDotmdRoute: typeof LinesLineIdIndexDotmdRoute
   OperatorsOperatorIdIndexDotmdRoute: typeof OperatorsOperatorIdIndexDotmdRoute
@@ -660,6 +673,13 @@ declare module '@tanstack/react-router' {
       path: '/issues/$issueId/index.md'
       fullPath: '/issues/$issueId/index.md'
       preLoaderRoute: typeof IssuesIssueIdIndexDotmdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/internal/api/crowd-reports': {
+      id: '/internal/api/crowd-reports'
+      path: '/internal/api/crowd-reports'
+      fullPath: '/internal/api/crowd-reports'
+      preLoaderRoute: typeof InternalApiCrowdReportsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/ph/$': {
@@ -850,6 +870,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiReportsRoute: ApiReportsRoute,
   ApiSentryAnonymousUserRoute: ApiSentryAnonymousUserRoute,
   ApiPhSplatRoute: ApiPhSplatRoute,
+  InternalApiCrowdReportsRoute: InternalApiCrowdReportsRoute,
   IssuesIssueIdIndexDotmdRoute: IssuesIssueIdIndexDotmdRoute,
   LinesLineIdIndexDotmdRoute: LinesLineIdIndexDotmdRoute,
   OperatorsOperatorIdIndexDotmdRoute: OperatorsOperatorIdIndexDotmdRoute,

--- a/app/routes/internal.api.crowd-reports.test.ts
+++ b/app/routes/internal.api.crowd-reports.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CrowdReportIdempotencyConflictError } from '~/util/crowdReports';
+import { handleProgrammaticCrowdReportPost } from './internal.api.crowd-reports';
+
+const ENVIRONMENT = {
+  CROWD_REPORT_PRODUCERS: JSON.stringify({
+    'reddit-monitor': {
+      token: 'reddit-monitor-secret',
+      sourceOrigins: ['https://www.reddit.com'],
+    },
+  }),
+};
+
+const VALID_BODY = {
+  externalReportId: 'opaque-post-id',
+  sourceUrl: 'https://www.reddit.com/r/singapore/comments/example',
+  report: {
+    reportScope: 'line',
+    lineIds: ['CCL'],
+    stationIds: [],
+    effect: 'delay',
+    delayMinutes: 10,
+    isStillHappening: true,
+  },
+};
+
+function makeRequest(body: unknown, token = 'reddit-monitor-secret') {
+  return new Request('https://example.com/internal/api/crowd-reports', {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+    },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+function makeDependencies() {
+  const db = {};
+  return {
+    db,
+    getDb: vi.fn(() => db),
+    purgePublicDataCache: vi.fn().mockResolvedValue({ status: 'purged' }),
+    triggerCrowdReportDispatchAfterSubmission: vi.fn(),
+    findMissingCrowdReportReferences: vi.fn().mockResolvedValue({
+      lineIds: [],
+      stationIds: [],
+      directionStationIds: [],
+    }),
+    findProgrammaticCrowdReportRetry: vi.fn().mockResolvedValue(undefined),
+    persistAutomoderatedProgrammaticCrowdReport: vi.fn().mockResolvedValue({
+      id: 'report-1',
+      status: 'accepted',
+      duplicateOfId: null,
+      created: true,
+    }),
+  };
+}
+
+describe('POST /internal/api/crowd-reports', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects invalid authentication before parsing or accessing the database', async () => {
+    const dependencies = makeDependencies();
+    const response = await handleProgrammaticCrowdReportPost(
+      makeRequest('{invalid-json', 'wrong-secret-value'),
+      ENVIRONMENT,
+      dependencies as never,
+    );
+
+    expect(response.status).toBe(401);
+    expect(dependencies.getDb).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: 'Unauthorized',
+    });
+  });
+
+  it('rejects malformed reports and missing references', async () => {
+    const malformedDependencies = makeDependencies();
+    const malformedResponse = await handleProgrammaticCrowdReportPost(
+      makeRequest({ ...VALID_BODY, report: { effect: 'delay' } }),
+      ENVIRONMENT,
+      malformedDependencies as never,
+    );
+    expect(malformedResponse.status).toBe(400);
+    expect(
+      malformedDependencies.persistAutomoderatedProgrammaticCrowdReport,
+    ).not.toHaveBeenCalled();
+
+    const missingDependencies = makeDependencies();
+    missingDependencies.findMissingCrowdReportReferences.mockResolvedValue({
+      lineIds: ['CCL'],
+      stationIds: [],
+      directionStationIds: [],
+    });
+    const missingResponse = await handleProgrammaticCrowdReportPost(
+      makeRequest(VALID_BODY),
+      ENVIRONMENT,
+      missingDependencies as never,
+    );
+    expect(missingResponse.status).toBe(400);
+    await expect(missingResponse.json()).resolves.toMatchObject({
+      error: 'Invalid affected line or station',
+      missingReferences: { lineIds: ['CCL'] },
+    });
+  });
+
+  it('creates a report and triggers dispatch and cache invalidation once', async () => {
+    const dependencies = makeDependencies();
+    const response = await handleProgrammaticCrowdReportPost(
+      makeRequest(VALID_BODY),
+      ENVIRONMENT,
+      dependencies as never,
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      data: {
+        id: 'report-1',
+        status: 'accepted',
+        duplicateOfId: null,
+        idempotentReplay: false,
+      },
+    });
+    expect(
+      dependencies.persistAutomoderatedProgrammaticCrowdReport,
+    ).toHaveBeenCalledWith(
+      dependencies.db,
+      expect.objectContaining({ lineIds: ['CCL'], effect: 'delay' }),
+      expect.objectContaining({
+        producer: 'reddit-monitor',
+        externalReportId: 'opaque-post-id',
+        sourceUrl: 'https://www.reddit.com/r/singapore/comments/example',
+        requestPayloadDigest: expect.stringMatching(/^[a-f0-9]{64}$/),
+      }),
+    );
+    expect(
+      dependencies.triggerCrowdReportDispatchAfterSubmission,
+    ).toHaveBeenCalledOnce();
+    expect(dependencies.purgePublicDataCache).toHaveBeenCalledOnce();
+  });
+
+  it('returns an idempotent retry without validation side effects', async () => {
+    const dependencies = makeDependencies();
+    dependencies.findProgrammaticCrowdReportRetry.mockResolvedValue({
+      id: 'report-1',
+      status: 'accepted',
+      duplicateOfId: null,
+      created: false,
+    });
+
+    const response = await handleProgrammaticCrowdReportPost(
+      makeRequest(VALID_BODY),
+      ENVIRONMENT,
+      dependencies as never,
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      data: { id: 'report-1', idempotentReplay: true },
+    });
+    expect(
+      dependencies.findMissingCrowdReportReferences,
+    ).not.toHaveBeenCalled();
+    expect(
+      dependencies.persistAutomoderatedProgrammaticCrowdReport,
+    ).not.toHaveBeenCalled();
+    expect(
+      dependencies.triggerCrowdReportDispatchAfterSubmission,
+    ).not.toHaveBeenCalled();
+    expect(dependencies.purgePublicDataCache).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 for a conflicting retry', async () => {
+    const dependencies = makeDependencies();
+    dependencies.findProgrammaticCrowdReportRetry.mockRejectedValue(
+      new CrowdReportIdempotencyConflictError('report-1'),
+    );
+
+    const response = await handleProgrammaticCrowdReportPost(
+      makeRequest(VALID_BODY),
+      ENVIRONMENT,
+      dependencies as never,
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: 'externalReportId was already used with a different payload',
+      reportId: 'report-1',
+    });
+  });
+
+  it('rejects source URLs outside the authenticated producer policy', async () => {
+    const dependencies = makeDependencies();
+    const response = await handleProgrammaticCrowdReportPost(
+      makeRequest({ ...VALID_BODY, sourceUrl: 'https://example.com/post' }),
+      ENVIRONMENT,
+      dependencies as never,
+    );
+
+    expect(response.status).toBe(400);
+    expect(dependencies.getDb).not.toHaveBeenCalled();
+  });
+});

--- a/app/routes/internal.api.crowd-reports.ts
+++ b/app/routes/internal.api.crowd-reports.ts
@@ -1,0 +1,220 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { getDb } from '~/db';
+import { purgePublicDataCache } from '~/util/cloudflareCache';
+import { triggerCrowdReportDispatchAfterSubmission } from '~/util/crowdReportDispatch';
+import {
+  CrowdReportIdempotencyConflictError,
+  findMissingCrowdReportReferences,
+  findProgrammaticCrowdReportRetry,
+  parseCrowdReportJsonBody,
+  persistAutomoderatedProgrammaticCrowdReport,
+  validateStructuredCrowdReportSubmission,
+} from '~/util/crowdReports';
+import {
+  authenticateCrowdReportProducer,
+  hashProgrammaticCrowdReportPayload,
+  isProgrammaticCrowdReportSourceAllowed,
+  ProgrammaticCrowdReportRequestSchema,
+} from '~/util/programmaticCrowdReports';
+
+type ProgrammaticCrowdReportEnvironment = Record<string, string | undefined> & {
+  CLOUDFLARE_CACHE_PURGE_TOKEN?: string;
+  CLOUDFLARE_ZONE_ID?: string;
+  CROWD_REPORT_PRODUCERS?: string;
+  TIER?: string;
+};
+
+const defaultDependencies = {
+  getDb,
+  purgePublicDataCache,
+  triggerCrowdReportDispatchAfterSubmission,
+  findMissingCrowdReportReferences,
+  findProgrammaticCrowdReportRetry,
+  persistAutomoderatedProgrammaticCrowdReport,
+};
+
+type ProgrammaticCrowdReportDependencies = typeof defaultDependencies;
+
+export async function handleProgrammaticCrowdReportPost(
+  request: Request,
+  environment: ProgrammaticCrowdReportEnvironment = process.env,
+  dependencies: ProgrammaticCrowdReportDependencies = defaultDependencies,
+) {
+  const authentication = await authenticateCrowdReportProducer(
+    request,
+    environment.CROWD_REPORT_PRODUCERS,
+  );
+  if (!authentication.success) {
+    return Response.json(
+      { success: false, error: authentication.error },
+      { status: authentication.status },
+    );
+  }
+
+  const parsedBody = await parseCrowdReportJsonBody(request);
+  if (!parsedBody.success) {
+    return Response.json(
+      { success: false, error: parsedBody.error },
+      { status: parsedBody.status },
+    );
+  }
+
+  const parsedRequest = ProgrammaticCrowdReportRequestSchema.safeParse(
+    parsedBody.body,
+  );
+  if (!parsedRequest.success) {
+    return Response.json(
+      {
+        success: false,
+        error: 'Invalid programmatic crowd report',
+        issues: parsedRequest.error.issues.map((issue) => issue.message),
+      },
+      { status: 400 },
+    );
+  }
+
+  if (
+    !isProgrammaticCrowdReportSourceAllowed(
+      authentication.producer,
+      parsedRequest.data.sourceUrl,
+    )
+  ) {
+    return Response.json(
+      {
+        success: false,
+        error: 'sourceUrl origin is not allowed for this producer',
+      },
+      { status: 400 },
+    );
+  }
+
+  const delivery = {
+    producer: authentication.producer.id,
+    externalReportId: parsedRequest.data.externalReportId,
+    sourceUrl: parsedRequest.data.sourceUrl,
+    requestPayloadDigest: await hashProgrammaticCrowdReportPayload(
+      parsedRequest.data,
+    ),
+  };
+  const db = dependencies.getDb();
+
+  try {
+    const retry = await dependencies.findProgrammaticCrowdReportRetry(
+      db,
+      delivery,
+    );
+    if (retry != null) {
+      return programmaticCrowdReportResponse(retry);
+    }
+  } catch (error) {
+    if (error instanceof CrowdReportIdempotencyConflictError) {
+      return idempotencyConflictResponse(error.reportId);
+    }
+    throw error;
+  }
+
+  const validation = validateStructuredCrowdReportSubmission(
+    parsedRequest.data.report,
+  );
+  if (!validation.success) {
+    return Response.json(
+      {
+        success: false,
+        error: 'Invalid report',
+        issues: validation.issues,
+      },
+      { status: 400 },
+    );
+  }
+
+  const missingReferences = await dependencies.findMissingCrowdReportReferences(
+    db,
+    validation.data,
+  );
+  if (
+    missingReferences.lineIds.length > 0 ||
+    missingReferences.stationIds.length > 0 ||
+    missingReferences.directionStationIds.length > 0
+  ) {
+    return Response.json(
+      {
+        success: false,
+        error: 'Invalid affected line or station',
+        missingReferences,
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result =
+      await dependencies.persistAutomoderatedProgrammaticCrowdReport(
+        db,
+        validation.data,
+        delivery,
+      );
+
+    if (result.created) {
+      dependencies.triggerCrowdReportDispatchAfterSubmission(db, environment);
+      try {
+        await dependencies.purgePublicDataCache({ env: environment });
+      } catch (error) {
+        console.error(
+          'Failed to purge public cache after programmatic crowd report submission',
+          { error },
+        );
+      }
+    }
+
+    return programmaticCrowdReportResponse(result);
+  } catch (error) {
+    if (error instanceof CrowdReportIdempotencyConflictError) {
+      return idempotencyConflictResponse(error.reportId);
+    }
+
+    console.error('Programmatic crowd report submission failed', { error });
+    return Response.json(
+      { success: false, error: 'Report submission failed' },
+      { status: 500 },
+    );
+  }
+}
+
+function programmaticCrowdReportResponse(result: {
+  id: string;
+  status: string;
+  duplicateOfId: string | null;
+  created: boolean;
+}) {
+  return Response.json(
+    {
+      success: true,
+      data: {
+        id: result.id,
+        status: result.status,
+        duplicateOfId: result.duplicateOfId,
+        idempotentReplay: !result.created,
+      },
+    },
+    { status: 202 },
+  );
+}
+
+function idempotencyConflictResponse(reportId: string) {
+  return Response.json(
+    {
+      success: false,
+      error: 'externalReportId was already used with a different payload',
+      reportId,
+    },
+    { status: 409 },
+  );
+}
+
+export const Route = createFileRoute('/internal/api/crowd-reports')({
+  server: {
+    handlers: {
+      POST: ({ request }) => handleProgrammaticCrowdReportPost(request),
+    },
+  },
+});

--- a/app/util/crowdReportDispatch.test.ts
+++ b/app/util/crowdReportDispatch.test.ts
@@ -41,7 +41,7 @@ function makeFakeCandidateDb() {
   };
 }
 
-function makeFakeClusterCandidateDb() {
+function makeFakeClusterCandidateDb(stillHappening = true) {
   const whereCalls: unknown[] = [];
   const selectResults = [
     [
@@ -63,7 +63,7 @@ function makeFakeClusterCandidateDb() {
         text: 'Train stalled near the platform for several minutes.',
         directionText: 'towards:BP6',
         delayMinutes: 10,
-        stillHappening: true,
+        stillHappening,
       },
     ],
   ];
@@ -393,7 +393,7 @@ describe('getDispatchableCrowdReportCandidates', () => {
     expect(whereSql).toContain('crowd_report_stations');
   });
 
-  it('builds cluster dispatch payloads from ongoing reports only', async () => {
+  it('builds cluster dispatch payloads from ongoing public reports', async () => {
     const fake = makeFakeClusterCandidateDb();
 
     await getDispatchableCrowdReportCandidates(fake.db as never, {
@@ -408,6 +408,32 @@ describe('getDispatchableCrowdReportCandidates', () => {
     ).sql;
 
     expect(reportRowsWhereSql).toContain('"still_happening" =');
+  });
+
+  it('includes authenticated producer resolution reports in dispatch', async () => {
+    const fake = makeFakeClusterCandidateDb(false);
+
+    const candidates = await getDispatchableCrowdReportCandidates(
+      fake.db as never,
+      {
+        kind: 'cluster',
+        limit: 1,
+        rootUrl: 'https://mrtdown.example',
+      },
+    );
+
+    const dialect = new PgDialect();
+    const clusterWhereSql = dialect.sqlToQuery(fake.whereCalls[0] as SQL).sql;
+    const reportRowsWhereSql = dialect.sqlToQuery(
+      fake.whereCalls[3] as SQL,
+    ).sql;
+
+    expect(clusterWhereSql).toContain('"producer" <>');
+    expect(reportRowsWhereSql).toContain('"producer" <>');
+    expect(candidates[0]?.payload.content[0]).toHaveProperty(
+      'text',
+      expect.stringContaining('no longer happening'),
+    );
   });
 
   it('marks only the report IDs included in a cluster dispatch payload', async () => {

--- a/app/util/crowdReportDispatch.ts
+++ b/app/util/crowdReportDispatch.ts
@@ -10,6 +10,7 @@ import {
   eq,
   inArray,
   isNull,
+  ne,
   notInArray,
   or,
   sql,
@@ -135,7 +136,19 @@ function hasCrowdReportScope() {
 }
 
 function hasCrowdReportClusterCurrentConfidence() {
-  return sql`${getCrowdReportClusterOngoingReportCountSql()} >= ${DEFAULT_DISPATCH_MIN_ONGOING_REPORTS} and ${getCrowdReportClusterOngoingDistinctIpHashCountSql()} >= ${DEFAULT_DISPATCH_MIN_DISTINCT_IP_HASHES}`;
+  return sql`(
+    (
+      ${getCrowdReportClusterOngoingReportCountSql()} >= ${DEFAULT_DISPATCH_MIN_ONGOING_REPORTS}
+      and ${getCrowdReportClusterOngoingDistinctIpHashCountSql()} >= ${DEFAULT_DISPATCH_MIN_DISTINCT_IP_HASHES}
+    )
+    or exists (
+      select 1
+      from ${crowdReportsTable}
+      where ${crowdReportsTable.cluster_id} = ${crowdReportClustersTable.id}
+        and ${crowdReportsTable.status} in ('accepted', 'duplicate')
+        and ${crowdReportsTable.producer} <> 'public'
+    )
+  )`;
 }
 
 function getCrowdReportClusterOngoingReportCountSql() {
@@ -157,6 +170,19 @@ function getCrowdReportClusterOngoingDistinctIpHashCountSql() {
     where ${crowdReportsTable.cluster_id} = ${crowdReportClustersTable.id}
       and ${crowdReportsTable.status} in ('accepted', 'duplicate')
       and ${crowdReportsTable.still_happening} is true
+  )`;
+}
+
+function getCrowdReportClusterDispatchReportCountSql() {
+  return sql<number>`(
+    select count(*)::int
+    from ${crowdReportsTable}
+    where ${crowdReportsTable.cluster_id} = ${crowdReportClustersTable.id}
+      and ${crowdReportsTable.status} in ('accepted', 'duplicate')
+      and (
+        ${crowdReportsTable.still_happening} is true
+        or ${crowdReportsTable.producer} <> 'public'
+      )
   )`;
 }
 
@@ -283,7 +309,7 @@ async function getDispatchableCrowdReportClusterCandidates(
     .select({
       id: crowdReportClustersTable.id,
       effect: crowdReportClustersTable.effect,
-      reportCount: getCrowdReportClusterOngoingReportCountSql(),
+      reportCount: getCrowdReportClusterDispatchReportCountSql(),
       windowEndAt: crowdReportClustersTable.window_end_at,
       updatedAt: crowdReportClustersTable.updated_at,
     })
@@ -333,7 +359,10 @@ async function getDispatchableCrowdReportClusterCandidates(
         and(
           inArray(crowdReportsTable.cluster_id, clusterIds),
           inArray(crowdReportsTable.status, ['accepted', 'duplicate']),
-          eq(crowdReportsTable.still_happening, true),
+          or(
+            eq(crowdReportsTable.still_happening, true),
+            ne(crowdReportsTable.producer, 'public'),
+          ),
         ),
       )
       .orderBy(desc(crowdReportsTable.observed_at)),
@@ -614,7 +643,10 @@ function hasNoOngoingClusterReportsOutsideDispatchPayload(
     from ${crowdReportsTable}
     where ${crowdReportsTable.cluster_id} = ${candidate.id}
       and ${crowdReportsTable.status} in ('accepted', 'duplicate')
-      and ${crowdReportsTable.still_happening} is true
+      and (
+        ${crowdReportsTable.still_happening} is true
+        or ${crowdReportsTable.producer} <> 'public'
+      )
       and ${notInArray(crowdReportsTable.id, candidate.reportIds)}
   )`;
 }
@@ -631,7 +663,10 @@ function hasAllClusterDispatchPayloadReportsCurrent(
     from ${crowdReportsTable}
     where ${crowdReportsTable.cluster_id} = ${candidate.id}
       and ${crowdReportsTable.status} in ('accepted', 'duplicate')
-      and ${crowdReportsTable.still_happening} is true
+      and (
+        ${crowdReportsTable.still_happening} is true
+        or ${crowdReportsTable.producer} <> 'public'
+      )
       and ${inArray(crowdReportsTable.id, candidate.reportIds)}
   ) = ${candidate.reportIds.length}`;
 }
@@ -795,7 +830,7 @@ export async function dispatchPendingCrowdReports(
 }
 
 /**
- * Starts an immediate dispatch attempt after a public submission commits.
+ * Starts an immediate dispatch attempt after a crowd-report submission commits.
  * Accepted rows remain the durable source of truth, so the scheduled dispatcher
  * can retry if this best-effort attempt fails or the process exits early.
  */

--- a/app/util/crowdReportSource.functions.test.ts
+++ b/app/util/crowdReportSource.functions.test.ts
@@ -16,7 +16,27 @@ function name(value: string) {
   };
 }
 
-function makeFakeClusterSourceDb() {
+function makeFakeClusterSourceDb(
+  reportRows: Array<{
+    observedAt: string;
+    directionText: string | null;
+    delayMinutes: number | null;
+    stillHappening: boolean;
+  }> = [
+    {
+      observedAt: '2026-05-24T04:30:00.000Z',
+      directionText: 'towards:BP6',
+      delayMinutes: 10,
+      stillHappening: true,
+    },
+    {
+      observedAt: '2026-05-24T04:40:00.000Z',
+      directionText: null,
+      delayMinutes: null,
+      stillHappening: true,
+    },
+  ],
+) {
   const whereCalls: unknown[] = [];
   const selectResults = [
     [
@@ -32,20 +52,7 @@ function makeFakeClusterSourceDb() {
     ],
     [{ id: 'BPLRT', name: name('Bukit Panjang LRT'), color: '#718472' }],
     [{ id: 'BP6', name: name('Bukit Panjang') }],
-    [
-      {
-        observedAt: '2026-05-24T04:30:00.000Z',
-        directionText: 'towards:BP6',
-        delayMinutes: 10,
-        stillHappening: true,
-      },
-      {
-        observedAt: '2026-05-24T04:40:00.000Z',
-        directionText: null,
-        delayMinutes: null,
-        stillHappening: true,
-      },
-    ],
+    reportRows,
   ];
   let selectCount = 0;
 
@@ -129,7 +136,7 @@ function makeFakeReportSourceDb(
 }
 
 describe('getCrowdReportSource', () => {
-  it('builds cluster evidence from ongoing reports only', async () => {
+  it('builds cluster evidence from ongoing public reports', async () => {
     const fake = makeFakeClusterSourceDb();
 
     const source = await getCrowdReportSource(fake.db as never, {
@@ -150,6 +157,32 @@ describe('getCrowdReportSource', () => {
     const reportWhereSql = dialect.sqlToQuery(fake.whereCalls[3] as SQL).sql;
 
     expect(reportWhereSql).toContain('"crowd_reports"."still_happening" =');
+    expect(reportWhereSql).toContain('"crowd_reports"."producer" <>');
+  });
+
+  it('keeps recovery-only authenticated cluster sources resolvable', async () => {
+    const fake = makeFakeClusterSourceDb([
+      {
+        observedAt: '2026-05-24T04:50:00.000Z',
+        directionText: null,
+        delayMinutes: 0,
+        stillHappening: false,
+      },
+    ]);
+
+    const source = await getCrowdReportSource(fake.db as never, {
+      kind: 'cluster',
+      sourceId: 'cluster-1',
+    });
+
+    expect(source).toMatchObject({
+      kind: 'cluster',
+      id: 'cluster-1',
+      reportCount: 1,
+      observedStartAt: '2026-05-24T04:50:00.000Z',
+      observedEndAt: '2026-05-24T04:50:00.000Z',
+      stillHappening: false,
+    });
   });
 
   it('builds single-report evidence for accepted unclustered reports with scope', async () => {

--- a/app/util/crowdReportSource.functions.ts
+++ b/app/util/crowdReportSource.functions.ts
@@ -1,6 +1,6 @@
 import type { Translations } from '@mrtdown/core';
 import { createServerFn } from '@tanstack/react-start';
-import { and, asc, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, isNull, ne, or, sql } from 'drizzle-orm';
 import { z } from 'zod';
 import { getDb } from '~/db';
 import {
@@ -149,7 +149,10 @@ async function getClusterSource(
             'duplicate',
             'dispatched',
           ]),
-          eq(crowdReportsTable.still_happening, true),
+          or(
+            eq(crowdReportsTable.still_happening, true),
+            ne(crowdReportsTable.producer, 'public'),
+          ),
         ),
       )
       .orderBy(desc(crowdReportsTable.observed_at)),

--- a/app/util/crowdReports.ts
+++ b/app/util/crowdReports.ts
@@ -62,7 +62,7 @@ const optionalTrimmedString = (maxLength: number) =>
     .optional()
     .transform((value) => (value && value.length > 0 ? value : undefined));
 
-const RawCrowdReportSubmissionSchema = z
+export const StructuredCrowdReportSubmissionSchema = z
   .object({
     reportScope: CrowdReportScopeSchema,
     observedAt: optionalTrimmedString(64),
@@ -73,10 +73,14 @@ const RawCrowdReportSubmissionSchema = z
     effect: CrowdReportEffectSchema,
     delayMinutes: z.number().int().min(0).max(180).optional(),
     isStillHappening: z.boolean().optional(),
-    turnstileToken: optionalTrimmedString(4096),
-    clientFingerprint: optionalTrimmedString(512),
   })
   .strict();
+
+const RawCrowdReportSubmissionSchema =
+  StructuredCrowdReportSubmissionSchema.extend({
+    turnstileToken: optionalTrimmedString(4096),
+    clientFingerprint: optionalTrimmedString(512),
+  }).strict();
 
 export type CrowdReportEffect = IngestContentCrowdReportEffect;
 
@@ -108,6 +112,12 @@ export class CrowdReportRateLimitError extends Error {
   }
 }
 
+export class CrowdReportIdempotencyConflictError extends Error {
+  constructor(public readonly reportId: string) {
+    super('External report ID was already used with a different payload');
+  }
+}
+
 export type CrowdReportJsonBodyResult =
   | { success: true; body: unknown }
   | { success: false; status: 400 | 413; error: string };
@@ -124,6 +134,13 @@ type PersistCrowdReportOptions = {
   idFactory?: () => string;
 };
 
+export type ProgrammaticCrowdReportDelivery = {
+  producer: string;
+  externalReportId: string;
+  sourceUrl?: string;
+  requestPayloadDigest: string;
+};
+
 type PersistCrowdReportTransactionContext = {
   rateLimitPerHour: number;
   idFactory: () => string;
@@ -135,6 +152,12 @@ type AutomoderateCrowdReportOptions = ClusterCrowdReportOptions & {
   duplicateWindowMinutes?: number;
   now?: DateTime;
 };
+
+type PersistProgrammaticCrowdReportOptions = Pick<
+  PersistCrowdReportOptions,
+  'idFactory' | 'now'
+> &
+  Pick<AutomoderateCrowdReportOptions, 'duplicateWindowMinutes'>;
 
 type ClusterCrowdReportOptions = {
   clusterWindowMinutes?: number;
@@ -337,11 +360,24 @@ function hasCrowdReportClusterCurrentConfidenceSql(
   minReportCount: number,
   minDistinctIpHashes: number,
 ) {
-  return sql`${getCrowdReportClusterOngoingReportCountSql(
-    crowdReportClustersTable.id,
-  )} >= ${minReportCount} and ${getCrowdReportClusterOngoingDistinctIpHashCountSql(
-    crowdReportClustersTable.id,
-  )} >= ${minDistinctIpHashes}`;
+  return sql`(
+    (
+      ${getCrowdReportClusterOngoingReportCountSql(
+        crowdReportClustersTable.id,
+      )} >= ${minReportCount}
+      and ${getCrowdReportClusterOngoingDistinctIpHashCountSql(
+        crowdReportClustersTable.id,
+      )} >= ${minDistinctIpHashes}
+    )
+    or exists (
+      select 1
+      from ${crowdReportsTable}
+      where ${crowdReportsTable.cluster_id} = ${crowdReportClustersTable.id}
+        and ${crowdReportsTable.status} in ('accepted', 'duplicate')
+        and ${crowdReportsTable.still_happening} is true
+        and ${crowdReportsTable.producer} <> 'public'
+    )
+  )`;
 }
 
 function hasCrowdReportClusterScopeSql() {
@@ -405,54 +441,70 @@ export function validateCrowdReportSubmission(
     };
   }
 
-  const lineIds = [...new Set(parsed.data.lineIds)];
-  const stationIds = [...new Set(parsed.data.stationIds)];
+  return validateParsedCrowdReportSubmission(parsed.data, now);
+}
+
+export function validateStructuredCrowdReportSubmission(
+  input: unknown,
+  now = DateTime.now().setZone(SG_TIMEZONE),
+): CrowdReportValidationResult {
+  const parsed = StructuredCrowdReportSubmissionSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false,
+      issues: parsed.error.issues.map((issue) => issue.message),
+    };
+  }
+
+  return validateParsedCrowdReportSubmission(parsed.data, now);
+}
+
+function validateParsedCrowdReportSubmission(
+  data: z.infer<typeof StructuredCrowdReportSubmissionSchema> & {
+    turnstileToken?: string;
+    clientFingerprint?: string;
+  },
+  now: DateTime,
+): CrowdReportValidationResult {
+  const lineIds = [...new Set(data.lineIds)];
+  const stationIds = [...new Set(data.stationIds)];
   const issues: string[] = [];
   if (lineIds.length === 0 && stationIds.length === 0) {
     issues.push('At least one affected line or station is required');
   }
-  if (parsed.data.reportScope === 'line' && lineIds.length === 0) {
+  if (data.reportScope === 'line' && lineIds.length === 0) {
     issues.push('Line reports require at least one affected line');
   }
-  if (parsed.data.reportScope === 'station' && stationIds.length === 0) {
+  if (data.reportScope === 'station' && stationIds.length === 0) {
     issues.push('Station reports require at least one affected station');
   }
-  if (parsed.data.reportScope === 'train' && lineIds.length !== 1) {
+  if (data.reportScope === 'train' && lineIds.length !== 1) {
     issues.push('Train reports require exactly one affected line');
   }
   if (
-    parsed.data.reportScope === 'train' &&
-    parsed.data.directionStationId == null &&
-    parsed.data.directionUnknown !== true
+    data.reportScope === 'train' &&
+    data.directionStationId == null &&
+    data.directionUnknown !== true
   ) {
     issues.push(
       'Train reports require a direction station or explicit unknown direction',
     );
   }
-  if (parsed.data.directionStationId != null && lineIds.length !== 1) {
+  if (data.directionStationId != null && lineIds.length !== 1) {
     issues.push('directionStationId requires exactly one affected line');
   }
-  if (
-    parsed.data.reportScope !== 'train' &&
-    parsed.data.directionStationId != null
-  ) {
+  if (data.reportScope !== 'train' && data.directionStationId != null) {
     issues.push('directionStationId is only allowed for train reports');
   }
-  if (
-    parsed.data.directionStationId != null &&
-    parsed.data.directionUnknown === true
-  ) {
+  if (data.directionStationId != null && data.directionUnknown === true) {
     issues.push('directionUnknown cannot be combined with directionStationId');
   }
-  if (
-    parsed.data.reportScope !== 'train' &&
-    parsed.data.directionUnknown != null
-  ) {
+  if (data.reportScope !== 'train' && data.directionUnknown != null) {
     issues.push('directionUnknown is only allowed for train reports');
   }
 
-  const observedAt = parsed.data.observedAt
-    ? DateTime.fromISO(parsed.data.observedAt, { setZone: true })
+  const observedAt = data.observedAt
+    ? DateTime.fromISO(data.observedAt, { setZone: true })
     : now;
 
   if (!observedAt.isValid) {
@@ -482,26 +534,24 @@ export function validateCrowdReportSubmission(
   return {
     success: true,
     data: {
-      reportScope: parsed.data.reportScope,
+      reportScope: data.reportScope,
       observedAt: observedAtIso,
       lineIds,
       stationIds,
-      ...(parsed.data.directionStationId != null
-        ? { directionStationId: parsed.data.directionStationId }
+      ...(data.directionStationId != null
+        ? { directionStationId: data.directionStationId }
         : {}),
-      ...(parsed.data.directionUnknown === true
-        ? { directionUnknown: true }
-        : {}),
-      directionText: parsed.data.directionStationId
-        ? `towards:${parsed.data.directionStationId}`
-        : parsed.data.directionUnknown === true
+      ...(data.directionUnknown === true ? { directionUnknown: true } : {}),
+      directionText: data.directionStationId
+        ? `towards:${data.directionStationId}`
+        : data.directionUnknown === true
           ? 'not-sure'
           : undefined,
-      effect: parsed.data.effect,
-      delayMinutes: parsed.data.delayMinutes,
-      isStillHappening: parsed.data.isStillHappening,
-      turnstileToken: parsed.data.turnstileToken,
-      clientFingerprint: parsed.data.clientFingerprint,
+      effect: data.effect,
+      delayMinutes: data.delayMinutes,
+      isStillHappening: data.isStillHappening,
+      turnstileToken: data.turnstileToken,
+      clientFingerprint: data.clientFingerprint,
     },
   };
 }
@@ -1328,9 +1378,10 @@ async function createCrowdReportClusterInTransaction(
     window_end_at: windowEndAt,
     report_count: 1,
     status:
-      submission.isStillHappening === true &&
       publicSignalMinReports <= 1 &&
-      publicSignalMinDistinctIpHashes <= 1
+      ((submission.isStillHappening === true &&
+        publicSignalMinDistinctIpHashes <= 1) ||
+        publicSignalMinDistinctIpHashes === 0)
         ? 'accepted'
         : 'pending',
   });
@@ -1464,34 +1515,15 @@ async function persistCrowdReportInTransaction(
     );
   }
 
-  await tx.insert(crowdReportsTable).values({
-    id: context.reportId,
-    observed_at: submission.observedAt,
-    direction_text: submission.directionText,
-    effect: submission.effect,
-    delay_minutes: submission.delayMinutes,
-    still_happening: submission.isStillHappening,
-    text: buildCrowdReportStorageText(submission),
-    status: 'pending',
-  });
+  await tx
+    .insert(crowdReportsTable)
+    .values(buildCrowdReportInsertValues(context.reportId, submission));
 
-  if (submission.lineIds.length > 0) {
-    await tx.insert(crowdReportLinesTable).values(
-      submission.lineIds.map((lineId) => ({
-        report_id: context.reportId,
-        line_id: lineId,
-      })),
-    );
-  }
-
-  if (submission.stationIds.length > 0) {
-    await tx.insert(crowdReportStationsTable).values(
-      submission.stationIds.map((stationId) => ({
-        report_id: context.reportId,
-        station_id: stationId,
-      })),
-    );
-  }
+  await insertCrowdReportReferencesInTransaction(
+    tx,
+    context.reportId,
+    submission,
+  );
 
   await tx.insert(crowdReportAbuseEventsTable).values({
     id: context.idFactory(),
@@ -1513,6 +1545,97 @@ async function persistCrowdReportInTransaction(
   });
 
   return { id: context.reportId, status: 'pending' as const };
+}
+
+function buildCrowdReportInsertValues(
+  reportId: string,
+  submission: CrowdReportSubmission,
+  delivery?: ProgrammaticCrowdReportDelivery,
+) {
+  return {
+    id: reportId,
+    observed_at: submission.observedAt,
+    direction_text: submission.directionText,
+    effect: submission.effect,
+    delay_minutes: submission.delayMinutes,
+    still_happening: submission.isStillHappening,
+    text: buildCrowdReportStorageText(submission),
+    status: 'pending',
+    producer: delivery?.producer ?? 'public',
+    external_report_id: delivery?.externalReportId,
+    source_url: delivery?.sourceUrl,
+    request_payload_digest: delivery?.requestPayloadDigest,
+  } as const;
+}
+
+async function insertCrowdReportReferencesInTransaction(
+  tx: CrowdReportTransaction,
+  reportId: string,
+  submission: CrowdReportSubmission,
+) {
+  if (submission.lineIds.length > 0) {
+    await tx.insert(crowdReportLinesTable).values(
+      submission.lineIds.map((lineId) => ({
+        report_id: reportId,
+        line_id: lineId,
+      })),
+    );
+  }
+
+  if (submission.stationIds.length > 0) {
+    await tx.insert(crowdReportStationsTable).values(
+      submission.stationIds.map((stationId) => ({
+        report_id: reportId,
+        station_id: stationId,
+      })),
+    );
+  }
+}
+
+async function selectProgrammaticCrowdReport(
+  db: CrowdReportReadableDb,
+  producer: string,
+  externalReportId: string,
+) {
+  const [report] = await db
+    .select({
+      id: crowdReportsTable.id,
+      status: crowdReportsTable.status,
+      duplicateOfId: crowdReportsTable.duplicate_of_id,
+      requestPayloadDigest: crowdReportsTable.request_payload_digest,
+    })
+    .from(crowdReportsTable)
+    .where(
+      and(
+        eq(crowdReportsTable.producer, producer),
+        eq(crowdReportsTable.external_report_id, externalReportId),
+      ),
+    )
+    .limit(1);
+  return report;
+}
+
+export async function findProgrammaticCrowdReportRetry(
+  db: AppDb,
+  delivery: ProgrammaticCrowdReportDelivery,
+) {
+  const report = await selectProgrammaticCrowdReport(
+    db,
+    delivery.producer,
+    delivery.externalReportId,
+  );
+  if (report == null) {
+    return undefined;
+  }
+  if (report.requestPayloadDigest !== delivery.requestPayloadDigest) {
+    throw new CrowdReportIdempotencyConflictError(report.id);
+  }
+  return {
+    id: report.id,
+    status: report.status,
+    duplicateOfId: report.duplicateOfId,
+    created: false as const,
+  };
 }
 
 export async function persistCrowdReport(
@@ -1576,6 +1699,77 @@ export async function persistAutomoderatedCrowdReport(
       options.publicSignalMinReports,
       options.publicSignalMinDistinctIpHashes,
     );
+  });
+}
+
+export async function persistAutomoderatedProgrammaticCrowdReport(
+  db: AppDb,
+  submission: CrowdReportSubmission,
+  delivery: ProgrammaticCrowdReportDelivery,
+  options: PersistProgrammaticCrowdReportOptions = {},
+) {
+  const now = options.now ?? DateTime.now().setZone(SG_TIMEZONE);
+  const duplicateWindowMinutes =
+    options.duplicateWindowMinutes ?? DEFAULT_DUPLICATE_WINDOW_MINUTES;
+  const idFactory = options.idFactory ?? (() => crypto.randomUUID());
+  const reportId = idFactory();
+
+  return db.transaction(async (tx) => {
+    const [insertedReport] = await tx
+      .insert(crowdReportsTable)
+      .values(buildCrowdReportInsertValues(reportId, submission, delivery))
+      .onConflictDoNothing({
+        target: [
+          crowdReportsTable.producer,
+          crowdReportsTable.external_report_id,
+        ],
+      })
+      .returning({ id: crowdReportsTable.id });
+
+    if (insertedReport == null) {
+      const existingReport = await selectProgrammaticCrowdReport(
+        tx,
+        delivery.producer,
+        delivery.externalReportId,
+      );
+      if (existingReport == null) {
+        throw new Error('Conflicting programmatic report could not be loaded');
+      }
+      if (
+        existingReport.requestPayloadDigest !== delivery.requestPayloadDigest
+      ) {
+        throw new CrowdReportIdempotencyConflictError(existingReport.id);
+      }
+      return {
+        id: existingReport.id,
+        status: existingReport.status,
+        duplicateOfId: existingReport.duplicateOfId,
+        created: false as const,
+      };
+    }
+
+    await insertCrowdReportReferencesInTransaction(tx, reportId, submission);
+    await tx.insert(crowdReportModerationEventsTable).values({
+      id: idFactory(),
+      report_id: reportId,
+      actor: 'system',
+      action: 'submitted',
+      note: `Report submitted by authenticated producer ${delivery.producer}`,
+    });
+
+    const moderated = await automoderateCrowdReportInTransaction(
+      tx,
+      reportId,
+      submission,
+      duplicateWindowMinutes,
+      idFactory,
+      now,
+      undefined,
+      1,
+      0,
+    );
+
+    return { ...moderated, created: true as const };
   });
 }
 

--- a/app/util/crowdReports.ts
+++ b/app/util/crowdReports.ts
@@ -1244,6 +1244,7 @@ async function automoderateCrowdReportInTransaction(
   clusterWindowMinutes = DEFAULT_CLUSTER_WINDOW_MINUTES,
   publicSignalMinReports = DEFAULT_PUBLIC_SIGNAL_MIN_REPORTS,
   publicSignalMinDistinctIpHashes = DEFAULT_PUBLIC_SIGNAL_MIN_DISTINCT_IP_HASHES,
+  trustedSubmission = false,
 ) {
   await tx.execute(
     sql`select pg_advisory_xact_lock(hashtextextended(${buildDuplicateLockKey(submission)}, 0::bigint))`,
@@ -1345,6 +1346,7 @@ async function automoderateCrowdReportInTransaction(
     publicSignalMinReports,
     publicSignalMinDistinctIpHashes,
     idFactory,
+    trustedSubmission,
   );
 
   return (
@@ -1364,6 +1366,7 @@ async function createCrowdReportClusterInTransaction(
   idFactory: () => string,
   publicSignalMinReports: number,
   publicSignalMinDistinctIpHashes: number,
+  trustedSubmission: boolean,
 ) {
   const clusterId = idFactory();
   const { windowStartAt, windowEndAt } = getCrowdReportClusterWindow(
@@ -1377,11 +1380,11 @@ async function createCrowdReportClusterInTransaction(
     window_start_at: windowStartAt,
     window_end_at: windowEndAt,
     report_count: 1,
-    status:
-      publicSignalMinReports <= 1 &&
-      ((submission.isStillHappening === true &&
-        publicSignalMinDistinctIpHashes <= 1) ||
-        publicSignalMinDistinctIpHashes === 0)
+    status: trustedSubmission
+      ? 'accepted'
+      : submission.isStillHappening === true &&
+          publicSignalMinReports <= 1 &&
+          publicSignalMinDistinctIpHashes <= 1
         ? 'accepted'
         : 'pending',
   });
@@ -1425,6 +1428,7 @@ async function clusterModeratedCrowdReportInTransaction(
   publicSignalMinReports: number,
   publicSignalMinDistinctIpHashes: number,
   idFactory: () => string,
+  trustedSubmission: boolean,
 ) {
   if (duplicate == null) {
     await createCrowdReportClusterInTransaction(
@@ -1435,6 +1439,7 @@ async function clusterModeratedCrowdReportInTransaction(
       idFactory,
       publicSignalMinReports,
       publicSignalMinDistinctIpHashes,
+      trustedSubmission,
     );
     return;
   }
@@ -1449,6 +1454,7 @@ async function clusterModeratedCrowdReportInTransaction(
       idFactory,
       publicSignalMinReports,
       publicSignalMinDistinctIpHashes,
+      trustedSubmission,
     ));
   const { windowStartAt, windowEndAt } = getCrowdReportClusterWindow(
     submission.observedAt,
@@ -1468,7 +1474,9 @@ async function clusterModeratedCrowdReportInTransaction(
     .update(crowdReportClustersTable)
     .set({
       report_count: sql`${crowdReportClustersTable.report_count} + 1`,
-      status: sql`case when ${crowdReportClustersTable.status} = 'pending' and ${getCrowdReportClusterOngoingReportCountSql(clusterId)} >= ${publicSignalMinReports} and ${getCrowdReportClusterOngoingDistinctIpHashCountSql(clusterId)} >= ${publicSignalMinDistinctIpHashes} then 'accepted'::crowd_report_cluster_status else ${crowdReportClustersTable.status} end`,
+      status: trustedSubmission
+        ? sql`case when ${crowdReportClustersTable.status} = 'pending' then 'accepted'::crowd_report_cluster_status else ${crowdReportClustersTable.status} end`
+        : sql`case when ${crowdReportClustersTable.status} = 'pending' and ${getCrowdReportClusterOngoingReportCountSql(clusterId)} >= ${publicSignalMinReports} and ${getCrowdReportClusterOngoingDistinctIpHashCountSql(clusterId)} >= ${publicSignalMinDistinctIpHashes} then 'accepted'::crowd_report_cluster_status else ${crowdReportClustersTable.status} end`,
       window_start_at: sql`least(${crowdReportClustersTable.window_start_at}, ${windowStartAt}::timestamptz)`,
       window_end_at: sql`greatest(${crowdReportClustersTable.window_end_at}, ${windowEndAt}::timestamptz)`,
       updated_at: sql`now()`,
@@ -1765,8 +1773,9 @@ export async function persistAutomoderatedProgrammaticCrowdReport(
       idFactory,
       now,
       undefined,
-      1,
-      0,
+      undefined,
+      undefined,
+      true,
     );
 
     return { ...moderated, created: true as const };

--- a/app/util/programmaticCrowdReportPersistence.test.ts
+++ b/app/util/programmaticCrowdReportPersistence.test.ts
@@ -1,0 +1,258 @@
+import { DateTime } from 'luxon';
+import { describe, expect, it } from 'vitest';
+import {
+  crowdReportAbuseEventsTable,
+  crowdReportClusterLinesTable,
+  crowdReportClustersTable,
+  crowdReportClusterStationsTable,
+  crowdReportLinesTable,
+  crowdReportModerationEventsTable,
+  crowdReportRateLimitsTable,
+  crowdReportsTable,
+  crowdReportStationsTable,
+} from '~/db/schema';
+import {
+  CrowdReportIdempotencyConflictError,
+  findProgrammaticCrowdReportRetry,
+  persistAutomoderatedProgrammaticCrowdReport,
+  type CrowdReportSubmission,
+} from './crowdReports';
+
+const NOW = DateTime.fromISO('2026-07-18T12:00:00+08:00', {
+  setZone: true,
+});
+
+const SUBMISSION: CrowdReportSubmission = {
+  reportScope: 'line',
+  observedAt: '2026-07-18T11:55:00+08:00',
+  lineIds: ['CCL'],
+  stationIds: ['CC1'],
+  effect: 'delay',
+  delayMinutes: 10,
+  isStillHappening: true,
+};
+
+const DELIVERY = {
+  producer: 'reddit-monitor',
+  externalReportId: 'opaque-post-id',
+  sourceUrl: 'https://www.reddit.com/r/singapore/comments/example',
+  requestPayloadDigest: 'a'.repeat(64),
+};
+
+function makeFakeDb(
+  options: {
+    insertedReport?: { id: string };
+    selectResults?: unknown[][];
+  } = {},
+) {
+  const inserts: Array<{ table: unknown; values: unknown }> = [];
+  const updates: Array<{ table: unknown; values: unknown }> = [];
+  const conflicts: unknown[] = [];
+  const selectResults = [...(options.selectResults ?? [[]])];
+  const insertedReport =
+    options.insertedReport === undefined
+      ? { id: 'report-1' }
+      : options.insertedReport;
+  const selectBuilder = {
+    from() {
+      return this;
+    },
+    where() {
+      return this;
+    },
+    orderBy() {
+      return this;
+    },
+    offset() {
+      return this;
+    },
+    limit() {
+      return Promise.resolve(selectResults.shift() ?? []);
+    },
+  };
+  const tx = {
+    execute() {
+      return Promise.resolve();
+    },
+    select() {
+      return selectBuilder;
+    },
+    insert(table: unknown) {
+      return {
+        values(values: unknown) {
+          inserts.push({ table, values });
+          if (table === crowdReportsTable) {
+            return {
+              onConflictDoNothing(config: unknown) {
+                conflicts.push(config);
+                return {
+                  returning() {
+                    return Promise.resolve(
+                      insertedReport == null ? [] : [insertedReport],
+                    );
+                  },
+                };
+              },
+            };
+          }
+          return Promise.resolve();
+        },
+      };
+    },
+    update(table: unknown) {
+      return {
+        set(values: unknown) {
+          updates.push({ table, values });
+          return {
+            where() {
+              return {
+                returning() {
+                  return Promise.resolve([
+                    {
+                      id: 'report-1',
+                      status: 'accepted',
+                      duplicateOfId: null,
+                    },
+                  ]);
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+
+  return {
+    inserts,
+    updates,
+    conflicts,
+    db: {
+      select: tx.select,
+      transaction<T>(callback: (transaction: typeof tx) => Promise<T>) {
+        return callback(tx);
+      },
+    },
+  };
+}
+
+describe('persistAutomoderatedProgrammaticCrowdReport', () => {
+  it('records provenance, skips public abuse state, and trusts one producer report', async () => {
+    const fake = makeFakeDb();
+    const ids = ['report-1', 'submitted-event', 'accepted-event', 'cluster-1'];
+
+    await expect(
+      persistAutomoderatedProgrammaticCrowdReport(
+        fake.db as never,
+        SUBMISSION,
+        DELIVERY,
+        {
+          now: NOW,
+          idFactory: () => ids.shift() ?? 'fallback-id',
+        },
+      ),
+    ).resolves.toEqual({
+      id: 'report-1',
+      status: 'accepted',
+      duplicateOfId: null,
+      created: true,
+    });
+
+    expect(fake.inserts.map((insert) => insert.table)).toEqual([
+      crowdReportsTable,
+      crowdReportLinesTable,
+      crowdReportStationsTable,
+      crowdReportModerationEventsTable,
+      crowdReportModerationEventsTable,
+      crowdReportClustersTable,
+      crowdReportClusterLinesTable,
+      crowdReportClusterStationsTable,
+    ]);
+    expect(fake.inserts[0]?.values).toMatchObject({
+      id: 'report-1',
+      producer: 'reddit-monitor',
+      external_report_id: 'opaque-post-id',
+      source_url: DELIVERY.sourceUrl,
+      request_payload_digest: DELIVERY.requestPayloadDigest,
+    });
+    expect(fake.inserts.map((insert) => insert.table)).not.toContain(
+      crowdReportAbuseEventsTable,
+    );
+    expect(fake.inserts.map((insert) => insert.table)).not.toContain(
+      crowdReportRateLimitsTable,
+    );
+    expect(fake.inserts[5]?.values).toMatchObject({ status: 'accepted' });
+    expect(fake.conflicts).toHaveLength(1);
+  });
+
+  it('returns the winning concurrent insert without adding side effects', async () => {
+    const fake = makeFakeDb({
+      insertedReport: null as never,
+      selectResults: [
+        [
+          {
+            id: 'existing-report',
+            status: 'accepted',
+            duplicateOfId: null,
+            requestPayloadDigest: DELIVERY.requestPayloadDigest,
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      persistAutomoderatedProgrammaticCrowdReport(
+        fake.db as never,
+        SUBMISSION,
+        DELIVERY,
+      ),
+    ).resolves.toEqual({
+      id: 'existing-report',
+      status: 'accepted',
+      duplicateOfId: null,
+      created: false,
+    });
+    expect(fake.inserts).toHaveLength(1);
+    expect(fake.updates).toHaveLength(0);
+  });
+
+  it('accepts a single authenticated resolution report for dispatch', async () => {
+    const fake = makeFakeDb();
+    const ids = ['report-1', 'submitted-event', 'accepted-event', 'cluster-1'];
+
+    await persistAutomoderatedProgrammaticCrowdReport(
+      fake.db as never,
+      { ...SUBMISSION, isStillHappening: false },
+      DELIVERY,
+      {
+        now: NOW,
+        idFactory: () => ids.shift() ?? 'fallback-id',
+      },
+    );
+
+    expect(fake.inserts[5]?.values).toMatchObject({ status: 'accepted' });
+  });
+});
+
+describe('findProgrammaticCrowdReportRetry', () => {
+  it('rejects reuse of an external ID with a different payload', async () => {
+    const fake = makeFakeDb({
+      selectResults: [
+        [
+          {
+            id: 'existing-report',
+            status: 'accepted',
+            duplicateOfId: null,
+            requestPayloadDigest: 'different-digest',
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      findProgrammaticCrowdReportRetry(fake.db as never, DELIVERY),
+    ).rejects.toEqual(
+      new CrowdReportIdempotencyConflictError('existing-report'),
+    );
+  });
+});

--- a/app/util/programmaticCrowdReportPersistence.test.ts
+++ b/app/util/programmaticCrowdReportPersistence.test.ts
@@ -1,4 +1,6 @@
 import { DateTime } from 'luxon';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { describe, expect, it } from 'vitest';
 import {
   crowdReportAbuseEventsTable,
@@ -43,6 +45,11 @@ function makeFakeDb(
   options: {
     insertedReport?: { id: string };
     selectResults?: unknown[][];
+    updatedReport?: {
+      id: string;
+      status: 'accepted' | 'duplicate';
+      duplicateOfId: string | null;
+    };
   } = {},
 ) {
   const inserts: Array<{ table: unknown; values: unknown }> = [];
@@ -53,6 +60,11 @@ function makeFakeDb(
     options.insertedReport === undefined
       ? { id: 'report-1' }
       : options.insertedReport;
+  const updatedReport = options.updatedReport ?? {
+    id: 'report-1',
+    status: 'accepted',
+    duplicateOfId: null,
+  };
   const selectBuilder = {
     from() {
       return this;
@@ -107,13 +119,7 @@ function makeFakeDb(
             where() {
               return {
                 returning() {
-                  return Promise.resolve([
-                    {
-                      id: 'report-1',
-                      status: 'accepted',
-                      duplicateOfId: null,
-                    },
-                  ]);
+                  return Promise.resolve([updatedReport]);
                 },
               };
             },
@@ -231,6 +237,54 @@ describe('persistAutomoderatedProgrammaticCrowdReport', () => {
     );
 
     expect(fake.inserts[5]?.values).toMatchObject({ status: 'accepted' });
+  });
+
+  it('promotes a pending cluster for a trusted recovery duplicate', async () => {
+    const fake = makeFakeDb({
+      selectResults: [
+        [
+          {
+            id: 'existing-report',
+            status: 'accepted',
+            observedAt: '2026-07-18T11:54:00+08:00',
+            directionText: null,
+            clusterId: 'cluster-1',
+          },
+        ],
+        [{ reportId: 'existing-report', lineId: 'CCL' }],
+        [{ reportId: 'existing-report', stationId: 'CC1' }],
+        [{ id: 'cluster-1' }],
+      ],
+      updatedReport: {
+        id: 'report-1',
+        status: 'duplicate',
+        duplicateOfId: 'existing-report',
+      },
+    });
+    const ids = ['report-1', 'submitted-event', 'duplicate-event'];
+
+    await expect(
+      persistAutomoderatedProgrammaticCrowdReport(
+        fake.db as never,
+        { ...SUBMISSION, isStillHappening: false },
+        DELIVERY,
+        {
+          now: NOW,
+          idFactory: () => ids.shift() ?? 'fallback-id',
+        },
+      ),
+    ).resolves.toEqual({
+      id: 'report-1',
+      status: 'duplicate',
+      duplicateOfId: 'existing-report',
+      created: true,
+    });
+
+    const clusterStatus = fake.updates[2]?.values as { status: SQL };
+    const statusSql = new PgDialect().sqlToQuery(clusterStatus.status).sql;
+    expect(statusSql).toContain("then 'accepted'");
+    expect(statusSql).not.toContain('still_happening');
+    expect(statusSql).not.toContain('count(distinct');
   });
 });
 

--- a/app/util/programmaticCrowdReports.test.ts
+++ b/app/util/programmaticCrowdReports.test.ts
@@ -48,6 +48,22 @@ describe('authenticateCrowdReportProducer', () => {
       ),
     ).resolves.toMatchObject({ success: false, status: 503 });
   });
+
+  it('rejects public as a reserved producer ID', async () => {
+    await expect(
+      authenticateCrowdReportProducer(
+        new Request('https://example.com/internal/api/crowd-reports', {
+          headers: { authorization: 'Bearer public-producer-secret' },
+        }),
+        JSON.stringify({
+          public: {
+            token: 'public-producer-secret',
+            sourceOrigins: [],
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({ success: false, status: 503 });
+  });
 });
 
 describe('programmatic crowd report request contract', () => {

--- a/app/util/programmaticCrowdReports.test.ts
+++ b/app/util/programmaticCrowdReports.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import {
+  authenticateCrowdReportProducer,
+  hashProgrammaticCrowdReportPayload,
+  isProgrammaticCrowdReportSourceAllowed,
+  ProgrammaticCrowdReportRequestSchema,
+} from './programmaticCrowdReports';
+
+const PRODUCER_CONFIG = JSON.stringify({
+  'reddit-monitor': {
+    token: 'reddit-monitor-secret',
+    sourceOrigins: ['https://www.reddit.com'],
+  },
+});
+
+describe('authenticateCrowdReportProducer', () => {
+  it('maps a producer-specific bearer secret to its producer policy', async () => {
+    const result = await authenticateCrowdReportProducer(
+      new Request('https://example.com/internal/api/crowd-reports', {
+        headers: { authorization: 'Bearer reddit-monitor-secret' },
+      }),
+      PRODUCER_CONFIG,
+    );
+
+    expect(result).toEqual({
+      success: true,
+      producer: {
+        id: 'reddit-monitor',
+        sourceOrigins: ['https://www.reddit.com'],
+      },
+    });
+  });
+
+  it('rejects invalid credentials and invalid producer configuration', async () => {
+    await expect(
+      authenticateCrowdReportProducer(
+        new Request('https://example.com/internal/api/crowd-reports', {
+          headers: { authorization: 'Bearer wrong-secret-value' },
+        }),
+        PRODUCER_CONFIG,
+      ),
+    ).resolves.toMatchObject({ success: false, status: 401 });
+
+    await expect(
+      authenticateCrowdReportProducer(
+        new Request('https://example.com/internal/api/crowd-reports'),
+        '{invalid',
+      ),
+    ).resolves.toMatchObject({ success: false, status: 503 });
+  });
+});
+
+describe('programmatic crowd report request contract', () => {
+  it('allows configured HTTP origins and rejects public-only report fields', () => {
+    const parsed = ProgrammaticCrowdReportRequestSchema.safeParse({
+      externalReportId: 'post-1',
+      sourceUrl: 'https://www.reddit.com/r/singapore/comments/example',
+      report: {
+        reportScope: 'line',
+        lineIds: ['CCL'],
+        stationIds: [],
+        effect: 'delay',
+        turnstileToken: 'not-allowed',
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+    expect(
+      isProgrammaticCrowdReportSourceAllowed(
+        {
+          id: 'reddit-monitor',
+          sourceOrigins: ['https://www.reddit.com'],
+        },
+        'https://www.reddit.com/r/singapore/comments/example',
+      ),
+    ).toBe(true);
+    expect(
+      isProgrammaticCrowdReportSourceAllowed(
+        {
+          id: 'reddit-monitor',
+          sourceOrigins: ['https://www.reddit.com'],
+        },
+        'https://example.com/not-allowed',
+      ),
+    ).toBe(false);
+  });
+
+  it('hashes semantically identical line and station sets consistently', async () => {
+    const first = ProgrammaticCrowdReportRequestSchema.parse({
+      externalReportId: 'post-1',
+      report: {
+        reportScope: 'line',
+        observedAt: '2026-07-18T08:00:00+08:00',
+        lineIds: ['CCL', 'EWL'],
+        stationIds: ['EW1', 'CC1'],
+        effect: 'delay',
+      },
+    });
+    const reordered = ProgrammaticCrowdReportRequestSchema.parse({
+      externalReportId: 'post-1',
+      report: {
+        reportScope: 'line',
+        observedAt: '2026-07-18T08:00:00+08:00',
+        lineIds: ['EWL', 'CCL', 'CCL'],
+        stationIds: ['CC1', 'EW1'],
+        effect: 'delay',
+      },
+    });
+
+    await expect(hashProgrammaticCrowdReportPayload(first)).resolves.toBe(
+      await hashProgrammaticCrowdReportPayload(reordered),
+    );
+  });
+});

--- a/app/util/programmaticCrowdReports.ts
+++ b/app/util/programmaticCrowdReports.ts
@@ -1,0 +1,190 @@
+import { z } from 'zod';
+import { StructuredCrowdReportSubmissionSchema } from './crowdReports';
+
+const ProducerIdSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(64)
+  .regex(/^[a-z0-9]+(?:[._-][a-z0-9]+)*$/);
+
+const HttpOriginSchema = z
+  .string()
+  .url()
+  .transform((value, context) => {
+    const url = new URL(value);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      context.addIssue({
+        code: 'custom',
+        message: 'Source origins must use HTTP or HTTPS',
+      });
+      return z.NEVER;
+    }
+    return url.origin;
+  });
+
+const ProducerConfigSchema = z
+  .record(
+    ProducerIdSchema,
+    z
+      .object({
+        token: z.string().min(16).max(4096),
+        sourceOrigins: z.array(HttpOriginSchema).max(16).default([]),
+      })
+      .strict(),
+  )
+  .superRefine((producers, context) => {
+    const seenTokens = new Set<string>();
+    for (const [producer, config] of Object.entries(producers)) {
+      if (seenTokens.has(config.token)) {
+        context.addIssue({
+          code: 'custom',
+          message: `Producer ${producer} reuses another producer token`,
+        });
+      }
+      seenTokens.add(config.token);
+    }
+  });
+
+const SourceUrlSchema = z
+  .string()
+  .trim()
+  .max(2048)
+  .url()
+  .transform((value, context) => {
+    const url = new URL(value);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      context.addIssue({
+        code: 'custom',
+        message: 'sourceUrl must use HTTP or HTTPS',
+      });
+      return z.NEVER;
+    }
+    return url.href;
+  });
+
+export const ProgrammaticCrowdReportRequestSchema = z
+  .object({
+    externalReportId: z.string().trim().min(1).max(256),
+    sourceUrl: SourceUrlSchema.optional(),
+    report: StructuredCrowdReportSubmissionSchema,
+  })
+  .strict();
+
+export type ProgrammaticCrowdReportRequest = z.infer<
+  typeof ProgrammaticCrowdReportRequestSchema
+>;
+
+export type CrowdReportProducer = {
+  id: string;
+  sourceOrigins: string[];
+};
+
+export type CrowdReportProducerAuthenticationResult =
+  | { success: true; producer: CrowdReportProducer }
+  | { success: false; status: 401 | 503; error: string };
+
+export async function authenticateCrowdReportProducer(
+  request: Request,
+  serializedConfig: string | undefined,
+): Promise<CrowdReportProducerAuthenticationResult> {
+  const producers = parseProducerConfig(serializedConfig);
+  if (producers == null) {
+    return {
+      success: false,
+      status: 503,
+      error: 'Programmatic crowd reports are not configured',
+    };
+  }
+
+  const authorization = request.headers.get('authorization');
+  const token = authorization?.match(/^Bearer\s+(.+)$/i)?.[1]?.trim();
+  if (!token) {
+    return { success: false, status: 401, error: 'Unauthorized' };
+  }
+
+  const tokenDigest = await digestBytes(token);
+  const entries = Object.entries(producers);
+  const secretDigests = await Promise.all(
+    entries.map(([, config]) => digestBytes(config.token)),
+  );
+  const matchingIndex = secretDigests.findIndex((digest) =>
+    constantTimeBytesEqual(tokenDigest, digest),
+  );
+  const matchingEntry = entries[matchingIndex];
+  if (matchingEntry == null) {
+    return { success: false, status: 401, error: 'Unauthorized' };
+  }
+
+  return {
+    success: true,
+    producer: {
+      id: matchingEntry[0],
+      sourceOrigins: matchingEntry[1].sourceOrigins,
+    },
+  };
+}
+
+export function isProgrammaticCrowdReportSourceAllowed(
+  producer: CrowdReportProducer,
+  sourceUrl: string | undefined,
+) {
+  if (sourceUrl == null) {
+    return true;
+  }
+  return producer.sourceOrigins.includes(new URL(sourceUrl).origin);
+}
+
+export async function hashProgrammaticCrowdReportPayload(
+  request: ProgrammaticCrowdReportRequest,
+) {
+  const canonicalPayload = JSON.stringify({
+    sourceUrl: request.sourceUrl ?? null,
+    report: {
+      reportScope: request.report.reportScope,
+      observedAt: request.report.observedAt ?? null,
+      lineIds: [...new Set(request.report.lineIds)].sort(),
+      stationIds: [...new Set(request.report.stationIds)].sort(),
+      directionStationId: request.report.directionStationId ?? null,
+      directionUnknown: request.report.directionUnknown ?? null,
+      effect: request.report.effect,
+      delayMinutes: request.report.delayMinutes ?? null,
+      isStillHappening: request.report.isStillHappening ?? null,
+    },
+  });
+  const digest = await digestBytes(canonicalPayload);
+  return [...digest].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function parseProducerConfig(serializedConfig: string | undefined) {
+  if (!serializedConfig) {
+    return undefined;
+  }
+  try {
+    const parsed = ProducerConfigSchema.safeParse(JSON.parse(serializedConfig));
+    return parsed.success && Object.keys(parsed.data).length > 0
+      ? parsed.data
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function digestBytes(value: string) {
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(value),
+  );
+  return new Uint8Array(digest);
+}
+
+function constantTimeBytesEqual(left: Uint8Array, right: Uint8Array) {
+  if (left.byteLength !== right.byteLength) {
+    return false;
+  }
+  let difference = 0;
+  for (let index = 0; index < left.byteLength; index += 1) {
+    difference |= (left[index] ?? 0) ^ (right[index] ?? 0);
+  }
+  return difference === 0;
+}

--- a/app/util/programmaticCrowdReports.ts
+++ b/app/util/programmaticCrowdReports.ts
@@ -6,7 +6,10 @@ const ProducerIdSchema = z
   .trim()
   .min(1)
   .max(64)
-  .regex(/^[a-z0-9]+(?:[._-][a-z0-9]+)*$/);
+  .regex(/^[a-z0-9]+(?:[._-][a-z0-9]+)*$/)
+  .refine((value) => value !== 'public', {
+    message: 'public is reserved for unauthenticated submissions',
+  });
 
 const HttpOriginSchema = z
   .string()

--- a/docs/DATA_PIPELINE.md
+++ b/docs/DATA_PIPELINE.md
@@ -82,6 +82,47 @@ the upstream ingest workflow six hours before the daily canonical pull. Use
 `CROWD_REPORT_DISPATCH_LIMIT` to tune the maximum number of dispatch candidates
 processed per scheduled run.
 
+### Programmatic crowd reports
+
+Registered machine producers submit structured reports to
+`POST /internal/api/crowd-reports` with their own bearer credential. Configure
+the credentials and permitted upstream origins as a JSON map in
+`CROWD_REPORT_PRODUCERS`:
+
+```json
+{
+  "reddit-monitor": {
+    "token": "replace-with-a-long-random-secret",
+    "sourceOrigins": ["https://www.reddit.com"]
+  }
+}
+```
+
+The request wraps the public structured-report fields with a producer-owned
+idempotency key and optional upstream URL:
+
+```json
+{
+  "externalReportId": "opaque-source-object-id",
+  "sourceUrl": "https://www.reddit.com/r/singapore/comments/example",
+  "report": {
+    "reportScope": "line",
+    "observedAt": "2026-07-18T08:00:00+08:00",
+    "lineIds": ["CCL"],
+    "stationIds": [],
+    "effect": "delay",
+    "delayMinutes": 10,
+    "isStillHappening": true
+  }
+}
+```
+
+A new report and an identical replay both return `202`; the response sets
+`idempotentReplay` to distinguish them. Reusing an external ID with a different
+payload returns `409`. Programmatic reports bypass public Turnstile, IP rate
+limits, and distinct-IP confidence requirements, but retain the same reference
+validation, moderation, clustering, cache purge, and canonical dispatch path.
+
 ## Staging Tables
 
 Staging tables are named with a `_next` suffix. They are the durable handoff between workflow steps and avoid returning large parsed payloads between Upstash Workflow steps.

--- a/docs/plans/active/reddit-community-monitoring.md
+++ b/docs/plans/active/reddit-community-monitoring.md
@@ -132,6 +132,18 @@ original result without creating another report. Reusing the ID with a
 different payload should return `409`, making producer bugs visible rather than
 silently changing a submitted report.
 
+```json
+{
+  "success": true,
+  "data": {
+    "id": "site-report-id",
+    "status": "accepted",
+    "duplicateOfId": null,
+    "idempotentReplay": false
+  }
+}
+```
+
 A single database uniqueness constraint on `(producer, external_report_id)` is
 the idempotency boundary. A separate inbox or event table is unnecessary.
 
@@ -215,7 +227,7 @@ updates or unnecessary request volume.
 
 ## Implementation Plan
 
-### Phase 1: Add the programmatic endpoint
+### Phase 1: Add the programmatic endpoint (completed 2026-07-18)
 
 - Define the small authenticated request schema alongside the crowd-report
   domain code.

--- a/drizzle/20260718080424_bouncy_cannonball/migration.sql
+++ b/drizzle/20260718080424_bouncy_cannonball/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "crowd_reports" ADD COLUMN "producer" text DEFAULT 'public' NOT NULL;--> statement-breakpoint
+ALTER TABLE "crowd_reports" ADD COLUMN "external_report_id" text;--> statement-breakpoint
+ALTER TABLE "crowd_reports" ADD COLUMN "source_url" text;--> statement-breakpoint
+ALTER TABLE "crowd_reports" ADD COLUMN "request_payload_digest" text;--> statement-breakpoint
+CREATE UNIQUE INDEX "crowd_reports_producer_external_report_id_uidx" ON "crowd_reports" ("producer","external_report_id");

--- a/drizzle/20260718080424_bouncy_cannonball/snapshot.json
+++ b/drizzle/20260718080424_bouncy_cannonball/snapshot.json
@@ -1,0 +1,6780 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "f238e842-2d76-4a45-807e-2f4d66934481",
+  "prevIds": [
+    "36186ac9-f467-4922-a98d-fd2ae5baa552"
+  ],
+  "ddl": [
+    {
+      "values": [
+        "lift",
+        "escalator",
+        "screen-door"
+      ],
+      "name": "affected_entity_facility_kind",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "pending",
+        "accepted",
+        "rejected",
+        "dispatched"
+      ],
+      "name": "crowd_report_cluster_status",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "delay",
+        "no-service",
+        "crowding",
+        "skipped-stop",
+        "unknown"
+      ],
+      "name": "crowd_report_effect",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "pending",
+        "accepted",
+        "rejected",
+        "duplicate",
+        "dispatched"
+      ],
+      "name": "crowd_report_status",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "statement.official",
+        "report.public",
+        "report.media"
+      ],
+      "name": "evidence_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "out-of-service",
+        "degraded"
+      ],
+      "name": "facility_effect_kind",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "signal.fault",
+        "track.fault",
+        "train.fault",
+        "power.fault",
+        "station.fault",
+        "security",
+        "weather",
+        "passenger.incident",
+        "platform_door.fault",
+        "delay",
+        "track.work",
+        "system.upgrade",
+        "elevator.outage",
+        "escalator.outage",
+        "air_conditioning.issue",
+        "station.renovation"
+      ],
+      "name": "impact_event_cause_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "service.whole",
+        "service.segment",
+        "service.point"
+      ],
+      "name": "impact_event_service_scope_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "disruption",
+        "maintenance",
+        "infra"
+      ],
+      "name": "issue_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "mrt.high",
+        "mrt.medium",
+        "lrt"
+      ],
+      "name": "line_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "delay",
+        "no-service",
+        "reduced-service",
+        "service-hours-adjustment"
+      ],
+      "name": "service_effect_kind",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "values": [
+        "elevated",
+        "underground",
+        "at_grade",
+        "in_building"
+      ],
+      "name": "station_structure_type",
+      "entityType": "enums",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "crowd_report_abuse_events",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "crowd_report_cluster_lines",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "crowd_report_cluster_stations",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "crowd_report_clusters",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "crowd_report_lines",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "crowd_report_moderation_events",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "crowd_report_rate_limits",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "crowd_report_stations",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "crowd_reports",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "evidences",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "impact_event_basis_evidences",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "impact_event_causes",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "impact_event_entity_facilities",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "impact_event_entity_services",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "impact_event_facility_effects",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "impact_event_periods",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "impact_event_service_effects",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "impact_event_service_scopes",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "impact_events",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "issue_day_facts",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "issues_next",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "issues",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "landmarks_next",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "landmarks",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "line_day_facts",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "line_day_issue_intervals",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "line_operators",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "line_services",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "lines_next",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "lines",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "metadata",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "operators_next",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "operators",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "public_holidays",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "service_revision_path_station_entries",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "service_revisions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "services_next",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "services",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "station_codes",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "station_landmarks",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "stations_next",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "stations",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "statistics_snapshots",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "towns_next",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "towns",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "workflow_leases",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_abuse_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "report_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_abuse_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ip_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_abuse_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_agent_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_abuse_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "client_fingerprint_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_abuse_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "turnstile_token_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_abuse_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "turnstile_outcome",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_abuse_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "rate_limit_bucket_start_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_abuse_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_abuse_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cluster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_cluster_lines"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "line_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_cluster_lines"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cluster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_cluster_stations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "station_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_cluster_stations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_clusters"
+    },
+    {
+      "type": "crowd_report_effect",
+      "typeSchema": "public",
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "effect",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_clusters"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "window_start_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_clusters"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "window_end_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_clusters"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "report_count",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_clusters"
+    },
+    {
+      "type": "crowd_report_cluster_status",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'pending'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_clusters"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dispatched_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_clusters"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_clusters"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_clusters"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "report_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_lines"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "line_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_lines"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_moderation_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "report_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_moderation_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "actor",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_moderation_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "action",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_moderation_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "note",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_moderation_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_moderation_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ip_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_rate_limits"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "bucket_start_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_rate_limits"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "submission_count",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_rate_limits"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "client_fingerprint_hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_rate_limits"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_rate_limits"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_rate_limits"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "report_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_stations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "station_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_report_stations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "observed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "direction_text",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "type": "crowd_report_effect",
+      "typeSchema": "public",
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "effect",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "delay_minutes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "still_happening",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "text",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "type": "crowd_report_status",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'pending'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cluster_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "duplicate_of_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dispatched_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dispatch_payload",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dispatch_error",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'public'",
+      "generated": null,
+      "identity": null,
+      "name": "producer",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "external_report_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "request_payload_digest",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "evidences"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ts",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "evidences"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "text",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "evidences"
+    },
+    {
+      "type": "evidence_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "evidences"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "render",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "evidences"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "evidences"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "issue_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "evidences"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "evidences"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "evidences"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "impact_event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_basis_evidences"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "evidence_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_basis_evidences"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_basis_evidences"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_basis_evidences"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "impact_event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_causes"
+    },
+    {
+      "type": "impact_event_cause_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_causes"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_causes"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_causes"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "impact_event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_entity_facilities"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "station_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_entity_facilities"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "line_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_entity_facilities"
+    },
+    {
+      "type": "affected_entity_facility_kind",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_entity_facilities"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_entity_facilities"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_entity_facilities"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "impact_event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_entity_services"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "service_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_entity_services"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_entity_services"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_entity_services"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "impact_event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_facility_effects"
+    },
+    {
+      "type": "facility_effect_kind",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_facility_effects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_facility_effects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_facility_effects"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "impact_event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_periods"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "index",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_periods"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "start_ts",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_periods"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "end_ts",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_periods"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_periods"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_periods"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "impact_event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_service_effects"
+    },
+    {
+      "type": "service_effect_kind",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_service_effects"
+    },
+    {
+      "type": "interval",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "duration",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_service_effects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_service_effects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_service_effects"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "impact_event_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_service_scopes"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "index",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_service_scopes"
+    },
+    {
+      "type": "impact_event_service_scope_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_service_scopes"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "station_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_service_scopes"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "from_station_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_service_scopes"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "to_station_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_service_scopes"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_service_scopes"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_event_service_scopes"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ts",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "issue_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "impact_events"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "date",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "issue_day_facts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "issue_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "issue_day_facts"
+    },
+    {
+      "type": "issue_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "issue_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "issue_day_facts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "as_of",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "issue_day_facts"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "active_anytime",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "issue_day_facts"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "active_end_of_day",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "issue_day_facts"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "duration_seconds",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "issue_day_facts"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "inferred_interval_count",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "issue_day_facts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "issue_day_facts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "issue_day_facts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "issues_next"
+    },
+    {
+      "type": "issue_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "issues_next"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "issues_next"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title_meta",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "issues_next"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "issues_next"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "evidences",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "issues_next"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "impact_events",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "issues_next"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "issues"
+    },
+    {
+      "type": "issue_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "issues"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "issues"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title_meta",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "issues"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "issues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "issues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "issues"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "landmarks_next"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "landmarks_next"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "landmarks_next"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "landmarks"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "landmarks"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "landmarks"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "landmarks"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "landmarks"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "date",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_day_facts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "line_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_day_facts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "as_of",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_day_facts"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "service_seconds",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_day_facts"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "downtime_disruption_seconds",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_day_facts"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "downtime_maintenance_seconds",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_day_facts"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "downtime_infra_seconds",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_day_facts"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "issue_count_disruption",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_day_facts"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "issue_count_maintenance",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_day_facts"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "issue_count_infra",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_day_facts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_day_facts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_day_facts"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "date",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_day_issue_intervals"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "line_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_day_issue_intervals"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "issue_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_day_issue_intervals"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "interval_index",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_day_issue_intervals"
+    },
+    {
+      "type": "issue_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "issue_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_day_issue_intervals"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "start_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_day_issue_intervals"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "end_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_day_issue_intervals"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "as_of",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_day_issue_intervals"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_day_issue_intervals"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_day_issue_intervals"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "line_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_operators"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "operator_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_operators"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_operators"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ended_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_operators"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_operators"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "line_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_services"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "service_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_services"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_services"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "line_services"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lines_next"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lines_next"
+    },
+    {
+      "type": "line_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lines_next"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "color",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lines_next"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lines_next"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ended_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lines_next"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "operating_hours",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lines_next"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lines_next"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "operators",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lines_next"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lines"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lines"
+    },
+    {
+      "type": "line_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lines"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "color",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lines"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lines"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ended_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lines"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "operating_hours",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lines"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lines"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lines"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "lines"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "metadata"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "value",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "metadata"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "operators_next"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "operators_next"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "founded_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "operators_next"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "operators_next"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "operators_next"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "operators"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "operators"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "founded_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "operators"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "operators"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "operators"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "operators"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "operators"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "public_holidays"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "date",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "public_holidays"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "holiday_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "public_holidays"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "public_holidays"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "public_holidays"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "public_holidays"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "service_revision_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "service_revision_path_station_entries"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "service_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "service_revision_path_station_entries"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "station_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "service_revision_path_station_entries"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "display_code",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "service_revision_path_station_entries"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "path_index",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "service_revision_path_station_entries"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "service_revision_path_station_entries"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "service_revision_path_station_entries"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "service_revisions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "service_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "service_revisions"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "start_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "service_revisions"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "end_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "service_revisions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "operating_hours",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "service_revisions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "service_revisions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "service_revisions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "services_next"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "services_next"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "services_next"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "line_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "services_next"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "revisions",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "services_next"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "services"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "line_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "services"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "services"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "services"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "services"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "services"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "line_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "station_codes"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "station_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "station_codes"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "code",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "station_codes"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "station_codes"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ended_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "station_codes"
+    },
+    {
+      "type": "station_structure_type",
+      "typeSchema": "public",
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "structure_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "station_codes"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "station_codes"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "station_codes"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "station_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "station_landmarks"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "landmark_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "station_landmarks"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "station_landmarks"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "station_landmarks"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "stations_next"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "stations_next"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "stations_next"
+    },
+    {
+      "type": "geometry(point,4326)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "geo",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "stations_next"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "town_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "stations_next"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "station_codes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "stations_next"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "landmark_ids",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "stations_next"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "stations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "stations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "stations"
+    },
+    {
+      "type": "geometry(point,4326)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "geo",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "stations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "town_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "stations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "stations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "stations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "statistics_snapshots"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "as_of",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "statistics_snapshots"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "data",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "statistics_snapshots"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "statistics_snapshots"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "statistics_snapshots"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "towns_next"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "towns_next"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "towns_next"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "towns"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "towns"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "hash",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "towns"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "towns"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "towns"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workflow_leases"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "owner",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workflow_leases"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "workflow_leases"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "report_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "crowd_report_abuse_events_report_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "crowd_report_abuse_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "ip_hash",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "crowd_report_abuse_events_ip_hash_created_at_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "crowd_report_abuse_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "line_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "crowd_report_cluster_lines_line_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "crowd_report_cluster_lines"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "station_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "crowd_report_cluster_stations_station_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "crowd_report_cluster_stations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "crowd_report_clusters_status_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "crowd_report_clusters"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "window_start_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "crowd_report_clusters_window_start_at_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "crowd_report_clusters"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "line_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "crowd_report_lines_line_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "crowd_report_lines"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "report_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "crowd_report_moderation_events_report_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "crowd_report_moderation_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "crowd_report_moderation_events_created_at_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "crowd_report_moderation_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "bucket_start_at",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "crowd_report_rate_limits_bucket_start_at_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "crowd_report_rate_limits"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "station_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "crowd_report_stations_station_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "crowd_report_stations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "observed_at",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "crowd_reports_observed_at_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "crowd_reports_status_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "cluster_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "crowd_reports_cluster_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "duplicate_of_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "crowd_reports_duplicate_of_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "producer",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "external_report_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "crowd_reports_producer_external_report_id_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "issue_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "evidences_issue_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "evidences"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "ts",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "evidences_ts_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "evidences"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "impact_event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "impact_event_basis_evidences_impact_event_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "impact_event_basis_evidences"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "evidence_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "impact_event_basis_evidences_evidence_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "impact_event_basis_evidences"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "impact_event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "impact_event_causes_impact_event_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "impact_event_causes"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "impact_event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "impact_event_entity_facilities_impact_event_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "impact_event_entity_facilities"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "station_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "impact_event_entity_facilities_station_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "impact_event_entity_facilities"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "line_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "impact_event_entity_facilities_line_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "impact_event_entity_facilities"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "impact_event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "impact_event_entity_services_impact_event_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "impact_event_entity_services"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "service_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "impact_event_entity_services_service_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "impact_event_entity_services"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "impact_event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "impact_event_facility_effects_impact_event_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "impact_event_facility_effects"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "kind",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "impact_event_facility_effects_kind_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "impact_event_facility_effects"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "start_ts",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "impact_event_periods_start_at_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "impact_event_periods"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "end_ts",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "impact_event_periods_end_at_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "impact_event_periods"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "impact_event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "impact_event_service_effects_impact_event_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "impact_event_service_effects"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "kind",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "impact_event_service_effects_kind_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "impact_event_service_effects"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "impact_event_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "impact_event_service_scopes_impact_event_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "impact_event_service_scopes"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "impact_event_service_scopes_type_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "impact_event_service_scopes"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "station_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "impact_event_service_scopes_station_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "impact_event_service_scopes"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "from_station_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "impact_event_service_scopes_from_station_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "impact_event_service_scopes"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "to_station_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "impact_event_service_scopes_to_station_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "impact_event_service_scopes"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "issue_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "impact_events_issue_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "impact_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "issue_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "issue_day_facts_issue_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "issue_day_facts"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "date",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "issue_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "issue_day_facts_date_issue_type_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "issue_day_facts"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "as_of",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "issue_day_facts_as_of_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "issue_day_facts"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "line_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "line_day_facts_line_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "line_day_facts"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "date",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "line_day_facts_date_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "line_day_facts"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "as_of",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "line_day_facts_as_of_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "line_day_facts"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "line_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "date",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "line_day_issue_intervals_line_id_date_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "line_day_issue_intervals"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "issue_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "line_day_issue_intervals_issue_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "line_day_issue_intervals"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "date",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "issue_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "line_day_issue_intervals_date_issue_type_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "line_day_issue_intervals"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "as_of",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "line_day_issue_intervals_as_of_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "line_day_issue_intervals"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "line_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "line_operators_line_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "line_operators"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "operator_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "line_operators_operator_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "line_operators"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "line_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "line_services_line_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "line_services"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "service_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "line_services_service_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "line_services"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "service_revision_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "service_revision_path_entries_service_revision_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "service_revision_path_station_entries"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "service_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "service_revision_path_entries_service_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "service_revision_path_station_entries"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "station_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "service_revision_path_entries_station_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "service_revision_path_station_entries"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "path_index",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "service_revision_path_entries_path_index_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "service_revision_path_station_entries"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "service_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "service_revisions_service_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "service_revisions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "line_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "services_line_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "services"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "line_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "station_codes_line_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "station_codes"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "station_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "station_codes_station_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "station_codes"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "station_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "station_landmarks_station_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "station_landmarks"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "landmark_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "station_landmarks_landmark_id_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "station_landmarks"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "geo",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "gist",
+      "concurrently": false,
+      "name": "stations_next_geo_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "stations_next"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "geo",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "gist",
+      "concurrently": false,
+      "name": "stations_geo_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "stations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "as_of",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "statistics_snapshots_as_of_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "statistics_snapshots"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "report_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "crowd_reports",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "crowd_report_abuse_events_report_id_crowd_reports_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "crowd_report_abuse_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "cluster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "crowd_report_clusters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "crowd_report_cluster_lines_cluster_id_crowd_report_clusters_id_",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "crowd_report_cluster_lines"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "line_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "lines",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "crowd_report_cluster_lines_line_id_lines_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "crowd_report_cluster_lines"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "cluster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "crowd_report_clusters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "crowd_report_cluster_stations_cluster_id_crowd_report_clusters_",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "crowd_report_cluster_stations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "station_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "stations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "crowd_report_cluster_stations_station_id_stations_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "crowd_report_cluster_stations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "report_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "crowd_reports",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "crowd_report_lines_report_id_crowd_reports_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "crowd_report_lines"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "line_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "lines",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "crowd_report_lines_line_id_lines_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "crowd_report_lines"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "report_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "crowd_reports",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "crowd_report_moderation_events_report_id_crowd_reports_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "crowd_report_moderation_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "report_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "crowd_reports",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "crowd_report_stations_report_id_crowd_reports_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "crowd_report_stations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "station_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "stations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "crowd_report_stations_station_id_stations_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "crowd_report_stations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "cluster_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "crowd_report_clusters",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "crowd_reports_cluster_id_crowd_report_clusters_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "duplicate_of_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "crowd_reports",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "crowd_reports_duplicate_of_id_crowd_reports_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "issue_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "issues",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "evidences_issue_id_issues_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "evidences"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "impact_event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "impact_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "impact_event_basis_evidences_impact_event_id_impact_events_id_f",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "impact_event_basis_evidences"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "evidence_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "evidences",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "impact_event_basis_evidences_evidence_id_evidences_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "impact_event_basis_evidences"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "impact_event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "impact_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "impact_event_causes_impact_event_id_impact_events_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "impact_event_causes"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "impact_event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "impact_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "impact_event_entity_facilities_impact_event_id_impact_events_id",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "impact_event_entity_facilities"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "station_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "stations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "impact_event_entity_facilities_station_id_stations_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "impact_event_entity_facilities"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "line_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "lines",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "impact_event_entity_facilities_line_id_lines_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "impact_event_entity_facilities"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "impact_event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "impact_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "impact_event_entity_services_impact_event_id_impact_events_id_f",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "impact_event_entity_services"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "service_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "services",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "impact_event_entity_services_service_id_services_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "impact_event_entity_services"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "impact_event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "impact_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "impact_event_facility_effects_impact_event_id_impact_events_id_",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "impact_event_facility_effects"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "impact_event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "impact_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "impact_event_periods_impact_event_id_impact_events_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "impact_event_periods"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "impact_event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "impact_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "impact_event_service_effects_impact_event_id_impact_events_id_f",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "impact_event_service_effects"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "impact_event_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "impact_events",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "impact_event_service_scopes_impact_event_id_impact_events_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "impact_event_service_scopes"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "station_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "stations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "impact_event_service_scopes_station_id_stations_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "impact_event_service_scopes"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "from_station_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "stations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "impact_event_service_scopes_from_station_id_stations_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "impact_event_service_scopes"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "to_station_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "stations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "impact_event_service_scopes_to_station_id_stations_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "impact_event_service_scopes"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "issue_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "issues",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "impact_events_issue_id_issues_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "impact_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "issue_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "issues",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "issue_day_facts_issue_id_issues_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "issue_day_facts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "line_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "lines",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "line_day_facts_line_id_lines_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "line_day_facts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "issue_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "issues",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "line_day_issue_intervals_issue_id_issues_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "line_day_issue_intervals"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "date",
+        "line_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "line_day_facts",
+      "columnsTo": [
+        "date",
+        "line_id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "line_day_issue_intervals_line_day_fact_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "line_day_issue_intervals"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "line_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "lines",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "line_operators_line_id_lines_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "line_operators"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "operator_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "operators",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "line_operators_operator_id_operators_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "line_operators"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "line_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "lines",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "line_services_line_id_lines_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "line_services"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "service_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "services",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "line_services_service_id_services_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "line_services"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "service_revision_id",
+        "service_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "service_revisions",
+      "columnsTo": [
+        "id",
+        "service_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "sr_path_entries_revision_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "service_revision_path_station_entries"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "station_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "stations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "sr_path_entries_station_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "service_revision_path_station_entries"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "service_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "services",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "service_revisions_service_id_services_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "service_revisions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "line_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "lines",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "services_line_id_lines_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "services"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "line_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "lines",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "station_codes_line_id_lines_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "station_codes"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "station_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "stations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "station_codes_station_id_stations_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "station_codes"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "station_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "stations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "station_landmarks_station_id_stations_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "station_landmarks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "landmark_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "landmarks",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "station_landmarks_landmark_id_landmarks_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "station_landmarks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "town_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "towns",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "stations_town_id_towns_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "stations"
+    },
+    {
+      "columns": [
+        "cluster_id",
+        "line_id"
+      ],
+      "nameExplicit": false,
+      "name": "crowd_report_cluster_lines_cluster_id_line_id_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "crowd_report_cluster_lines"
+    },
+    {
+      "columns": [
+        "cluster_id",
+        "station_id"
+      ],
+      "nameExplicit": false,
+      "name": "crowd_report_cluster_stations_cluster_id_station_id_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "crowd_report_cluster_stations"
+    },
+    {
+      "columns": [
+        "report_id",
+        "line_id"
+      ],
+      "nameExplicit": false,
+      "name": "crowd_report_lines_report_id_line_id_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "crowd_report_lines"
+    },
+    {
+      "columns": [
+        "ip_hash",
+        "bucket_start_at"
+      ],
+      "nameExplicit": false,
+      "name": "crowd_report_rate_limits_ip_hash_bucket_start_at_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "crowd_report_rate_limits"
+    },
+    {
+      "columns": [
+        "report_id",
+        "station_id"
+      ],
+      "nameExplicit": false,
+      "name": "crowd_report_stations_report_id_station_id_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "crowd_report_stations"
+    },
+    {
+      "columns": [
+        "impact_event_id",
+        "evidence_id"
+      ],
+      "nameExplicit": false,
+      "name": "impact_event_basis_evidences_impact_event_id_evidence_id_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "impact_event_basis_evidences"
+    },
+    {
+      "columns": [
+        "impact_event_id",
+        "type"
+      ],
+      "nameExplicit": false,
+      "name": "impact_event_causes_impact_event_id_type_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "impact_event_causes"
+    },
+    {
+      "columns": [
+        "impact_event_id",
+        "station_id",
+        "kind"
+      ],
+      "nameExplicit": false,
+      "name": "impact_event_entity_facilities_impact_event_id_station_id_kind_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "impact_event_entity_facilities"
+    },
+    {
+      "columns": [
+        "impact_event_id",
+        "service_id"
+      ],
+      "nameExplicit": false,
+      "name": "impact_event_entity_services_impact_event_id_service_id_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "impact_event_entity_services"
+    },
+    {
+      "columns": [
+        "impact_event_id",
+        "kind"
+      ],
+      "nameExplicit": false,
+      "name": "impact_event_facility_effects_impact_event_id_kind_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "impact_event_facility_effects"
+    },
+    {
+      "columns": [
+        "impact_event_id",
+        "index"
+      ],
+      "nameExplicit": false,
+      "name": "impact_event_periods_impact_event_id_index_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "impact_event_periods"
+    },
+    {
+      "columns": [
+        "impact_event_id",
+        "kind"
+      ],
+      "nameExplicit": false,
+      "name": "impact_event_service_effects_impact_event_id_kind_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "impact_event_service_effects"
+    },
+    {
+      "columns": [
+        "impact_event_id",
+        "index"
+      ],
+      "nameExplicit": false,
+      "name": "impact_event_service_scopes_impact_event_id_index_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "impact_event_service_scopes"
+    },
+    {
+      "columns": [
+        "date",
+        "issue_id"
+      ],
+      "nameExplicit": false,
+      "name": "issue_day_facts_date_issue_id_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "issue_day_facts"
+    },
+    {
+      "columns": [
+        "date",
+        "line_id"
+      ],
+      "nameExplicit": false,
+      "name": "line_day_facts_date_line_id_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "line_day_facts"
+    },
+    {
+      "columns": [
+        "date",
+        "line_id",
+        "issue_id",
+        "interval_index"
+      ],
+      "nameExplicit": false,
+      "name": "line_day_issue_intervals_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "line_day_issue_intervals"
+    },
+    {
+      "columns": [
+        "line_id",
+        "operator_id"
+      ],
+      "nameExplicit": false,
+      "name": "line_operators_line_id_operator_id_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "line_operators"
+    },
+    {
+      "columns": [
+        "line_id",
+        "service_id"
+      ],
+      "nameExplicit": false,
+      "name": "line_services_line_id_service_id_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "line_services"
+    },
+    {
+      "columns": [
+        "service_revision_id",
+        "service_id",
+        "station_id",
+        "path_index"
+      ],
+      "nameExplicit": true,
+      "name": "sr_path_entries_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "service_revision_path_station_entries"
+    },
+    {
+      "columns": [
+        "id",
+        "service_id"
+      ],
+      "nameExplicit": false,
+      "name": "service_revisions_id_service_id_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "service_revisions"
+    },
+    {
+      "columns": [
+        "line_id",
+        "station_id",
+        "code"
+      ],
+      "nameExplicit": false,
+      "name": "station_codes_line_id_station_id_code_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "station_codes"
+    },
+    {
+      "columns": [
+        "station_id",
+        "landmark_id"
+      ],
+      "nameExplicit": false,
+      "name": "station_landmarks_station_id_landmark_id_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "station_landmarks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "crowd_report_abuse_events_pkey",
+      "schema": "public",
+      "table": "crowd_report_abuse_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "crowd_report_clusters_pkey",
+      "schema": "public",
+      "table": "crowd_report_clusters",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "crowd_report_moderation_events_pkey",
+      "schema": "public",
+      "table": "crowd_report_moderation_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "crowd_reports_pkey",
+      "schema": "public",
+      "table": "crowd_reports",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "evidences_pkey",
+      "schema": "public",
+      "table": "evidences",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "impact_events_pkey",
+      "schema": "public",
+      "table": "impact_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issues_next_pkey",
+      "schema": "public",
+      "table": "issues_next",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issues_pkey",
+      "schema": "public",
+      "table": "issues",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "landmarks_next_pkey",
+      "schema": "public",
+      "table": "landmarks_next",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "landmarks_pkey",
+      "schema": "public",
+      "table": "landmarks",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "lines_next_pkey",
+      "schema": "public",
+      "table": "lines_next",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "lines_pkey",
+      "schema": "public",
+      "table": "lines",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "key"
+      ],
+      "nameExplicit": false,
+      "name": "metadata_pkey",
+      "schema": "public",
+      "table": "metadata",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "operators_next_pkey",
+      "schema": "public",
+      "table": "operators_next",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "operators_pkey",
+      "schema": "public",
+      "table": "operators",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "public_holidays_pkey",
+      "schema": "public",
+      "table": "public_holidays",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "services_next_pkey",
+      "schema": "public",
+      "table": "services_next",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "services_pkey",
+      "schema": "public",
+      "table": "services",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "stations_next_pkey",
+      "schema": "public",
+      "table": "stations_next",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "stations_pkey",
+      "schema": "public",
+      "table": "stations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "statistics_snapshots_pkey",
+      "schema": "public",
+      "table": "statistics_snapshots",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "towns_next_pkey",
+      "schema": "public",
+      "table": "towns_next",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "towns_pkey",
+      "schema": "public",
+      "table": "towns",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "key"
+      ],
+      "nameExplicit": false,
+      "name": "workflow_leases_pkey",
+      "schema": "public",
+      "table": "workflow_leases",
+      "entityType": "pks"
+    },
+    {
+      "value": "\"delay_minutes\" is null or (\"delay_minutes\" >= 0 and \"delay_minutes\" <= 180)",
+      "name": "crowd_reports_delay_minutes_check",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "crowd_reports"
+    },
+    {
+      "value": "\n          (\n            \"type\" = 'service.whole'\n            and \"station_id\" is null\n            and \"from_station_id\" is null\n            and \"to_station_id\" is null\n          )\n          or (\n            \"type\" = 'service.point'\n            and \"station_id\" is not null\n            and \"from_station_id\" is null\n            and \"to_station_id\" is null\n          )\n          or (\n            \"type\" = 'service.segment'\n            and \"station_id\" is null\n            and \"from_station_id\" is not null\n            and \"to_station_id\" is not null\n          )\n        ",
+      "name": "impact_event_service_scopes_type_station_shape_check",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "impact_event_service_scopes"
+    }
+  ],
+  "renames": []
+}


### PR DESCRIPTION
## Summary

- add an authenticated `POST /internal/api/crowd-reports` boundary for registered machine producers
- persist generic producer provenance and conflict-safe external report IDs through a generated Drizzle migration
- reuse crowd-report validation, moderation, clustering, cache invalidation, and dispatch without public Turnstile, IP rate-limit, or abuse-event assumptions
- allow trusted ongoing and recovery reports to reach presentation and canonical dispatch while preserving public confidence thresholds
- document producer configuration and mark Phase 1 of the Reddit monitoring plan complete

## Why

The Reddit monitor needs to revisit useful conversations and submit posts or replies as independent crowd reports. The site only needs a generic machine-producer boundary; Reddit discovery, parsing, polling, and retry policy remain in the sibling monitor.

## Impact

Producers configure an individual bearer secret and permitted source origins through `CROWD_REPORT_PRODUCERS`. Identical retries return the original report, while reusing an external ID with a different payload returns `409`. Existing public submissions retain their current protections and behavior.

## Validation

- `npm run verify`
- 56 test files passed
- 321 tests passed
- Drizzle migrations are up to date

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated programmatic crowd-report submissions via `POST /internal/api/crowd-reports`, including allowed-source validation.
  * Added idempotent processing using `externalReportId`, with replay responses and `409` conflict handling for differing submissions.
  * Added producer provenance tracking and support for trusted automated moderation/dispatch for submitted reports.
* **Documentation**
  * Documented the new endpoint, `CROWD_REPORT_PRODUCERS` configuration, request payload shape, and response/idempotency behavior.
* **Bug Fixes**
  * Improved clustering/dispatch logic to treat non-public (producer-resolved) reports as “current” even if they’re no longer ongoing.
* **Tests**
  * Added comprehensive coverage for the new endpoint and programmatic persistence/idempotency behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->