### PR TITLE
fix: keep station arrival estimates fresh

### DIFF
--- a/app/util/publicResponseCache.test.ts
+++ b/app/util/publicResponseCache.test.ts
@@ -54,6 +54,26 @@ describe('public response cache policy', () => {
     expect(fallback.headers.get('x-mrtdown-cache')).toBeNull();
   });
 
+  it.each([
+    'https://www.mrtdown.org/stations/NS1',
+    'https://www.mrtdown.org/stations/NS1/',
+    'https://www.mrtdown.org/en-SG/stations/NS1',
+  ])('keeps live station profile HTML uncached at %s', (url) => {
+    const stationResponse = applyPublicDataCacheHeaders(
+      new Request(url),
+      response('text/html; charset=utf-8'),
+    );
+
+    expect(stationResponse.headers.get('cache-control')).toBe('no-store');
+    expect(
+      stationResponse.headers.get('cloudflare-cdn-cache-control'),
+    ).toBeNull();
+    expect(stationResponse.headers.get('cache-tag')).toBeNull();
+    expect(stationResponse.headers.get('x-mrtdown-cache')).toBe(
+      'dynamic-station',
+    );
+  });
+
   it('marks successful public JSON read responses as cacheable', () => {
     const serverFunction = applyPublicDataCacheHeaders(
       request({ headers: { 'x-tsr-serverfn': 'true' } }),

--- a/app/util/publicResponseCache.ts
+++ b/app/util/publicResponseCache.ts
@@ -80,6 +80,14 @@ export function applyPublicDataCacheHeaders(
 ) {
   const kind = getResponseKind(request, response);
   if (
+    (request.method === 'GET' || request.method === 'HEAD') &&
+    response.status === 200 &&
+    kind === 'html' &&
+    isStationProfilePath(new URL(request.url).pathname)
+  ) {
+    return setNoStore(response);
+  }
+  if (
     (request.method !== 'GET' && request.method !== 'HEAD') ||
     response.status !== 200 ||
     kind == null ||
@@ -94,6 +102,33 @@ export function applyPublicDataCacheHeaders(
   } catch {
     const headers = new Headers(response.headers);
     setPublicDataCacheHeaders(headers, kind);
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
+}
+
+function isStationProfilePath(pathname: string) {
+  const segments = pathname.split('/').filter(Boolean);
+  const stationsIndex = segments.at(-2);
+  return stationsIndex === 'stations' && segments.length <= 3;
+}
+
+function setNoStore(response: Response) {
+  try {
+    response.headers.set('Cache-Control', 'no-store');
+    response.headers.delete('Cloudflare-CDN-Cache-Control');
+    response.headers.delete('Cache-Tag');
+    response.headers.set('X-MRTDown-Cache', 'dynamic-station');
+    return response;
+  } catch {
+    const headers = new Headers(response.headers);
+    headers.set('Cache-Control', 'no-store');
+    headers.delete('Cloudflare-CDN-Cache-Control');
+    headers.delete('Cache-Tag');
+    headers.set('X-MRTDown-Cache', 'dynamic-station');
     return new Response(response.body, {
       status: response.status,
       statusText: response.statusText,


### PR DESCRIPTION
### Motivation

- Station profile HTML containing time-sensitive arrival estimates was being eligible for the shared public cache, causing a page refresh to show stale arrival values.

### Description

- Detect station profile HTML requests in `applyPublicDataCacheHeaders` and short-circuit to mark them uncachable by returning a `no-store` response; implemented in `app/util/publicResponseCache.ts` via `isStationProfilePath` and `setNoStore`.
- `setNoStore` removes shared cache metadata (Cloudflare headers and cache tags) and sets `X-MRTDown-Cache: dynamic-station` for diagnostics.
- Added regression tests for localized, unlocalized, and trailing-slash station URLs in `app/util/publicResponseCache.test.ts`.
- Modified files: `app/util/publicResponseCache.ts` and `app/util/publicResponseCache.test.ts`.

### Testing

- Ran the focused unit tests with `npm run test:run -- app/util/publicResponseCache.test.ts` and they passed (10 tests passed).
- Ran the full verification `npm run verify` (typecheck, lint, format check, migration drift check, and tests) and it completed successfully with all tests passing (367 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d62e7612483208025f434228cbde1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Station profile pages now bypass shared caching when serving HTML content.
  * Improved handling of trailing-slash and localized station profile URLs.
  * Responses correctly use dynamic, no-store caching behavior to ensure fresh page content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->