### PR TITLE
fix: refresh station estimate after crowd report

### DIFF
--- a/app/routes/api.stations.$stationId.arrivals.tsx
+++ b/app/routes/api.stations.$stationId.arrivals.tsx
@@ -7,7 +7,7 @@ export const Route = createFileRoute('/api/stations/$stationId/arrivals')({
       async GET({ params }) {
         try {
           const profile = await getStationProfileReadModel(params.stationId, {
-            includeCommunitySignals: true,
+            includeCommunitySignals: false,
           });
           return Response.json(
             { success: true, data: profile.data.arrivalLines },

--- a/app/routes/api.stations.$stationId.arrivals.tsx
+++ b/app/routes/api.stations.$stationId.arrivals.tsx
@@ -7,7 +7,7 @@ export const Route = createFileRoute('/api/stations/$stationId/arrivals')({
       async GET({ params }) {
         try {
           const profile = await getStationProfileReadModel(params.stationId, {
-            includeCommunitySignals: false,
+            includeCommunitySignals: true,
           });
           return Response.json(
             { success: true, data: profile.data.arrivalLines },

--- a/app/routes/{-$lang}/stations/$stationId/components/PlatformArrivalSummary.tsx
+++ b/app/routes/{-$lang}/stations/$stationId/components/PlatformArrivalSummary.tsx
@@ -1,25 +1,29 @@
+import { Popover } from '@base-ui/react/popover';
 import { InformationCircleIcon } from '@heroicons/react/20/solid';
 import { Link } from '@tanstack/react-router';
 import { DateTime } from 'luxon';
 import { useEffect, useState } from 'react';
 import { FormattedMessage, type IntlShape, useIntl } from 'react-intl';
-import { Popover } from '@base-ui/react/popover';
 import { getLocalizedTranslation } from '~/helpers/getLocalizedTranslation';
 import { PlatformSign } from './StationGuideSigns';
 import type { ArrivalTiming } from './stationGuide.types';
 import { useHoverPopover } from './useHoverPopover';
 
+type ServiceArrivalSummaryProps = {
+  arrivalTiming: ArrivalTiming;
+  isHydrated: boolean;
+  lineColor: string;
+  onArrivalReportSubmitted: () => Promise<void>;
+  stationId: string;
+};
+
 export function ServiceArrivalSummary({
   arrivalTiming,
   isHydrated,
   lineColor,
+  onArrivalReportSubmitted,
   stationId,
-}: {
-  arrivalTiming: ArrivalTiming;
-  isHydrated: boolean;
-  lineColor: string;
-  stationId: string;
-}) {
+}: ServiceArrivalSummaryProps) {
   const intl = useIntl();
   const now = useCurrentTime(isHydrated);
   const destinationName =
@@ -78,6 +82,7 @@ export function ServiceArrivalSummary({
       </div>
       {arrivalTiming.departures[0] != null && (
         <CrowdArrivalReportButton
+          onSubmitted={onArrivalReportSubmitted}
           serviceId={arrivalTiming.serviceId}
           stationId={stationId}
         />
@@ -86,13 +91,17 @@ export function ServiceArrivalSummary({
   );
 }
 
-function CrowdArrivalReportButton({
-  serviceId,
-  stationId,
-}: {
+type CrowdArrivalReportButtonProps = {
+  onSubmitted: () => Promise<void>;
   serviceId: string;
   stationId: string;
-}) {
+};
+
+function CrowdArrivalReportButton({
+  onSubmitted,
+  serviceId,
+  stationId,
+}: CrowdArrivalReportButtonProps) {
   const [status, setStatus] = useState<'idle' | 'sending' | 'sent' | 'error'>(
     'idle',
   );
@@ -104,7 +113,12 @@ function CrowdArrivalReportButton({
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ stationId, serviceId, minutesToArrival }),
       });
-      setStatus(response.ok ? 'sent' : 'error');
+      if (!response.ok) {
+        setStatus('error');
+        return;
+      }
+      await onSubmitted();
+      setStatus('sent');
     } catch {
       setStatus('error');
     }

--- a/app/routes/{-$lang}/stations/$stationId/components/StationGuide.tsx
+++ b/app/routes/{-$lang}/stations/$stationId/components/StationGuide.tsx
@@ -1,14 +1,23 @@
-import { InformationCircleIcon } from '@heroicons/react/20/solid';
-import { FormattedMessage } from 'react-intl';
-import { Link } from '@tanstack/react-router';
-import { useEffect, useState } from 'react';
 import { Popover } from '@base-ui/react/popover';
+import { InformationCircleIcon } from '@heroicons/react/20/solid';
+import { Link } from '@tanstack/react-router';
+import { useCallback, useEffect, useState } from 'react';
+import { FormattedMessage } from 'react-intl';
 import { BetaBadge } from '~/components/BetaBadge';
 import { getStationArrivalLinesFn } from '~/util/station.functions';
 import { ServiceArrivalSummary } from './PlatformArrivalSummary';
 import { ExitSign } from './StationGuideSigns';
 import type { ArrivalLine, StationExit } from './stationGuide.types';
 import { useHoverPopover } from './useHoverPopover';
+
+type StationGuideProps = {
+  arrivalLines: ArrivalLine[];
+  exits: StationExit[];
+  isHydrated: boolean;
+  lineColors: Record<string, string>;
+  lineNames: Record<string, string>;
+  stationId: string;
+};
 
 export function StationGuide({
   arrivalLines,
@@ -17,35 +26,30 @@ export function StationGuide({
   lineColors,
   lineNames,
   stationId,
-}: {
-  arrivalLines: ArrivalLine[];
-  exits: StationExit[];
-  isHydrated: boolean;
-  lineColors: Record<string, string>;
-  lineNames: Record<string, string>;
-  stationId: string;
-}) {
+}: StationGuideProps) {
   const [liveArrivalLines, setLiveArrivalLines] = useState(arrivalLines);
 
+  const refreshArrivalLines = useCallback(async () => {
+    try {
+      const nextArrivalLines = await getStationArrivalLinesFn({
+        data: { stationId },
+      });
+      setLiveArrivalLines(nextArrivalLines);
+    } catch {
+      // Keep the latest available estimates when the refresh is unavailable.
+    }
+  }, [stationId]);
+
   useEffect(() => {
-    let cancelled = false;
-    const refresh = async () => {
-      try {
-        const nextArrivalLines = await getStationArrivalLinesFn({
-          data: { stationId },
-        });
-        if (!cancelled) setLiveArrivalLines(nextArrivalLines);
-      } catch {
-        // Keep the server-rendered estimates when the refresh is unavailable.
-      }
-    };
-    void refresh();
-    const interval = window.setInterval(() => void refresh(), 30_000);
+    void refreshArrivalLines();
+    const interval = window.setInterval(
+      () => void refreshArrivalLines(),
+      30_000,
+    );
     return () => {
-      cancelled = true;
       window.clearInterval(interval);
     };
-  }, [stationId]);
+  }, [refreshArrivalLines]);
 
   return (
     <section
@@ -108,6 +112,7 @@ export function StationGuide({
                     isHydrated={isHydrated}
                     key={arrivalTiming.serviceId}
                     lineColor={lineColors[line.lineId]}
+                    onArrivalReportSubmitted={refreshArrivalLines}
                     stationId={stationId}
                   />
                 ))}

--- a/app/routes/{-$lang}/stations/$stationId/components/StationGuide.tsx
+++ b/app/routes/{-$lang}/stations/$stationId/components/StationGuide.tsx
@@ -18,6 +18,10 @@ type StationGuideProps = {
   stationId: string;
 };
 
+type RefreshArrivalLinesOptions = {
+  afterReport?: boolean;
+};
+
 export function StationGuide({
   arrivalLines,
   exits,
@@ -28,56 +32,74 @@ export function StationGuide({
 }: StationGuideProps) {
   const [liveArrivalLines, setLiveArrivalLines] = useState(arrivalLines);
   const activeStationIdRef = useRef<string | null>(null);
+  const refreshAbortControllerRef = useRef<AbortController | null>(null);
   const refreshInFlightRef = useRef<Promise<void> | null>(null);
 
-  const refreshArrivalLines = useCallback(async () => {
-    if (activeStationIdRef.current !== stationId) {
-      return;
-    }
-    if (refreshInFlightRef.current != null) {
-      await refreshInFlightRef.current;
-      return;
-    }
-
-    const refresh = (async () => {
-      try {
-        const response = await fetch(
-          `/api/stations/${encodeURIComponent(stationId)}/arrivals`,
-          { cache: 'no-store' },
-        );
-        if (!response.ok) {
+  const refreshArrivalLines = useCallback(
+    async ({ afterReport = false }: RefreshArrivalLinesOptions = {}) => {
+      if (activeStationIdRef.current !== stationId) {
+        return;
+      }
+      if (refreshInFlightRef.current != null) {
+        if (!afterReport) {
+          await refreshInFlightRef.current;
           return;
         }
-        const payload = (await response.json()) as {
-          data?: ArrivalLine[];
-          success?: boolean;
-        };
-        if (
-          payload.success === true &&
-          payload.data != null &&
-          activeStationIdRef.current === stationId
-        ) {
-          setLiveArrivalLines(payload.data);
+        refreshAbortControllerRef.current?.abort();
+        await refreshInFlightRef.current;
+        if (activeStationIdRef.current !== stationId) {
+          return;
         }
-      } catch {
-        // Keep the latest available estimates when the refresh is unavailable.
       }
-    })();
-    refreshInFlightRef.current = refresh;
-    try {
-      await refresh;
-    } finally {
-      if (refreshInFlightRef.current === refresh) {
-        refreshInFlightRef.current = null;
+
+      const abortController = new AbortController();
+      const refresh = (async () => {
+        try {
+          const response = await fetch(
+            `/api/stations/${encodeURIComponent(stationId)}/arrivals`,
+            { cache: 'no-store', signal: abortController.signal },
+          );
+          if (!response.ok) {
+            return;
+          }
+          const payload = (await response.json()) as {
+            data?: ArrivalLine[];
+            success?: boolean;
+          };
+          if (
+            payload.success === true &&
+            payload.data != null &&
+            activeStationIdRef.current === stationId
+          ) {
+            setLiveArrivalLines(payload.data);
+          }
+        } catch {
+          // Keep the latest available estimates when the refresh is unavailable.
+        }
+      })();
+      refreshAbortControllerRef.current = abortController;
+      refreshInFlightRef.current = refresh;
+      try {
+        await refresh;
+      } finally {
+        if (refreshAbortControllerRef.current === abortController) {
+          refreshAbortControllerRef.current = null;
+        }
+        if (refreshInFlightRef.current === refresh) {
+          refreshInFlightRef.current = null;
+        }
       }
-    }
-  }, [stationId]);
+    },
+    [stationId],
+  );
 
   useEffect(() => {
     activeStationIdRef.current = stationId;
     setLiveArrivalLines(arrivalLines);
     return () => {
       activeStationIdRef.current = null;
+      refreshAbortControllerRef.current?.abort();
+      refreshAbortControllerRef.current = null;
       refreshInFlightRef.current = null;
     };
   }, [arrivalLines, stationId]);
@@ -92,6 +114,11 @@ export function StationGuide({
       window.clearInterval(interval);
     };
   }, [refreshArrivalLines]);
+
+  const refreshArrivalLinesAfterReport = useCallback(
+    () => refreshArrivalLines({ afterReport: true }),
+    [refreshArrivalLines],
+  );
 
   return (
     <section
@@ -154,7 +181,7 @@ export function StationGuide({
                     isHydrated={isHydrated}
                     key={arrivalTiming.serviceId}
                     lineColor={lineColors[line.lineId]}
-                    onArrivalReportSubmitted={refreshArrivalLines}
+                    onArrivalReportSubmitted={refreshArrivalLinesAfterReport}
                     stationId={stationId}
                   />
                 ))}

--- a/app/routes/{-$lang}/stations/$stationId/components/StationGuide.tsx
+++ b/app/routes/{-$lang}/stations/$stationId/components/StationGuide.tsx
@@ -22,6 +22,8 @@ type RefreshArrivalLinesOptions = {
   afterReport?: boolean;
 };
 
+const REFRESH_TIMEOUT_MILLIS = 15_000;
+
 export function StationGuide({
   arrivalLines,
   exits,
@@ -35,6 +37,7 @@ export function StationGuide({
   const arrivalLinesRef = useRef(arrivalLines);
   const refreshAbortControllerRef = useRef<AbortController | null>(null);
   const refreshInFlightRef = useRef<Promise<void> | null>(null);
+  const refreshTimeoutRef = useRef<number | null>(null);
 
   const refreshArrivalLines = useCallback(
     async ({ afterReport = false }: RefreshArrivalLinesOptions = {}) => {
@@ -80,9 +83,18 @@ export function StationGuide({
       })();
       refreshAbortControllerRef.current = abortController;
       refreshInFlightRef.current = refresh;
+      const timeout = window.setTimeout(
+        () => abortController.abort(),
+        REFRESH_TIMEOUT_MILLIS,
+      );
+      refreshTimeoutRef.current = timeout;
       try {
         await refresh;
       } finally {
+        if (refreshTimeoutRef.current === timeout) {
+          window.clearTimeout(timeout);
+          refreshTimeoutRef.current = null;
+        }
         if (refreshAbortControllerRef.current === abortController) {
           refreshAbortControllerRef.current = null;
         }
@@ -105,6 +117,10 @@ export function StationGuide({
       activeStationIdRef.current = null;
       refreshAbortControllerRef.current?.abort();
       refreshAbortControllerRef.current = null;
+      if (refreshTimeoutRef.current != null) {
+        window.clearTimeout(refreshTimeoutRef.current);
+        refreshTimeoutRef.current = null;
+      }
       refreshInFlightRef.current = null;
     };
   }, [stationId]);

--- a/app/routes/{-$lang}/stations/$stationId/components/StationGuide.tsx
+++ b/app/routes/{-$lang}/stations/$stationId/components/StationGuide.tsx
@@ -1,10 +1,9 @@
 import { Popover } from '@base-ui/react/popover';
 import { InformationCircleIcon } from '@heroicons/react/20/solid';
 import { Link } from '@tanstack/react-router';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { BetaBadge } from '~/components/BetaBadge';
-import { getStationArrivalLinesFn } from '~/util/station.functions';
 import { ServiceArrivalSummary } from './PlatformArrivalSummary';
 import { ExitSign } from './StationGuideSigns';
 import type { ArrivalLine, StationExit } from './stationGuide.types';
@@ -28,16 +27,42 @@ export function StationGuide({
   stationId,
 }: StationGuideProps) {
   const [liveArrivalLines, setLiveArrivalLines] = useState(arrivalLines);
+  const activeStationIdRef = useRef<string | null>(null);
+  const refreshGenerationRef = useRef(0);
 
   const refreshArrivalLines = useCallback(async () => {
+    const requestGeneration = ++refreshGenerationRef.current;
     try {
-      const nextArrivalLines = await getStationArrivalLinesFn({
-        data: { stationId },
-      });
-      setLiveArrivalLines(nextArrivalLines);
+      const response = await fetch(
+        `/api/stations/${encodeURIComponent(stationId)}/arrivals`,
+        { cache: 'no-store' },
+      );
+      if (!response.ok) {
+        return;
+      }
+      const payload = (await response.json()) as {
+        data?: ArrivalLine[];
+        success?: boolean;
+      };
+      if (
+        payload.success === true &&
+        payload.data != null &&
+        refreshGenerationRef.current === requestGeneration &&
+        activeStationIdRef.current === stationId
+      ) {
+        setLiveArrivalLines(payload.data);
+      }
     } catch {
       // Keep the latest available estimates when the refresh is unavailable.
     }
+  }, [stationId]);
+
+  useEffect(() => {
+    activeStationIdRef.current = stationId;
+    return () => {
+      activeStationIdRef.current = null;
+      refreshGenerationRef.current += 1;
+    };
   }, [stationId]);
 
   useEffect(() => {

--- a/app/routes/{-$lang}/stations/$stationId/components/StationGuide.tsx
+++ b/app/routes/{-$lang}/stations/$stationId/components/StationGuide.tsx
@@ -28,42 +28,59 @@ export function StationGuide({
 }: StationGuideProps) {
   const [liveArrivalLines, setLiveArrivalLines] = useState(arrivalLines);
   const activeStationIdRef = useRef<string | null>(null);
-  const refreshGenerationRef = useRef(0);
+  const refreshInFlightRef = useRef<Promise<void> | null>(null);
 
   const refreshArrivalLines = useCallback(async () => {
-    const requestGeneration = ++refreshGenerationRef.current;
+    if (activeStationIdRef.current !== stationId) {
+      return;
+    }
+    if (refreshInFlightRef.current != null) {
+      await refreshInFlightRef.current;
+      return;
+    }
+
+    const refresh = (async () => {
+      try {
+        const response = await fetch(
+          `/api/stations/${encodeURIComponent(stationId)}/arrivals`,
+          { cache: 'no-store' },
+        );
+        if (!response.ok) {
+          return;
+        }
+        const payload = (await response.json()) as {
+          data?: ArrivalLine[];
+          success?: boolean;
+        };
+        if (
+          payload.success === true &&
+          payload.data != null &&
+          activeStationIdRef.current === stationId
+        ) {
+          setLiveArrivalLines(payload.data);
+        }
+      } catch {
+        // Keep the latest available estimates when the refresh is unavailable.
+      }
+    })();
+    refreshInFlightRef.current = refresh;
     try {
-      const response = await fetch(
-        `/api/stations/${encodeURIComponent(stationId)}/arrivals`,
-        { cache: 'no-store' },
-      );
-      if (!response.ok) {
-        return;
+      await refresh;
+    } finally {
+      if (refreshInFlightRef.current === refresh) {
+        refreshInFlightRef.current = null;
       }
-      const payload = (await response.json()) as {
-        data?: ArrivalLine[];
-        success?: boolean;
-      };
-      if (
-        payload.success === true &&
-        payload.data != null &&
-        refreshGenerationRef.current === requestGeneration &&
-        activeStationIdRef.current === stationId
-      ) {
-        setLiveArrivalLines(payload.data);
-      }
-    } catch {
-      // Keep the latest available estimates when the refresh is unavailable.
     }
   }, [stationId]);
 
   useEffect(() => {
     activeStationIdRef.current = stationId;
+    setLiveArrivalLines(arrivalLines);
     return () => {
       activeStationIdRef.current = null;
-      refreshGenerationRef.current += 1;
+      refreshInFlightRef.current = null;
     };
-  }, [stationId]);
+  }, [arrivalLines, stationId]);
 
   useEffect(() => {
     void refreshArrivalLines();

--- a/app/routes/{-$lang}/stations/$stationId/components/StationGuide.tsx
+++ b/app/routes/{-$lang}/stations/$stationId/components/StationGuide.tsx
@@ -32,6 +32,7 @@ export function StationGuide({
 }: StationGuideProps) {
   const [liveArrivalLines, setLiveArrivalLines] = useState(arrivalLines);
   const activeStationIdRef = useRef<string | null>(null);
+  const arrivalLinesRef = useRef(arrivalLines);
   const refreshAbortControllerRef = useRef<AbortController | null>(null);
   const refreshInFlightRef = useRef<Promise<void> | null>(null);
 
@@ -94,15 +95,19 @@ export function StationGuide({
   );
 
   useEffect(() => {
+    arrivalLinesRef.current = arrivalLines;
+  }, [arrivalLines]);
+
+  useEffect(() => {
     activeStationIdRef.current = stationId;
-    setLiveArrivalLines(arrivalLines);
+    setLiveArrivalLines(arrivalLinesRef.current);
     return () => {
       activeStationIdRef.current = null;
       refreshAbortControllerRef.current?.abort();
       refreshAbortControllerRef.current = null;
       refreshInFlightRef.current = null;
     };
-  }, [arrivalLines, stationId]);
+  }, [stationId]);
 
   useEffect(() => {
     void refreshArrivalLines();

--- a/app/util/dbQueries/dateTime.ts
+++ b/app/util/dbQueries/dateTime.ts
@@ -8,12 +8,7 @@ export function nowSg() {
   return DateTime.now().setZone(SG_TIMEZONE);
 }
 
-export function parseDateTime(value: string) {
-  const cached = dateTimeCache.get(value);
-  if (cached != null) {
-    return cached;
-  }
-
+export function parseDateTimeUncached(value: string) {
   let parsed: DateTime;
   if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
     parsed = DateTime.fromISO(value, { zone: SG_TIMEZONE });
@@ -28,6 +23,17 @@ export function parseDateTime(value: string) {
         : DateTime.fromJSDate(new Date(value)).setZone(SG_TIMEZONE);
     }
   }
+
+  return parsed;
+}
+
+export function parseDateTime(value: string) {
+  const cached = dateTimeCache.get(value);
+  if (cached != null) {
+    return cached;
+  }
+
+  const parsed = parseDateTimeUncached(value);
 
   dateTimeCache.set(value, parsed);
   return parsed;

--- a/app/util/estimatedArrivals.test.ts
+++ b/app/util/estimatedArrivals.test.ts
@@ -119,6 +119,47 @@ describe('getEstimatedStationArrivalTimings', () => {
     ]);
   });
 
+  it('uses crowd reports returned as Postgres timestamp strings', () => {
+    const arrivalTimings = getEstimatedStationArrivalTimings({
+      station,
+      services: [
+        {
+          serviceId: 'alpha-eastbound',
+          lineId: 'AL',
+          serviceName: {
+            'en-SG': 'Alpha Line eastbound',
+            'zh-Hans': null,
+            ms: null,
+            ta: null,
+          },
+          destinationStationId: 'bravo',
+          destinationCode: 'B2',
+          destinationName: null,
+          revision,
+        },
+      ],
+      referenceNow: DateTime.fromISO('2026-07-20T05:04:00', {
+        zone: 'Asia/Singapore',
+      }),
+      publicHolidayDates: new Set(),
+      crowdReports: [
+        {
+          id: 'report-1',
+          serviceId: 'alpha-eastbound',
+          reportedAt: '2026-07-19 21:04:00+00',
+          minutesToArrival: 0,
+        },
+      ],
+    });
+
+    expect(arrivalTimings[0]?.departures[0]).toMatchObject({
+      basis: 'crowd_report',
+      confidence: 'high',
+      crowdReportCount: 1,
+      time: '2026-07-20T05:04:00.000+08:00',
+    });
+  });
+
   it('marks the overnight gap as ended and provides the next first train', () => {
     expect(
       getEstimatedStationArrivalTimings({

--- a/app/util/estimatedArrivals.test.ts
+++ b/app/util/estimatedArrivals.test.ts
@@ -120,43 +120,60 @@ describe('getEstimatedStationArrivalTimings', () => {
   });
 
   it('uses an arriving-now report returned as a Postgres timestamp string', () => {
-    const arrivalTimings = getEstimatedStationArrivalTimings({
-      station,
-      services: [
-        {
-          serviceId: 'alpha-eastbound',
-          lineId: 'AL',
-          serviceName: {
-            'en-SG': 'Alpha Line eastbound',
-            'zh-Hans': null,
-            ms: null,
-            ta: null,
+    const crowdReports = [
+      {
+        id: 'report-1',
+        serviceId: 'alpha-eastbound',
+        reportedAt: '2026-07-19 21:04:00.100+00',
+        minutesToArrival: 0,
+      },
+    ];
+    const getArrivalTimings = (referenceNow: DateTime) =>
+      getEstimatedStationArrivalTimings({
+        station,
+        services: [
+          {
+            serviceId: 'alpha-eastbound',
+            lineId: 'AL',
+            serviceName: {
+              'en-SG': 'Alpha Line eastbound',
+              'zh-Hans': null,
+              ms: null,
+              ta: null,
+            },
+            destinationStationId: 'bravo',
+            destinationCode: 'B2',
+            destinationName: null,
+            revision,
           },
-          destinationStationId: 'bravo',
-          destinationCode: 'B2',
-          destinationName: null,
-          revision,
-        },
-      ],
-      referenceNow: DateTime.fromISO('2026-07-20T05:04:00.700', {
+        ],
+        referenceNow,
+        publicHolidayDates: new Set(),
+        crowdReports,
+      });
+    const arrivalTimings = getArrivalTimings(
+      DateTime.fromISO('2026-07-20T05:04:00.700', {
         zone: 'Asia/Singapore',
       }),
-      publicHolidayDates: new Set(),
-      crowdReports: [
-        {
-          id: 'report-1',
-          serviceId: 'alpha-eastbound',
-          reportedAt: '2026-07-19 21:04:00.100+00',
-          minutesToArrival: 0,
-        },
-      ],
-    });
+    );
 
     expect(arrivalTimings[0]?.departures[0]).toMatchObject({
       basis: 'crowd_report',
       confidence: 'high',
       crowdReportCount: 1,
       time: '2026-07-20T05:04:01.000+08:00',
+    });
+
+    const laterArrivalTimings = getArrivalTimings(
+      DateTime.fromISO('2026-07-20T05:04:30', {
+        zone: 'Asia/Singapore',
+      }),
+    );
+
+    expect(laterArrivalTimings[0]?.departures[0]).toMatchObject({
+      basis: 'frequency_estimate',
+      crowdReportCount: 0,
+      time: '2026-07-20T05:09:30.000+08:00',
     });
   });
 

--- a/app/util/estimatedArrivals.test.ts
+++ b/app/util/estimatedArrivals.test.ts
@@ -119,7 +119,7 @@ describe('getEstimatedStationArrivalTimings', () => {
     ]);
   });
 
-  it('uses crowd reports returned as Postgres timestamp strings', () => {
+  it('uses an arriving-now report returned as a Postgres timestamp string', () => {
     const arrivalTimings = getEstimatedStationArrivalTimings({
       station,
       services: [
@@ -138,7 +138,7 @@ describe('getEstimatedStationArrivalTimings', () => {
           revision,
         },
       ],
-      referenceNow: DateTime.fromISO('2026-07-20T05:04:00', {
+      referenceNow: DateTime.fromISO('2026-07-20T05:04:00.700', {
         zone: 'Asia/Singapore',
       }),
       publicHolidayDates: new Set(),
@@ -146,7 +146,7 @@ describe('getEstimatedStationArrivalTimings', () => {
         {
           id: 'report-1',
           serviceId: 'alpha-eastbound',
-          reportedAt: '2026-07-19 21:04:00+00',
+          reportedAt: '2026-07-19 21:04:00.100+00',
           minutesToArrival: 0,
         },
       ],
@@ -156,7 +156,7 @@ describe('getEstimatedStationArrivalTimings', () => {
       basis: 'crowd_report',
       confidence: 'high',
       crowdReportCount: 1,
-      time: '2026-07-20T05:04:00.000+08:00',
+      time: '2026-07-20T05:04:01.000+08:00',
     });
   });
 

--- a/app/util/estimatedArrivals.ts
+++ b/app/util/estimatedArrivals.ts
@@ -8,7 +8,13 @@ import {
   type Station,
 } from '@mrtdown/core';
 import type { DateTime } from 'luxon';
-import { isoDate, isoDateTime, parseDateTime } from './dbQueries/dateTime';
+import {
+  isoDate,
+  isoDateTime,
+  parseDateTimeUncached,
+} from './dbQueries/dateTime';
+
+const CROWD_REPORT_FRESHNESS_MILLIS = 3 * 60 * 1_000;
 
 export type EstimatedArrivalService = {
   serviceId: string;
@@ -102,6 +108,12 @@ export function getEstimatedStationArrivalTimings(input: {
     input.referenceNow.diff(input.referenceNow.startOf('day'), 'seconds')
       .seconds,
   );
+  const crowdReports = input.crowdReports?.map((report) => ({
+    ...report,
+    reportedAt: parseDateTimeUncached(report.reportedAt).setZone(
+      input.referenceNow.zone,
+    ),
+  }));
 
   return input.services
     .flatMap((service) => {
@@ -132,22 +144,30 @@ export function getEstimatedStationArrivalTimings(input: {
               queriedAtTime,
               {
                 count: 2,
-                crowdReports: input.crowdReports
+                crowdReports: crowdReports
                   ?.filter((report) => report.serviceId === service.serviceId)
-                  .map(
-                    (report): CrowdArrivalReport => ({
+                  .map((report): CrowdArrivalReport => {
+                    const reportAgeMillis =
+                      referenceMillis - report.reportedAt.toMillis();
+                    const isFreshArrivingNow =
+                      report.minutesToArrival === 0 &&
+                      reportAgeMillis >= 0 &&
+                      reportAgeMillis <= CROWD_REPORT_FRESHNESS_MILLIS;
+                    return {
                       id: report.id,
-                      reportedAtTime: formatServiceDayTime(
-                        Math.round(
-                          parseDateTime(report.reportedAt)
-                            .setZone(input.referenceNow.zone)
-                            .diff(serviceDate.startOf('day'), 'seconds')
-                            .seconds,
-                        ),
-                      ),
+                      reportedAtTime: isFreshArrivingNow
+                        ? queriedAtTime
+                        : formatServiceDayTime(
+                            Math.round(
+                              report.reportedAt.diff(
+                                serviceDate.startOf('day'),
+                                'seconds',
+                              ).seconds,
+                            ),
+                          ),
                       minutesToArrival: report.minutesToArrival,
-                    }),
-                  ),
+                    };
+                  }),
               },
             ).map((estimate) => ({
               basis: estimate.basis,

--- a/app/util/estimatedArrivals.ts
+++ b/app/util/estimatedArrivals.ts
@@ -7,8 +7,8 @@ import {
   type ServiceRevision,
   type Station,
 } from '@mrtdown/core';
-import { DateTime } from 'luxon';
-import { isoDate, isoDateTime } from './dbQueries/dateTime';
+import type { DateTime } from 'luxon';
+import { isoDate, isoDateTime, parseDateTime } from './dbQueries/dateTime';
 
 export type EstimatedArrivalService = {
   serviceId: string;
@@ -139,9 +139,7 @@ export function getEstimatedStationArrivalTimings(input: {
                       id: report.id,
                       reportedAtTime: formatServiceDayTime(
                         Math.round(
-                          DateTime.fromISO(report.reportedAt, {
-                            setZone: true,
-                          })
+                          parseDateTime(report.reportedAt)
                             .setZone(input.referenceNow.zone)
                             .diff(serviceDate.startOf('day'), 'seconds')
                             .seconds,

--- a/app/util/estimatedArrivals.ts
+++ b/app/util/estimatedArrivals.ts
@@ -14,7 +14,7 @@ import {
   parseDateTimeUncached,
 } from './dbQueries/dateTime';
 
-const CROWD_REPORT_FRESHNESS_MILLIS = 3 * 60 * 1_000;
+const ARRIVING_NOW_CLAMP_WINDOW_MILLIS = 1_000;
 
 export type EstimatedArrivalService = {
   serviceId: string;
@@ -152,7 +152,7 @@ export function getEstimatedStationArrivalTimings(input: {
                     const isFreshArrivingNow =
                       report.minutesToArrival === 0 &&
                       reportAgeMillis >= 0 &&
-                      reportAgeMillis <= CROWD_REPORT_FRESHNESS_MILLIS;
+                      reportAgeMillis <= ARRIVING_NOW_CLAMP_WINDOW_MILLIS;
                     return {
                       id: report.id,
                       reportedAtTime: isFreshArrivingNow


### PR DESCRIPTION
## Motivation

Community arrival reports were persisted successfully but did not reliably update the station page immediately. The refresh path also needed to remain correct across overlapping requests, station changes, and timestamp rounding at submission time.

## What changed

- Refresh station arrivals immediately after a successful crowd report, while retaining the initial fetch and 30-second polling.
- Serialize refreshes, abort superseded requests, ignore stale station results, and time out a stalled request after 15 seconds.
- Preserve live arrival data across same-station loader updates (such as locale changes).
- Parse Postgres crowd-report timestamps without the global date cache.
- Handle fractional-second `Arriving now` reports during the immediate refresh, without keeping them artificially current on later polls.
- Add regression coverage for persisted Postgres timestamps, fractional-second reports, and later-poll behavior.

## Verification

- `npm run verify` passed: typecheck, lint, format, migration-drift check, and tests.
- Vitest: 63 test files passed, 362 tests passed.